### PR TITLE
feat/docs: adds shuffle playback, ambient mode, color schemes, and doc clarity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Please write "No AI used" if that's the case. PRs that omit this may be closed w
 
 ## Checklist
 
-- [ ] Works with remote-only navigation (up/down/left/right, enter, esc/backspace)
-- [ ] Sizing and Positioning with `root.sh` / `root.sw` (no hardcoded pixels) and mindful of CRT overscan
-- [ ] No tracking/analytics; only writes to the local data directory
+- [ ] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
+- [ ] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
+- [ ] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
 - [ ] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,3 +201,8 @@ jobs:
 
             - Raspberry Pi OS Trixie (arm64): [Instructions](INSTALL.md#on-a-raspberry-pi)
             - macOS (Apple Silicon): Download the `.dmg`, open and move 240mp.app to your applications folder
+
+            ### Update Instructions:
+
+            - Raspberry Pi OS Trixie (arm64): [Instructions](INSTALL.md#update)
+            - macOS (Apple Silicon): Download the `.dmg`, open and move 240mp.app to your applications folder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ The most useful community contributions are often not code, items like the follo
 ### Principles to keep in mind
 
 1. **Baseline on remote control as an input device**: All experiences should be built so they can be interacted with via up/down/left/right enter and esc/backspace.  More complex inputs should be avoided so that users can navigate via a simple usb remote.
-2. **Lay out screens for 240p/480i on a CRT**: Design layouts and size elements to display well on a CRT TV.  Consider overscan when placing elements on screen.  If you leverage the `root.sh` and `root.sw` vars for sizing you'll get responsive display for LCD tvs out of the box.
+2. **Lay out screens for 240p/480i on a CRT**: Design layouts and size elements to display well on a CRT TV.  Consider overscan when placing elements on screen.  If you leverage the `root.sh` and `root.sw` properties for sizing you'll get responsive display for LCD tvs out of the box.
 3. **Keep modules self contained**:  If your module just relies on QML then you can simply add your module in a `/modules/[module name]` directory with a `manifest.json` and 240-MP will pick it up for display.  If your module requires a backend then you'll also need to register it in `/src/main.cpp`.  But other than that please keep all of your module source in a `/src/modules/[module name]` folder.  See [Anatomy of a Module](ARCHITECTURE.md#anatomy-of-a-module) for the full layout.
-4. **No tracking or analytics**: Do not include any mechanisms for tracking or reporting usage to an external source that you maintain.  A module should only ever write details to the local 240-MP configuration directory.  If a module relies on connecting to a 3rd party API (example: the Plex module) then it should only communicate with that API directly.
+4. **Don't add tracking or analytics**: Do not include any mechanisms for tracking or reporting usage to an external source that you maintain.  A module should only ever write details to the local 240-MP configuration directory.  If a module relies on connecting to a 3rd party API (example: the Plex module) then it should only communicate with that API directly.
 5. **Browse & Hand-off**: Think of 240-MP and its modules as a way to browse structured content (either on a filesystem or via an API response) and to hand-off to a purpose built tool for an action (like how it relies on MPV for video playback which is purpose built for that ask).  The approach is to leverage existing, purpose built applications that exist on a system and not bundle everything into 240-MP.
 
 ### Understanding the codebase
@@ -79,10 +79,10 @@ Sorry I've not made time yet to work on automated tests so for now testing is ma
 
 Before opening a PR, please check your change against these:
 
-- [ ] **Remote-only navigation** works end to end — up/down/left/right, enter, and esc/backspace. No mouse or complex input required.
-- [ ] **Sized and positioned elements with `root.sh` / `root.sw`**, no hardcoded pixel sizes, and laid out with CRT overscan in mind.
-- [ ] **Avoided hardcoded values** where a parameter or existing variable would do — parameterize as much as possible.
-- [ ] **No tracking or analytics.** The only network calls are direct to a third-party API the module integrates with.
+- [ ] **Changes work with remote-only navigation** works end to end — up/down/left/right, enter, and esc/backspace. No mouse or complex input added.
+- [ ] **Sized and positioned elements using the `root.sh` / `root.sw` properties**, did not hardcode pixel sizes, and kept CRT overscan in mind.
+- [ ] **Avoided hardcoded values** where a parameter or existing variable would do the change parameterized as much as possible.
+- [ ] **Didn't add tracking or analytics.** The only network calls (if needed) are direct to the third-party API the module integrates with.
 - [ ] **Only writes to the local data directory** (`config.json` and module state files) — nothing outside it.
 - [ ] **Browse & hand-off** — heavy lifting (like playback) is handed to a purpose-built tool, not bundled in.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -175,7 +175,7 @@ To update to the latest release on Raspberry Pi please follow these steps (your 
     - if you already have autostart set up you can press either Y or N, it will keep your current autostart
     - if you don't have autostart installed and want to keep it that way just answer N
     - and if you want to turn on autostart just answer Y
-4) Once that completes just run 'sudo reboot' and when your pi restarts you'll be on the latest version
+4) Once that completes just run `sudo reboot` and when your pi restarts you'll be on the latest version
 
 ### Uninstall
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
 ### Requirements
 
-- A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/), [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/) or [3B](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) - These are the only models I've tested with, it may work on others but sorry I can't say for sure
+- A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/) - These are the only models I've tested with, it may work on others but sorry I can't say for sure
 - SD Card (minimum of 4GB)
 - Internet Access (either WiFi or network cable will work)
 
