### PR TITLE
Allow right shift key to go back (like ESC) for one handed keyboard use

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -488,6 +488,11 @@ bool InputManager::eventFilter(QObject *obj, QEvent *event) {
     // gamepad Back path, which posts Escape into QML — or sends ESC to mpv
     // over IPC when fullscreen mpv holds OS focus and the window can't take
     // key events. The bare Shift event is consumed; no view binds Key_Shift.
+    //
+    // Known gap: during fullscreen playback on macOS the keyboard goes to
+    // mpv, not us, and mpv can't bind a bare modifier — so right shift only
+    // works in the player on platforms where the app keeps the keyboard
+    // (RPi/EGLFS). Same asymmetry as gamepads, minus their SDL workaround.
     if (ke->key() == Qt::Key_Shift && isRightShift(ke)) {
         if (!ke->isAutoRepeat()) {
             if (type == QEvent::KeyPress)

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -20,6 +20,19 @@ constexpr Sint16 kAxisRelease = 12000;
 // Held-direction auto-repeat, tuned to feel like keyboard repeat in lists.
 constexpr int kRepeatDelayMs    = 400;
 constexpr int kRepeatIntervalMs = 100;
+
+// Qt reports both shift keys as Qt::Key_Shift; telling them apart takes the
+// platform code. Linux keymaps (eglfs/evdev, X11, Wayland) report evdev's
+// KEY_RIGHTSHIFT, with or without the X11-style +8 offset; macOS reports
+// kVK_RightShift in the virtual key.
+bool isRightShift(const QKeyEvent *ke) {
+#ifdef Q_OS_MACOS
+    return ke->nativeVirtualKey() == 0x3C;   // kVK_RightShift
+#else
+    const quint32 sc = ke->nativeScanCode();
+    return sc == 54 || sc == 62;             // KEY_RIGHTSHIFT, +8 offset
+#endif
+}
 }
 
 InputManager::InputManager(const QString &dataRoot, QObject *parent)
@@ -463,10 +476,26 @@ bool InputManager::isDirectional(Action a) {
 
 bool InputManager::eventFilter(QObject *obj, QEvent *event) {
     Q_UNUSED(obj)
-    if (event->type() == QEvent::KeyPress) {
-        const auto *ke = static_cast<QKeyEvent *>(event);
-        if (ke->nativeScanCode() != kSyntheticScanCode)
-            setLastInputDevice(QStringLiteral("keyboard"));
+    const QEvent::Type type = event->type();
+    if (type != QEvent::KeyPress && type != QEvent::KeyRelease)
+        return false;
+    const auto *ke = static_cast<QKeyEvent *>(event);
+
+    if (type == QEvent::KeyPress && ke->nativeScanCode() != kSyntheticScanCode)
+        setLastInputDevice(QStringLiteral("keyboard"));
+
+    // Right shift acts as Back so the keyboard works one-handed: reuse the
+    // gamepad Back path, which posts Escape into QML — or sends ESC to mpv
+    // over IPC when fullscreen mpv holds OS focus and the window can't take
+    // key events. The bare Shift event is consumed; no view binds Key_Shift.
+    if (ke->key() == Qt::Key_Shift && isRightShift(ke)) {
+        if (!ke->isAutoRepeat()) {
+            if (type == QEvent::KeyPress)
+                deliverPress(Action::Back, false);
+            else
+                releaseAction(Action::Back);
+        }
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
## Summary

It allows the right shift key to be used to navigate back (like ESC) for one handed (right handed) keyboard use.

## AI involvement

All code and comments were AI generated by Claude Fable 5. A human reviewed the code and manually tested.

As called out in the comments, right shift during video playback does not work to go back in the Mac build due to the MPV issue but does work in the Pi build.

## Testing

Manual human testing was done on both the Mac and pi (I used a pi 3b+) builds. The mac build was tested on an M4 macbook air display and the pi build was tested on a CRT although there is no visual change introduced by this PR.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
