### PR TITLE
fix(plex): persist audio/subtitle selection and use a fresh session per play

### DIFF
--- a/modules/plex/views/Item.qml
+++ b/modules/plex/views/Item.qml
@@ -22,8 +22,12 @@ FocusScope {
     property int audioIdx: 0
     property int subtitleIdx: 0
 
-    // Unique session ID for this playback instance
-    readonly property string sessionId: {
+    // Session ID for the current playback instance. Regenerated on every play
+    // (see Keys.onReturnPressed): reusing one lets Plex hand back a stale
+    // transcode session built with the previously selected audio/subtitle.
+    property string sessionId: newSessionId()
+
+    function newSessionId() {
         var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
         var id = ""
         for (var i = 0; i < 12; i++) id += chars[Math.floor(Math.random() * chars.length)]
@@ -135,11 +139,25 @@ FocusScope {
     }
     Keys.onReturnPressed: {
         if (focusRow === 0 && detail) {
+            var audioId = detail.audioStreams && detail.audioStreams[audioIdx]
+                ? detail.audioStreams[audioIdx].id : ""
+            var subId = detail.subtitleStreams && detail.subtitleStreams[subtitleIdx]
+                ? detail.subtitleStreams[subtitleIdx].id : "0"
+
+            // Persist the picked tracks to Plex so they survive returning to
+            // this screen, and so a transcode burns the streams the user chose
+            // (the server selects from its stored default, not just inline
+            // params). subtitleStreamID "0" disables subtitles.
+            if (detail.partId) {
+                if (audioId) plexBackend.set_audio_stream(audioId, detail.partId)
+                plexBackend.set_subtitle_stream(subId, detail.partId)
+            }
+
+            // Fresh session per play so Plex builds a new transcode for this
+            // exact selection instead of reusing the prior one.
+            sessionId = newSessionId()
+
             if (detail.forceTranscode) {
-                var audioId = detail.audioStreams && detail.audioStreams[audioIdx]
-                    ? detail.audioStreams[audioIdx].id : ""
-                var subId = detail.subtitleStreams && detail.subtitleStreams[subtitleIdx]
-                    ? detail.subtitleStreams[subtitleIdx].id : "0"
                 plexBackend.request_transcode(detail.ratingKey, detail.partKey, sessionId, audioId, subId, detail.viewOffset || 0)
             } else {
                 plexBackend.build_stream_url(detail.ratingKey, detail.partKey, sessionId)


### PR DESCRIPTION
## Problem
On the Plex detail view's **PLAYBACK SETTINGS**, the chosen **AUDIO**/**SUBTITLES** were not reliably applied to playback, and the selection reset to OFF when returning to the screen.

Root cause: the picks were never sent to Plex. `set_audio_stream`/`set_subtitle_stream` existed but were never called, so:
- returning to the detail screen reloaded Plex's stored default (looked like a reset to OFF), and
- transcodes could burn Plex's default streams instead of the chosen ones (the server selects from its stored default).

## Fix
On play (`Item.qml` `Keys.onReturnPressed`):
- Persist the selected audio/subtitle to the part via `set_audio_stream`/`set_subtitle_stream` (`subtitleStreamID=0` = off).
- Regenerate the playback `sessionId` per play so Plex builds a fresh transcode for the current selection instead of reusing a stale one.

QML-only change.

## Testing (human)
Tested on **macOS** and **Raspberry Pi 3B+**, in both **direct play** and **transcode** modes. Selection now persists across returning to the detail screen; direct play applies the correct audio/subtitle tracks. Transcode is substantially improved (some Plex server-side edge cases may remain — tracked separately).

## Notes
- Persisting selection sets the part's default **server-side**, so the choice also sticks in other Plex clients (standard Plex behavior).
- Not addressed here: direct-play selection of downloadable **text/SRT** subtitles (separate mpv `--sid` mapping issue, rare), and residual **transcode** edge cases (Plex-side caching/burn timing) — follow-up investigation noted.

## AI disclosure
Implemented with AI assistance (Claude Code); diagnosis and code reviewed and hardware-tested by a human.