@@ -27,118 +27,116 @@ The following steps will set up an image for your Raspberry Pi with the latest v
     | --- | --- |
     | <img src="https://github.com/user-attachments/assets/bb9f7a47-12b7-4580-abf4-ec8ad22153ba" /> | <img src="https://github.com/user-attachments/assets/30c39fce-99f8-48c9-9ad0-2b39b52690c1" /> |
 
-2) After the write is complete, reconnect the card to your PC and update your boot/config.txt to one of the following:
+2) After the write is complete, reconnect the card to your PC and update your boot/config.txt to one of the following (please make sure to choose the one that best matches your TV):
 
-    <details>
-        <summary>For composite out on a CRT TV (NTSC)...</summary>
-        
-        # --- Global ---
+    **Option 1: For composite out on a CRT TV (NTSC)...**
+    ```
+    # --- Global ---
 
-        arm_64bit=1
-        disable_fw_kms_setup=1
-        disable_splash=1
-        disable_overscan=1
-        dtparam=audio=on
-        
-        # Composite
-        enable_tvout=1
-        sdtv_mode=0
-        sdtv_aspect=1
-        
-        # --- Pi 4B ---
-        [pi4]
-        
-        # Drivers & Video
-        dtoverlay=vc4-fkms-v3d,cma-256
-        dtoverlay=rpivid-v4l2
-        
-        # Overclocking
-        over_voltage=2
-        arm_freq=1750
-        gpu_freq=600
-        
-        # --- Pi 3B ---
-        [pi3]
-        
-        # Drivers & Video
-        dtoverlay=vc4-fkms-v3d,cma-256
-        
-        # Overclocking
-        over_voltage=4
-        arm_freq=1300
-        core_freq=450
-        sdram_freq=500
-        
-        # --- Pi 3B+ ---
-        [pi3+]
-        
-        # Drivers & Video
-        dtoverlay=vc4-fkms-v3d,cma-256
-        
-        # Overclocking
-        over_voltage=2
-        arm_freq=1500
-        core_freq=500
-        sdram_freq=500
-        
-        # --- Global ---
-        [all]
-    </details>
+    arm_64bit=1
+    disable_fw_kms_setup=1
+    disable_splash=1
+    disable_overscan=1
+    dtparam=audio=on
+    
+    # Composite
+    enable_tvout=1
+    sdtv_mode=0
+    sdtv_aspect=1
+    
+    # --- Pi 4B ---
+    [pi4]
+    
+    # Drivers & Video
+    dtoverlay=vc4-fkms-v3d,cma-256
+    dtoverlay=rpivid-v4l2
+    
+    # Overclocking
+    over_voltage=2
+    arm_freq=1750
+    gpu_freq=600
+    
+    # --- Pi 3B ---
+    [pi3]
+    
+    # Drivers & Video
+    dtoverlay=vc4-fkms-v3d,cma-256
+    
+    # Overclocking
+    over_voltage=4
+    arm_freq=1300
+    core_freq=450
+    sdram_freq=500
+    
+    # --- Pi 3B+ ---
+    [pi3+]
+    
+    # Drivers & Video
+    dtoverlay=vc4-fkms-v3d,cma-256
+    
+    # Overclocking
+    over_voltage=2
+    arm_freq=1500
+    core_freq=500
+    sdram_freq=500
+    
+    # --- Global ---
+    [all]
+    ```
 
