### PR TITLE
Switch Plex servers from the main menu

### DIFF
--- a/modules/plex/views/Libraries.qml
+++ b/modules/plex/views/Libraries.qml
@@ -14,6 +14,10 @@ FocusScope {
     property var libraries: []
     property string serverName: ""
     property string userName: ""
+    // Servers the active user can switch to from the main menu. More than one
+    // means the quick-switch action (◄/►) is offered.
+    property var switchableServers: []
+    property bool canSwitchServer: switchableServers.length > 1
 
     Connections {
         target: plexBackend
@@ -35,7 +39,15 @@ FocusScope {
     Component.onCompleted: {
         browseRoot.serverName = plexBackend.get_active_server_name()
         browseRoot.userName = plexBackend.get_active_user_name()
+        browseRoot.switchableServers = plexBackend.get_switchable_servers()
         plexBackend.load_libraries()
+    }
+
+    function openServerSwitch() {
+        if (!canSwitchServer) return
+        browseRoot.navigateTo("ServerSelect.qml",
+                              { servers: switchableServers, switching: true },
+                              { currentIndex: libraryList.currentIndex })
     }
 
     focus: true
@@ -80,6 +92,8 @@ FocusScope {
 
         Keys.onUpPressed: if (currentIndex > 0) currentIndex--
         Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onLeftPressed: browseRoot.openServerSwitch()
+        Keys.onRightPressed: browseRoot.openServerSwitch()
 
         Keys.onReturnPressed: {
             var lib = libraries[currentIndex]
@@ -160,6 +174,7 @@ FocusScope {
     Text {
         id: footer
         text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":SELECT"
+              + (browseRoot.canSwitchServer ? " " + root.hints.change + ":SERVER" : "")
         color: root.tertiaryColor
         font.family: root.globalFont
         anchors.bottom: parent.bottom

--- a/modules/plex/views/ServerSelect.qml
+++ b/modules/plex/views/ServerSelect.qml
@@ -10,6 +10,10 @@ FocusScope {
     signal goBack()
 
     property var servers: navParams.servers || []
+    // When opened from the main menu (Libraries) as a quick switch rather than as
+    // part of the initial auth flow, return to the menu on success instead of
+    // pushing a fresh Libraries onto the stack.
+    property bool switching: navParams.switching === true
 
     Connections {
         target: plexBackend
@@ -19,7 +23,11 @@ FocusScope {
         }
 
         function onAuthSuccess() {
-            serverSelectRoot.navigateTo("Libraries.qml", {})
+            if (serverSelectRoot.switching) {
+                serverSelectRoot.goBack()
+            } else {
+                serverSelectRoot.navigateTo("Libraries.qml", {})
+            }
         }
 
         function onErrorOccurred(msg) {
@@ -28,7 +36,13 @@ FocusScope {
     }
 
     Component.onCompleted: {
-        if (servers.length > 0) serverList.currentIndex = 0
+        if (servers.length === 0) return
+        // Pre-highlight the currently active server when switching.
+        var activeName = plexBackend.get_active_server_name()
+        serverList.currentIndex = 0
+        for (var i = 0; i < servers.length; i++) {
+            if (servers[i].name === activeName) { serverList.currentIndex = i; break }
+        }
     }
 
     focus: true

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -725,6 +725,24 @@ QString PlexBackend::get_active_server_name() {
     return {};
 }
 
+// Servers the active user can switch to, in {name, machineId} form for
+// ServerSelect.qml. Mirrors getServers() filtering (managed users only see their
+// own servers) but returns synchronously from cached auth so the main menu can
+// offer an in-place server switch without a round-trip.
+QVariantList PlexBackend::get_switchable_servers() {
+    QJsonObject auth = loadAuth();
+    QJsonObject managed = auth["managed_user_tokens"].toObject();
+    bool managedActive = !managed.isEmpty();
+    QVariantList list;
+    for (const auto &v : auth["servers"].toArray()) {
+        QJsonObject s = v.toObject();
+        QString mid = s["machineId"].toString();
+        if (managedActive && !managed.contains(mid)) continue;
+        list.append(QVariantMap{{"name", s["name"].toString()}, {"machineId", mid}});
+    }
+    return list;
+}
+
 void PlexBackend::build_stream_url(const QString &ratingKey,
                                    const QString &partKey,
                                    const QString &sessionId) {

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -18,6 +18,7 @@ public:
     Q_INVOKABLE QString  get_auth_state();
     Q_INVOKABLE QString  get_active_user_name();
     Q_INVOKABLE QString  get_active_server_name();
+    Q_INVOKABLE QVariantList get_switchable_servers();
     Q_INVOKABLE void     build_stream_url(const QString &ratingKey,
                                           const QString &partKey,
                                           const QString &sessionId);


### PR DESCRIPTION
## What

Adds a way to quickly switch the active Plex server from the module's main menu, instead of having to go back to Settings. The Plex module connects to the default/configured server on entry; this lets you jump to any of your other configured servers in a couple of keypresses.

## How

- **`Libraries.qml` (main menu):** press **◄/►** to open the server picker. A footer hint (`[◄►]:SERVER`) appears only when more than one server is available. Left/Right were unused on this vertical list and are delivered identically on gamepad (d-pad → arrow keys), so this works on keyboard and controller with no `InputManager` changes.
- **`PlexBackend::get_switchable_servers()`:** new synchronous `Q_INVOKABLE` returning the active user's servers as `{name, machineId}`, filtered the same way as `getServers()` (managed users only see their own servers). Reads from cached auth, so no network round-trip.
- **`ServerSelect.qml`:** reuses the existing picker. A new `switching` nav param makes it return to the refreshed main menu on success (the initial auth flow is unchanged) and pre-highlights the currently active server.

After selecting a server, `select_server` persists it and the menu reloads with that server's libraries. Cancelling returns to the menu, and the nav stack stays clean (Back from the menu still exits the module).

## Testing

Human-tested: verified Plex server switching works end-to-end on both macOS and Raspberry Pi 3B+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)