### PR TITLE
fix: macos mpv font

### DIFF
--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -284,6 +284,14 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         args << QString("--input-conf=%1").arg(m_inputConfPath)
              << "--video-sync=audio"
              << "--fullscreen" << "--no-native-fs";
+#ifdef Q_OS_MACOS
+        // mpv runs as a separate process and can't see the app-bundle font via
+        // FontLoader. This will load the bundled VCR OSD Mono directly into the OSD libass
+        // instance (used by the OSC scripts) so users don't need a system install.
+        // macOS libass uses the coretext provider, so the Linux FONTCONFIG_FILE
+        // approach doesn't apply here; --osd-fonts-dir is provider-independent.
+        args << QString("--osd-fonts-dir=%1").arg(m_appRoot + "/assets/fonts");
+#endif
         qDebug("[MpvController] desktop launch: mpv %s", qPrintable(args.join(" ")));
         m_process->start(bin, args);
         m_connectTimer->start();


### PR DESCRIPTION
## Summary

Fixes #12 so font is passed to mpv on MacOS (no need for users to install it manually)

## AI involvement

Used to research approaches to try on Mac vs what we do on headless raspberry pi os

## Testing

- Platform(s) tested: MacOS and Raspberry Pi OS Lite (Trixie)
- Display / output tested: HDMI and Composite

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)