-    <details>
-        <summary>For HDMI out...</summary>
+    or **Option 2: for HDMI out on a modern TV...**
+    ```
+    # --- Global ---
 
-        # --- Global ---
+    arm_64bit=1
+    disable_fw_kms_setup=1
+    disable_splash=1
+    disable_overscan=1
+    dtparam=audio=on
 
-        arm_64bit=1
-        disable_fw_kms_setup=1
-        disable_splash=1
-        disable_overscan=1
-        dtparam=audio=on
+    # HDMI
+    display_auto_detect=1
+    hdmi_force_hotplug=1
 
-        # HDMI
-        display_auto_detect=1
-        hdmi_force_hotplug=1
-
-        # --- Pi 4B ---
-        [pi4]
-        
-        # Drivers & Video
-        dtoverlay=vc4-fkms-v3d,cma-256
-        dtoverlay=rpivid-v4l2
-        
-        # Overclocking
-        over_voltage=2
-        arm_freq=1750
-        gpu_freq=600
-        
-        # --- Pi 3B ---
-        [pi3]
-        
-        # Drivers & Video
-        dtoverlay=vc4-fkms-v3d,cma-256
-        
-        # Overclocking
-        over_voltage=4
-        arm_freq=1300
-        core_freq=450
-        sdram_freq=500
-        
-        # --- Pi 3B+ ---
-        [pi3+]
-        
-        # Drivers & Video
-        dtoverlay=vc4-fkms-v3d,cma-256
-        
-        # Overclocking
-        over_voltage=2
-        arm_freq=1500
-        core_freq=500
-        sdram_freq=500
-        
-        # --- Global ---
-        [all]
-    </details>
+    # --- Pi 4B ---
+    [pi4]
+    
+    # Drivers & Video
+    dtoverlay=vc4-fkms-v3d,cma-256
+    dtoverlay=rpivid-v4l2
+    
+    # Overclocking
+    over_voltage=2
+    arm_freq=1750
+    gpu_freq=600
+    
+    # --- Pi 3B ---
+    [pi3]
+    
+    # Drivers & Video
+    dtoverlay=vc4-fkms-v3d,cma-256
+    
+    # Overclocking
+    over_voltage=4
+    arm_freq=1300
+    core_freq=450
+    sdram_freq=500
+    
+    # --- Pi 3B+ ---
+    [pi3+]
+    
+    # Drivers & Video
+    dtoverlay=vc4-fkms-v3d,cma-256
+    
+    # Overclocking
+    over_voltage=2
+    arm_freq=1500
+    core_freq=500
+    sdram_freq=500
+    
+    # --- Global ---
+    [all]
+    ```
 
 3) Place the SD card in your Raspberry Pi and let it run through its first boot sequence
 
@@ -162,7 +160,7 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
     If you choose that option please make sure to enter your primary user for the pi at the next prompt.  If you don't provide one it will set it up for the `Pi` user.
 
-At this point you can type `240mp` to start up the app.  When you quit the app it will automatically shutdown your Pi and if you chose to install the autostart service then the next time you boot your Pi it will boot into 240-MP.
+    At this point you can type `240mp` to start up the app.  If you chose to install the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
 
 ### Update
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,6 +164,21 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
 At this point you can type `240mp` to start up the app.  When you quit the app it will automatically shutdown your Pi and if you chose to install the autostart service then the next time you boot your Pi it will boot into 240-MP.
 
+### Update
+
+To update to the latest release on Raspberry Pi please follow these steps (your settings will be retained):
+
+1) SSH into your Raspberry Pi
+2) Re-run the install script
+    ```bash
+    bash <(curl -fsSL https://github.com/anthonycaccese/240-mp/releases/latest/download/install.sh)
+    ```
+3) When it asks to `Install systemd autostart service? [y/N]`
+    - if you already have autostart set up you can press either Y or N, it will keep your current autostart
+    - if you don't have autostart installed and want to keep it that way just answer N
+    - and if you want to turn on autostart just answer Y
+4) Once that completes just run 'sudo reboot' and when your pi restarts you'll be on the latest version
+
 ### Uninstall
 
 1) If you'd like to remove 240-MP and continue to use your SD card for other things you can run the following commands via terminal or over SSH:
@@ -194,9 +209,15 @@ If you don't have a Raspberry Pi and would like to try 240-MP, I also provide a 
 ### Steps
 
 1. Download the DMG archive from the latest release
-2. Mount it and move the 240mp.app into your Applicaitons folder
+2. Mount it and move the 240mp.app into your Applications folder
 3. Make sure you have mpv installed (240-MP requires MPV for playback): `brew install mpv`
 4. Double click 240-MP and it should open full screen
+
+### Update
+
+To update to the latest release on MacOS please follow these steps (your settings will be retained):
+1. Download the DMG archive from the latest release
+2. Mount it and move the 240mp.app into your Applications folder to overwrite your existing version. *Your existing configuration settings will be retained and it's safe to overwrite*
 
 ### Uninstall
 

--- a/Main.qml
+++ b/Main.qml
@@ -50,11 +50,11 @@ Window {
             "accent": "#EE442F"
         },
         "Amber": {
-            "primary": "#FFE31C",
+            "primary": "#FFB000",
             "secondary": "#B37B00",
             "tertiary": "#B37B00",
-            "surface": "#271617",
-            "accent": "#FFE31C"
+            "surface": "#000000",
+            "accent": "#FFEE11"
         },
         "Kinescope": {
             "primary": "#FFFFFF",

--- a/Main.qml
+++ b/Main.qml
@@ -48,6 +48,20 @@ Window {
             "tertiary": "#df9c27",
             "surface": "#FAF5E8",
             "accent": "#EE442F"
+        },
+        "Amber": {
+            "primary": "#FFE31C",
+            "secondary": "#B37B00",
+            "tertiary": "#B37B00",
+            "surface": "#271617",
+            "accent": "#FFE31C"
+        },
+        "Kinescope": {
+            "primary": "#FFFFFF",
+            "secondary": "#9E9E9E",
+            "tertiary": "#424242",
+            "surface": "#121212",
+            "accent": "#FFFFFF"
         }
     })
     property var allThemes: themes  // may gain a "Custom" entry on startup

--- a/README.md
+++ b/README.md
@@ -62,11 +62,14 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 - Will this work on other Raspberry Pi models? (like the 5, 2 zero, etc...)
     - Sorry, I can't say for sure as I've only tested on the 4b, 3b+ and 3b and don't have plans to test on other devices at this time.
 - Where does the name "240-MP" come from?
-    - 240 has a double meaning referring to the longest [VHS tape length](https://en.wikipedia.org/wiki/VHS#Tape_lengths) and my primary display target for it of [CRT TVs](https://consolemods.org/wiki/CRT:What_is_240p%3F)
+    - 240 has a double meaning referring to the longest [VHS tape length](https://en.wikipedia.org/wiki/VHS#Tape_lengths) and my primary display target for it of [CRT TVs](https://consolemods.org/wiki/CRT:What_is_240p%3F).
     - MP also has a double meaning of "Media Player" and a play on the "SP/LP/EP/SLP" terminology that was used to refer to the recording quality for VHS recordings.
+- Does the 240 in the name mean that it outputs at 240p resolution?
+    - No and I apologize for any confusion I've caused on this, it's 240 in name only.
+    - The output resolution for the menu and video playback when using it on a CRT is 480i.
 - Does 240-MP work over HDMI on a modern television too?
     - Yes! The UI was built to scale on modern televisions over HDMI as well.
-    - Please make sure you use the config.txt I provide for HDMI instead of CRT.
+    - Please make sure you use the config.txt I provide for HDMI and it will output at the proper resolution for a modern tv.
 
 ## Credits & Acknowledgments 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 240-MP is a retro VCR style frontend to play content on Raspberry Pi (preferably hooked up to a CRT TV). 
 
-Playback experiences are handled via modules to enable new integrations without requiring major changes to the overall frontend. There are 2 currently included playback modules; one for [Local Files](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files) and one for [Plex](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex).
+Playback experiences are handled via modules to enable new integrations without requiring major changes to the overall frontend. There are 3 currently included playback modules; one for [Local Files](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files), one for [Plex](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex) and a module similar to art/wallpaper modes on modern tvs called ([Ambient:Mode](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode))
 
 It's built to work in conjuction with MPV which will be installed (or updated) as a dependency during the [install](#Install) steps outlined below.
 
@@ -45,6 +45,12 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 - Full library browsing by letter
 - Show/Season browsing
 - Video quality selection: Direct Playback (Default) or Transcode options
+
+### Ambient:Mode Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode))
+- Supported video file types: `"mp4", "mkv", "avi", "mov", "m4v", "webm", "wmv", "flv", "f4v", "mpg", "mpeg", "vob"`
+- Playlist support for audio tracks using `m3u` and `m3u8` files
+- Mix video with a different audio track
+- Loops forever until you stop it
 
 ## Install 
 

--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -23,6 +23,12 @@
       "default": "OFF"
     },
     {
+      "key": "shuffle_playback",
+      "label": "Shuffle Playback",
+      "type": "toggle",
+      "default": "OFF"
+    },
+    {
       "key": "resume_playback",
       "label": "Resume Playback",
       "type": "list_single",

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -15,6 +15,7 @@ FocusScope {
     property int    savedPlaylistPos:    -1
     property int    choiceIndex:         0
     property bool   loopOn:              false
+    property bool   shuffleOn:           false
     property string resumeSetting:       "ask"
 
     // Track last non-null values during playback for robust save on exit
@@ -128,7 +129,15 @@ FocusScope {
     Component.onCompleted: {
         if (filePath === "") return
         loopOn        = !!appCore.get_setting(moduleRoot.moduleId, "loop_playback")
+        shuffleOn     = !!appCore.get_setting(moduleRoot.moduleId, "shuffle_playback")
         resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
+
+        // Shuffle wins: a shuffled playlist starts fresh & random; resume position
+        // (a sequential item index) is meaningless once order is randomized.
+        if (shuffleOn && isPlaylist(filePath)) {
+            mpvController.loadAndPlay(filePath, 0.0, 0, -1, [], loopOn, -1, 0.0, "", false, "", true)
+            return
+        }
 
         if (resumeSetting === "no") {
             mpvController.loadAndPlay(filePath, 0.0, 0, -1, [], loopOn, -1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ static QString resolveDataRoot() {
 int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
     app.setApplicationName("240-MP");
-    app.setApplicationVersion("2026.06.06");
+    app.setApplicationVersion("2026.06.10");
 
     // Hide cursor — 240-MP is keyboard-only so the cursor serves no purpose.
     // On Linux, only hide on headless EGLFS (not desktop X11/Wayland sessions).

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -97,7 +97,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
                                  const QStringList &subFiles, bool loop,
                                  int playlistStart, float transcodeOffsetSec,
                                  const QString &plexToken, bool muteAudio,
-                                 const QString &oscMode) {
+                                 const QString &oscMode, bool shuffle) {
     if (m_process) {
         m_process->disconnect();
         if (m_process->state() != QProcess::NotRunning) {
@@ -177,6 +177,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
 
     if (loop)
         args << QStringLiteral("--loop-playlist=inf");
+    if (shuffle)
+        args << QStringLiteral("--shuffle");
     if (muteAudio)
         args << QStringLiteral("--no-audio");
     if (!plexToken.isEmpty()) {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -42,7 +42,8 @@ public:
                                   float transcodeOffsetSec = 0.0f,
                                   const QString &plexToken = {},
                                   bool muteAudio = false,
-                                  const QString &oscMode = {});
+                                  const QString &oscMode = {},
+                                  bool shuffle = false);
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -27,7 +27,7 @@ FocusScope {
         var items = []
 
         // APPLICATION section
-        var colorOpts = ["Video 1","Late Night","Synthwave","Terminal","T-120"]
+        var colorOpts = ["Video 1","Late Night","Synthwave","Terminal","T-120","Amber","Kinescope"]
         var custom = appCore.getCustomColorScheme()
         if (Object.keys(custom).length === 5) colorOpts.push("Custom")
         items.push({


### PR DESCRIPTION
## Summary

Features:
- Adds `Shuffle Playback` setting for Local Files module
- Adds Ambient:Mode module
- Adds new Color Schemes: Amber & Kinescope

Docs:
- Updates Contribution Docs to clarify PR needs
- Updates Install Docs to make config differences between CRT and HDMI outputs clearer 
- Updates Install Docs to add `update` instructions for both Raspberry Pi and MacOS
- Updates Readme with details on CRT output resolution

## AI involvement

Used to explore how best to integrate shuffle playback into Local Files and avoid regressions

## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->

- Platform(s) tested: MacOS 26.3.1 & Raspberry Pi 4b running Trixie Lite
- Display / output tested: 1080p & CRT @ 480i

## Checklist

- [x] Works with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Sizing and Positioning with `root.sh` / `root.sw` (no hardcoded pixels) and mindful of CRT overscan
- [x] No tracking/analytics; only writes to the local data directory
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
