### PR TITLE
Feat/plex: Autoplay Next Episode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 - User profile switching and auto sign in
 - Select specific libraries to display
 - Continue Watching and Resume
+- Autoplay next episode in a season (optional, off by default)
 - Hub, Playlist, Collection and Category support
 - Movie editions
 - Select preferred audio/subtitle track before playback and switch tracks during playback

--- a/modules/plex/manifest.json
+++ b/modules/plex/manifest.json
@@ -61,6 +61,13 @@
       "requires_auth": true
     },
     {
+      "key": "autoplay_next_episode",
+      "label": "Autoplay Next Episode",
+      "type": "toggle",
+      "default": "OFF",
+      "requires_auth": true
+    },
+    {
       "key": "logout",
       "label": "Sign out",
       "type": "action",

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -25,7 +25,6 @@ FocusScope {
     property int    subtitleIdx: 0
     property bool   isTranscoding:    navParams.isTranscoding    || false
     property var    imageSubtitleIds: navParams.imageSubtitleIds || []
-    property string activeSessionId: sessionId
     property string selectedAudioId:    navParams.selectedAudioId    || ""
     property string selectedSubtitleId: navParams.selectedSubtitleId || "0"
 
@@ -113,23 +112,19 @@ FocusScope {
         return transcodeStartOffset + streamPosMs
     }
 
-    function stopPlayback() {
-        if (!stoppedReported) {
-            stoppedReported = true
-            var pos = lastKnownPositionMs || absPos(mpvController.position)
-            var dur = lastKnownDurationMs || mpvController.duration
-            plexBackend.update_timeline(ratingKey, partKey, "stopped", pos, dur)
-        }
-        mpvController.stop()
-    }
-
-    // Report the final "stopped" timeline for the current episode (idempotent —
-    // skipped if stopPlayback already reported it).
+    // Report the final "stopped" timeline for the current episode exactly once.
+    // The fallback position/duration are used only when no live value is known.
     function reportStopped(finalPositionMs, finalDurationMs) {
         if (stoppedReported) return
+        stoppedReported = true
         var pos = lastKnownPositionMs || absPos(finalPositionMs)
         var dur = lastKnownDurationMs || finalDurationMs
         plexBackend.update_timeline(ratingKey, partKey, "stopped", pos, dur)
+    }
+
+    function stopPlayback() {
+        reportStopped(mpvController.position, mpvController.duration)
+        mpvController.stop()
     }
 
     function initStreamIndices() {
@@ -283,7 +278,6 @@ FocusScope {
         lastKnownPositionMs  = 0
         lastKnownDurationMs  = 0
         sessionId            = newSessionId()
-        activeSessionId      = sessionId
 
         // Repoint the BACK target so exiting returns to THIS episode's detail
         // screen, not the one we auto-advanced from. Item.qml reloads from

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -7,11 +7,15 @@ FocusScope {
 
     signal navigateTo(string path, var params)
     signal goBack()
+    // Emitted when autoplay advances in place, so Root can repoint the BACK
+    // target to the now-playing episode's detail instead of the original one.
+    signal updateBackItem(var item)
 
     property string streamUrl:    navParams.streamUrl    || ""
     property string plexToken:    navParams.plexToken    || ""
     property string ratingKey:    navParams.ratingKey    || ""
     property string partKey:      navParams.partKey      || ""
+    property string partId:       navParams.partId       || ""
     property string sessionId:    navParams.sessionId    || ""
     property int    viewOffset:   navParams.viewOffset   || 0
     property string itemTitle:    navParams.title        || ""
@@ -31,6 +35,13 @@ FocusScope {
     property string resumeSetting:    "ask"
     property bool pendingZeroStart:   false
     property bool pendingRetryTranscode: false
+
+    // Autoplay-next-episode. When enabled, a natural end-of-file advances to the
+    // next episode in the same season, carrying over the audio/subtitle language.
+    property bool   autoplayNext:       false
+    property bool   pendingNextEpisode: false
+    property string carryAudioLang:     ""        // language code of the chosen audio track
+    property string carrySubLang:       "__off__" // language code, or "__off__" when subtitles are off
 
     // For transcoded streams, Plex HLS segments have timestamps starting at 0
     // relative to the transcode offset. We add this to every position we report
@@ -112,6 +123,15 @@ FocusScope {
         mpvController.stop()
     }
 
+    // Report the final "stopped" timeline for the current episode (idempotent —
+    // skipped if stopPlayback already reported it).
+    function reportStopped(finalPositionMs, finalDurationMs) {
+        if (stoppedReported) return
+        var pos = lastKnownPositionMs || absPos(finalPositionMs)
+        var dur = lastKnownDurationMs || finalDurationMs
+        plexBackend.update_timeline(ratingKey, partKey, "stopped", pos, dur)
+    }
+
     function initStreamIndices() {
         var selAudio = navParams.selectedAudioId    || ""
         var selSub   = navParams.selectedSubtitleId || "0"
@@ -120,6 +140,32 @@ FocusScope {
         }
         for (var j = 0; j < subtitleStreams.length; j++) {
             if (subtitleStreams[j].id === selSub) { subtitleIdx = j; break }
+        }
+        captureCarryLanguages()
+    }
+
+    // Record the language of the current audio/subtitle selection so the next
+    // episode (which has different per-file stream IDs) can be matched by language.
+    function captureCarryLanguages() {
+        var a = audioStreams[audioIdx]
+        carryAudioLang = (a && a.language) ? a.language : ""
+        // subtitleIdx 0 is the synthetic "OFF" entry — preserve "off" deliberately.
+        var s = subtitleStreams[subtitleIdx]
+        carrySubLang = (subtitleIdx === 0 || !s) ? "__off__" : (s.language || "")
+    }
+
+    // Select audioIdx/subtitleIdx on the current stream lists to match the carried
+    // languages. Falls back to the first audio track / subtitles-off when no match.
+    function applyCarryLanguages() {
+        audioIdx = 0
+        for (var i = 0; i < audioStreams.length; i++) {
+            if (carryAudioLang && audioStreams[i].language === carryAudioLang) { audioIdx = i; break }
+        }
+        subtitleIdx = 0
+        if (carrySubLang !== "__off__" && carrySubLang !== "") {
+            for (var j = 1; j < subtitleStreams.length; j++) {
+                if (subtitleStreams[j].language === carrySubLang) { subtitleIdx = j; break }
+            }
         }
     }
 
@@ -184,6 +230,14 @@ FocusScope {
         target: plexBackend
         function onErrorOccurred(msg) { console.log("[Player] Backend error: " + msg) }
         function onStreamUrlReady(url, plexToken) {
+            if (pendingNextEpisode) {
+                // Stream URL for the auto-advanced next episode just arrived.
+                pendingNextEpisode = false
+                playerRoot.streamUrl = url
+                playerRoot.plexToken = plexToken
+                doStartPlayback(0)
+                return
+            }
             if (pendingRetryTranscode) {
                 pendingRetryTranscode = false
                 isTranscoding = true
@@ -196,6 +250,76 @@ FocusScope {
             pendingZeroStart = false
             var sub = buildSubArgs()
             mpvController.loadAndPlay(url, 0.0, audioIdx + 1, sub.track, sub.urls, false, -1, 0.0, plexToken)
+        }
+
+        function onNextEpisodeReady(detail) {
+            if (!pendingNextEpisode) return
+            // Empty detail → no next episode in the season (or a lookup failure).
+            // Fall back to the standard behavior: return to the detail view.
+            if (!detail || !detail.ratingKey) {
+                pendingNextEpisode = false
+                goBack()
+                return
+            }
+            playerRoot.advanceToEpisode(detail)
+        }
+    }
+
+    // Swap the player's context to the next episode in place (no navigation) and
+    // begin playing it from the beginning, carrying over the track languages.
+    function advanceToEpisode(detail) {
+        ratingKey   = detail.ratingKey
+        partKey     = detail.partKey      || ""
+        partId      = detail.partId       || ""
+        itemTitle   = detail.title        || ""
+        audioStreams    = detail.audioStreams    || []
+        subtitleStreams = detail.subtitleStreams || []
+        isTranscoding   = detail.forceTranscode  || false
+
+        // Fresh-start state for the new episode.
+        viewOffset           = 0
+        transcodeStartOffset = 0
+        stoppedReported      = false
+        lastKnownPositionMs  = 0
+        lastKnownDurationMs  = 0
+        sessionId            = newSessionId()
+        activeSessionId      = sessionId
+
+        // Repoint the BACK target so exiting returns to THIS episode's detail
+        // screen, not the one we auto-advanced from. Item.qml reloads from
+        // item.ratingKey, so a minimal item carrying the new keys suffices.
+        updateBackItem({
+            ratingKey: detail.ratingKey,
+            type: detail.type || "episode",
+            title: detail.title || "",
+            grandparentTitle: detail.grandparentTitle || "",
+            parentIndex: detail.parentIndex,
+            index: detail.index
+        })
+
+        // Match the carried languages onto this episode's stream lists, then
+        // remember the resulting selection for the episode after this one.
+        applyCarryLanguages()
+        var audioId = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? audioStreams[audioIdx].id : ""
+        var subId   = (subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? subtitleStreams[subtitleIdx].id : "0"
+        selectedAudioId    = audioId
+        selectedSubtitleId = subId
+        captureCarryLanguages()
+
+        // Persist the chosen tracks to Plex so a transcode burns the right streams
+        // (mirrors Item.qml's behavior before playback).
+        if (partId) {
+            if (audioId) plexBackend.set_audio_stream(audioId, partId)
+            plexBackend.set_subtitle_stream(subId, partId)
+        }
+
+        // Both paths resolve through onStreamUrlReady, which checks this flag.
+        // build_stream_url emits synchronously, so the flag must be set first.
+        pendingNextEpisode = true
+        if (isTranscoding) {
+            plexBackend.request_transcode(ratingKey, partKey, sessionId, audioId, subId, 0)
+        } else {
+            plexBackend.build_stream_url(ratingKey, partKey, sessionId)
         }
     }
 
@@ -210,12 +334,18 @@ FocusScope {
         }
 
         function onPlaybackFinished(finalPositionMs, finalDurationMs) {
-            if (!playerRoot.stoppedReported) {
-                var pos = playerRoot.lastKnownPositionMs || playerRoot.absPos(finalPositionMs)
-                var dur = playerRoot.lastKnownDurationMs || finalDurationMs
-                plexBackend.update_timeline(ratingKey, partKey, "stopped", pos, dur)
-            }
+            // mpv exited because the user quit/stopped — return to the detail view.
+            reportStopped(finalPositionMs, finalDurationMs)
             goBack()
+        }
+
+        function onPlaybackFinishedNaturally(finalPositionMs, finalDurationMs) {
+            // mpv reached the end of the file. Mark it stopped (watched) in Plex,
+            // then auto-advance to the next episode if the feature is enabled.
+            reportStopped(finalPositionMs, finalDurationMs)
+            if (!autoplayNext) { goBack(); return }
+            pendingNextEpisode = true
+            plexBackend.load_next_episode(ratingKey)
         }
 
         function onPlaybackFailed() {
@@ -247,6 +377,7 @@ FocusScope {
         initStreamIndices()
         if (streamUrl === "") return
         resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
+        autoplayNext  = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode") === true
 
         // Plex HLS transcode segments start at time 0 regardless of viewOffset.
         // Track the offset so every reported position is absolute in the video.

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -271,6 +271,15 @@ FocusScope {
         subtitleStreams = detail.subtitleStreams || []
         isTranscoding   = detail.forceTranscode  || false
 
+        // Recompute the image-subtitle IDs for THIS episode (stream IDs are
+        // per-file), mirroring Item.qml's build before the initial hand-off.
+        var imageSubs = []
+        for (var k = 0; k < subtitleStreams.length; k++) {
+            if (subtitleStreams[k] && subtitleStreams[k].imageSubtitle)
+                imageSubs.push(subtitleStreams[k].id)
+        }
+        imageSubtitleIds = imageSubs
+
         // Fresh-start state for the new episode.
         viewOffset           = 0
         transcodeStartOffset = 0
@@ -371,7 +380,10 @@ FocusScope {
         initStreamIndices()
         if (streamUrl === "") return
         resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
-        autoplayNext  = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode") === true
+        // Match ModuleSettings.qml's reading of a toggle: stored as a real bool
+        // once the user touches it, but accept the legacy "ON" string too.
+        var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
+        autoplayNext  = (autoplayRaw === true || autoplayRaw === "ON")
 
         // Plex HLS transcode segments start at time 0 regardless of viewOffset.
         // Track the offset so every reported position is absolute in the video.

--- a/modules/plex/views/Root.qml
+++ b/modules/plex/views/Root.qml
@@ -32,6 +32,15 @@ FocusScope {
         internalLoader.setSource(resolved, { "navParams": params || {} })
     }
 
+    // Repoint the BACK target after autoplay advances in place. The top of the
+    // stack is the detail view the player was launched from; swap its item so
+    // exiting the player returns to the now-playing episode's detail screen.
+    function updateBackItem(item) {
+        if (navStack.length === 0) return
+        var top = navStack[navStack.length - 1]
+        top.params = Object.assign({}, top.params, { item: item })
+    }
+
     function navigateBack() {
         if (navStack.length === 0) {
             moduleRoot.goBack()
@@ -60,6 +69,7 @@ FocusScope {
             function onNavigateTo(path, params, listState) { moduleRoot.navigateTo(path, params, listState) }
             function onReplaceWith(path, params) { moduleRoot.replaceWith(path, params) }
             function onGoBack() { moduleRoot.navigateBack() }
+            function onUpdateBackItem(item) { moduleRoot.updateBackItem(item) }
         }
     }
 

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -636,6 +636,7 @@ QVariantMap PlexBackend::formatItem(const QJsonObject &m) const {
         {"durationDisplay",        msToDisplay(m["duration"].toInt())},
         {"grandparentTitle",       m["grandparentTitle"].toString()},
         {"parentTitle",            m["parentTitle"].toString()},
+        {"parentRatingKey",        m["parentRatingKey"].toString()},
         {"index",                  m["index"].toInt()},
         {"parentIndex",            m["parentIndex"].toInt()},
         {"leafCount",              m["leafCount"].toInt()},
@@ -1554,10 +1555,96 @@ void PlexBackend::check_section_capabilities(const QString &sectionId) {
 // Item detail & playback
 // ---------------------------------------------------------------------------
 
+QString PlexBackend::mediaFilePath(const QJsonObject &meta) {
+    QJsonArray mediaArr = meta["Media"].toArray();
+    if (mediaArr.isEmpty()) return {};
+    QJsonArray partArr = mediaArr.first().toObject()["Part"].toArray();
+    if (partArr.isEmpty()) return {};
+    return partArr.first().toObject()["file"].toString();
+}
+
+QVariantMap PlexBackend::buildItemDetail(const QJsonObject &meta) const {
+    const QString uri = serverUrl();
+    QJsonObject media = meta["Media"].toArray().first().toObject();
+    QJsonObject part  = media["Part"].toArray().first().toObject();
+    QJsonArray streams = part["Stream"].toArray();
+
+    static const QSet<QString> IMAGE_SUB_CODECS = {
+        "pgssub","dvdsub","dvbsub","hdmv_pgs_subtitle","dvd_subtitle"
+    };
+
+    QVariantList audioStreams;
+    QVariantList subtitleStreams;
+    // The "OFF" pseudo-stream uses an empty language so subtitles-off carry-over
+    // is matched by the Player via its explicit "__off__" sentinel, not by language.
+    subtitleStreams.append(QVariantMap{{"id","0"},{"displayTitle","OFF"},
+                                       {"language",""},
+                                       {"selected",false},{"imageSubtitle",false}});
+    QString selectedAudio, selectedSubtitle = "0";
+    QString videoCodec;
+
+    for (const auto &sv : streams) {
+        QJsonObject s = sv.toObject();
+        int st  = s["streamType"].toInt();
+        QString sid   = QString::number(s["id"].toInt());
+        QString title = s["displayTitle"].toString(s["language"].toString("UNKNOWN")).toUpper();
+        // Prefer the ISO language code (stable across episodes); fall back to the
+        // human-readable language name. Used for audio/subtitle carry-over matching.
+        QString lang  = s["languageCode"].toString(s["language"].toString()).toLower();
+        QString codec = s["codec"].toString().toLower();
+        if (st == 1) {
+            videoCodec = codec;
+        } else if (st == 2) {
+            audioStreams.append(QVariantMap{{"id",sid},{"displayTitle",title},{"language",lang}});
+            if (s["selected"].toBool() && selectedAudio.isEmpty())
+                selectedAudio = sid;
+        } else if (st == 3) {
+            bool isImage = IMAGE_SUB_CODECS.contains(codec);
+            QString subKey = s["key"].toString();
+            QString subUrl = subKey.isEmpty() ? "" : uri + subKey;
+            subtitleStreams.append(QVariantMap{{"id",sid},{"displayTitle",title},{"language",lang},{"imageSubtitle",isImage},{"subUrl",subUrl}});
+            if (s["selected"].toBool() && selectedSubtitle == "0")
+                selectedSubtitle = sid;
+        }
+    }
+    if (selectedAudio.isEmpty() && !audioStreams.isEmpty())
+        selectedAudio = audioStreams[0].toMap()["id"].toString();
+
+    bool forceTranscode = (videoQuality() != "auto");
+    qDebug() << "[Plex] Item detail loaded — codec:" << videoCodec
+             << "| quality:" << videoQuality()
+             << "| playback:" << (forceTranscode ? "transcode" : "direct play");
+    int duration = meta["duration"].toInt();
+
+    return QVariantMap{
+        {"ratingKey",        meta["ratingKey"].toString()},
+        {"title",            meta["title"].toString().toUpper()},
+        {"editionTitle",     meta["editionTitle"].toString()},
+        {"year",             meta["year"].toVariant()},
+        {"duration",         duration},
+        {"viewOffset",       meta["viewOffset"].toInt()},
+        {"summary",          meta["summary"].toString()},
+        {"partKey",          part["key"].toString()},
+        {"partId",           QString::number(part["id"].toInt())},
+        {"audioStreams",     audioStreams},
+        {"subtitleStreams",  subtitleStreams},
+        {"selectedAudioId",  selectedAudio},
+        {"selectedSubtitleId", selectedSubtitle},
+        {"durationDisplay",  msToDisplay(duration)},
+        {"forceTranscode",   forceTranscode},
+        {"type",             meta["type"].toString()},
+        {"index",            meta["index"].toInt()},
+        {"parentIndex",      meta["parentIndex"].toInt()},
+        {"parentRatingKey",  meta["parentRatingKey"].toString()},
+        {"grandparentTitle", meta["grandparentTitle"].toString()},
+        {"parentTitle",      meta["parentTitle"].toString()},
+    };
+}
+
 void PlexBackend::load_item_detail(const QString &ratingKey) {
     QString uri = serverUrl(), token = serverToken();
     auto *reply = plexGet(QUrl(uri + "/library/metadata/" + ratingKey), token);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, ratingKey, uri, token]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, ratingKey]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
             if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
@@ -1568,74 +1655,7 @@ void PlexBackend::load_item_detail(const QString &ratingKey) {
         QJsonArray metaArr = QJsonDocument::fromJson(reply->readAll())
                              .object()["MediaContainer"].toObject()["Metadata"].toArray();
         if (metaArr.isEmpty()) { emit errorOccurred("LOAD DETAIL FAILED: empty metadata"); return; }
-        QJsonObject meta  = metaArr[0].toObject();
-        QJsonObject media = meta["Media"].toArray().first().toObject();
-        QJsonObject part  = media["Part"].toArray().first().toObject();
-        QJsonArray streams = part["Stream"].toArray();
-
-        static const QSet<QString> IMAGE_SUB_CODECS = {
-            "pgssub","dvdsub","dvbsub","hdmv_pgs_subtitle","dvd_subtitle"
-        };
-
-        QVariantList audioStreams;
-        QVariantList subtitleStreams;
-        subtitleStreams.append(QVariantMap{{"id","0"},{"displayTitle","OFF"},
-                                           {"selected",false},{"imageSubtitle",false}});
-        QString selectedAudio, selectedSubtitle = "0";
-        QString videoCodec;
-
-        for (const auto &sv : streams) {
-            QJsonObject s = sv.toObject();
-            int st  = s["streamType"].toInt();
-            QString sid   = QString::number(s["id"].toInt());
-            QString title = s["displayTitle"].toString(s["language"].toString("UNKNOWN")).toUpper();
-            QString codec = s["codec"].toString().toLower();
-            if (st == 1) {
-                videoCodec = codec;
-            } else if (st == 2) {
-                audioStreams.append(QVariantMap{{"id",sid},{"displayTitle",title}});
-                if (s["selected"].toBool() && selectedAudio.isEmpty())
-                    selectedAudio = sid;
-            } else if (st == 3) {
-                bool isImage = IMAGE_SUB_CODECS.contains(codec);
-                QString subKey = s["key"].toString();
-                QString subUrl = subKey.isEmpty() ? "" : uri + subKey;
-                subtitleStreams.append(QVariantMap{{"id",sid},{"displayTitle",title},{"imageSubtitle",isImage},{"subUrl",subUrl}});
-                if (s["selected"].toBool() && selectedSubtitle == "0")
-                    selectedSubtitle = sid;
-            }
-        }
-        if (selectedAudio.isEmpty() && !audioStreams.isEmpty())
-            selectedAudio = audioStreams[0].toMap()["id"].toString();
-
-        bool forceTranscode = (videoQuality() != "auto");
-        qDebug() << "[Plex] Item detail loaded — codec:" << videoCodec
-                 << "| quality:" << videoQuality()
-                 << "| playback:" << (forceTranscode ? "transcode" : "direct play");
-        int duration = meta["duration"].toInt();
-
-        emit itemLoaded(QVariantMap{
-            {"ratingKey",        ratingKey},
-            {"title",            meta["title"].toString().toUpper()},
-            {"editionTitle",     meta["editionTitle"].toString()},
-            {"year",             meta["year"].toVariant()},
-            {"duration",         duration},
-            {"viewOffset",       meta["viewOffset"].toInt()},
-            {"summary",          meta["summary"].toString()},
-            {"partKey",          part["key"].toString()},
-            {"partId",           QString::number(part["id"].toInt())},
-            {"audioStreams",     audioStreams},
-            {"subtitleStreams",  subtitleStreams},
-            {"selectedAudioId",  selectedAudio},
-            {"selectedSubtitleId", selectedSubtitle},
-            {"durationDisplay",  msToDisplay(duration)},
-            {"forceTranscode",   forceTranscode},
-            {"type",             meta["type"].toString()},
-            {"index",            meta["index"].toInt()},
-            {"parentIndex",      meta["parentIndex"].toInt()},
-            {"grandparentTitle", meta["grandparentTitle"].toString()},
-            {"parentTitle",      meta["parentTitle"].toString()},
-        });
+        emit itemLoaded(buildItemDetail(metaArr[0].toObject()));
     });
 }
 
@@ -1679,6 +1699,85 @@ void PlexBackend::load_on_deck_for(const QString &ratingKey) {
             }
         }
         emit inProgressEpisodeLoaded(QVariantMap{});
+    });
+}
+
+void PlexBackend::load_next_episode(const QString &currentRatingKey) {
+    QString uri = serverUrl(), token = serverToken();
+    // Step 1: fetch the current episode's metadata to learn its season
+    // (parentRatingKey) and episode number (index).
+    auto *reply = plexGet(QUrl(uri + "/library/metadata/" + currentRatingKey), token);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, currentRatingKey, uri, token]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                handle498([this, currentRatingKey]{ load_next_episode(currentRatingKey); }); return;
+            }
+            emit nextEpisodeReady(QVariantMap{}); return;
+        }
+        QJsonArray metaArr = QJsonDocument::fromJson(reply->readAll())
+                             .object()["MediaContainer"].toObject()["Metadata"].toArray();
+        if (metaArr.isEmpty()) { emit nextEpisodeReady(QVariantMap{}); return; }
+        QJsonObject meta = metaArr[0].toObject();
+
+        const QString seasonKey   = meta["parentRatingKey"].toString();
+        const int     currentIndex = meta["index"].toInt();
+        // Server-side file of the episode that just finished. Stacked shows back
+        // several episode entries with ONE physical file (e.g. an "E01-E02" file);
+        // advancing into such a sibling would just replay the same file, so we
+        // skip every sibling sharing this path and land on the next distinct file.
+        const QString currentFile = mediaFilePath(meta);
+        if (meta["type"].toString() != "episode" || seasonKey.isEmpty()) {
+            emit nextEpisodeReady(QVariantMap{}); return;
+        }
+
+        // Step 2: fetch the season's episodes and pick the one whose index is the
+        // smallest value strictly greater than the current episode (robust to gaps
+        // and arbitrary ordering), skipping siblings backed by the same file.
+        auto *childReply = plexGet(QUrl(uri + "/library/metadata/" + seasonKey + "/children"), token);
+        connect(childReply, &QNetworkReply::finished, this,
+                [this, childReply, currentRatingKey, currentIndex, currentFile, uri, token]() {
+            childReply->deleteLater();
+            if (childReply->error() != QNetworkReply::NoError) {
+                if (childReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                    handle498([this, currentRatingKey]{ load_next_episode(currentRatingKey); }); return;
+                }
+                emit nextEpisodeReady(QVariantMap{}); return;
+            }
+            QJsonArray eps = QJsonDocument::fromJson(childReply->readAll())
+                             .object()["MediaContainer"].toObject()["Metadata"].toArray();
+            QString nextKey;
+            int nextIndex = 0;
+            for (const auto &ev : eps) {
+                QJsonObject e = ev.toObject();
+                int idx = e["index"].toInt();
+                const QString file = mediaFilePath(e);
+                // Skip siblings that share the just-played file (stacked entries).
+                const bool sameFile = (!currentFile.isEmpty() && file == currentFile);
+                if (idx > currentIndex && !sameFile && (nextKey.isEmpty() || idx < nextIndex)) {
+                    nextIndex = idx;
+                    nextKey   = e["ratingKey"].toString();
+                }
+            }
+            if (nextKey.isEmpty()) { emit nextEpisodeReady(QVariantMap{}); return; }
+
+            // Step 3: fetch the next episode's full metadata and build playable detail.
+            auto *detailReply = plexGet(QUrl(uri + "/library/metadata/" + nextKey), token);
+            connect(detailReply, &QNetworkReply::finished, this,
+                    [this, detailReply, currentRatingKey]() {
+                detailReply->deleteLater();
+                if (detailReply->error() != QNetworkReply::NoError) {
+                    if (detailReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                        handle498([this, currentRatingKey]{ load_next_episode(currentRatingKey); }); return;
+                    }
+                    emit nextEpisodeReady(QVariantMap{}); return;
+                }
+                QJsonArray arr = QJsonDocument::fromJson(detailReply->readAll())
+                                 .object()["MediaContainer"].toObject()["Metadata"].toArray();
+                if (arr.isEmpty()) { emit nextEpisodeReady(QVariantMap{}); return; }
+                emit nextEpisodeReady(buildItemDetail(arr[0].toObject()));
+            });
+        });
     });
 }
 

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -1565,8 +1565,15 @@ QString PlexBackend::mediaFilePath(const QJsonObject &meta) {
 
 QVariantMap PlexBackend::buildItemDetail(const QJsonObject &meta) const {
     const QString uri = serverUrl();
-    QJsonObject media = meta["Media"].toArray().first().toObject();
-    QJsonObject part  = media["Part"].toArray().first().toObject();
+    // Guard against metadata with no media/part (e.g. an item the server can't
+    // play). Return an empty map so callers fall back to their no-detail path
+    // instead of emitting a detail with empty stream/part keys.
+    QJsonArray mediaArr = meta["Media"].toArray();
+    if (mediaArr.isEmpty()) return {};
+    QJsonObject media = mediaArr.first().toObject();
+    QJsonArray partArr = media["Part"].toArray();
+    if (partArr.isEmpty()) return {};
+    QJsonObject part  = partArr.first().toObject();
     QJsonArray streams = part["Stream"].toArray();
 
     static const QSet<QString> IMAGE_SUB_CODECS = {

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -46,6 +46,10 @@ public:
     Q_INVOKABLE void check_section_capabilities(const QString &sectionId);
     Q_INVOKABLE void load_children(const QString &ratingKey);
     Q_INVOKABLE void load_on_deck_for(const QString &ratingKey);
+    // Resolves the next episode in the same season as currentRatingKey and emits
+    // nextEpisodeReady with a full playable detail (same shape as load_item_detail),
+    // or an empty map when there is no next episode / on any failure.
+    Q_INVOKABLE void load_next_episode(const QString &currentRatingKey);
 
     // Playback
     Q_INVOKABLE void load_item_detail(const QString &ratingKey);
@@ -90,6 +94,7 @@ signals:
     void streamUrlReady(const QString &url, const QString &plexToken);
     void childrenLoaded(const QVariant &items);
     void inProgressEpisodeLoaded(const QVariant &item);
+    void nextEpisodeReady(const QVariant &detail);
 
     void dynamicOptionsReady(const QString &key, const QVariant &options);
 
@@ -124,6 +129,14 @@ private:
 
     // Item formatting helpers
     QVariantMap formatItem(const QJsonObject &m) const;
+    // Builds the full playable detail map (streams, selections, transcode flag)
+    // from a single /library/metadata Metadata object. Shared by load_item_detail
+    // and load_next_episode.
+    QVariantMap buildItemDetail(const QJsonObject &meta) const;
+    // Returns the server-side file path of a metadata object's first media part,
+    // or an empty string when unavailable. Used to detect stacked multi-episode
+    // files (several episode entries backed by one physical file).
+    static QString mediaFilePath(const QJsonObject &meta);
     static QString msToDisplay(int ms);
 
     // Expands any season-type items in rawItems into their child episodes, then calls callback.

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -113,6 +113,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     m_position    = 0;
     m_duration    = 0;
     m_playlistPos = -1;
+    m_lastEndFileReason.clear();
 
 #ifdef Q_OS_MACOS
     // .app bundles launched via double-click get a minimal PATH that excludes
@@ -325,7 +326,16 @@ void MpvController::onIpcReadyRead() {
     while (m_ipc->canReadLine()) {
         const QByteArray line = m_ipc->readLine().trimmed();
         const QJsonObject obj = QJsonDocument::fromJson(line).object();
-        if (obj.isEmpty() || obj["event"].toString() != "property-change")
+        if (obj.isEmpty()) continue;
+        const QString event = obj["event"].toString();
+        if (event == "end-file") {
+            // mpv reports why playback ended: "eof" (played to the end),
+            // "quit"/"stop" (user exited), "error", etc. Remember the last one
+            // so onProcessFinished can distinguish a natural finish from a quit.
+            m_lastEndFileReason = obj["reason"].toString();
+            continue;
+        }
+        if (event != "property-change")
             continue;
 
         m_lastIpcEventMs = QDateTime::currentMSecsSinceEpoch();
@@ -365,6 +375,11 @@ void MpvController::onProcessFinished() {
     m_position = 0;
     m_duration = 0;
 
+    // mpv reports reason "eof" only when the file played to its natural end.
+    // Any other reason (quit/stop/error) or a missing end-file event (crash/kill)
+    // is treated as a non-natural exit — the safe default that never auto-advances.
+    const bool naturalEof = (m_lastEndFileReason == "eof");
+
     if (m_headlessMode) {
         // Defer DRM restore and VT switch by 200 ms. mpv's last KMS atomic
         // commit may still be pending in the vc4 driver at the moment the
@@ -373,18 +388,20 @@ void MpvController::onProcessFinished() {
         // the kernel falls back to showing the text console on Qt's VT.
         // 200 ms is more than three VSync periods at 60 Hz — enough to clear
         // any in-flight commit without a perceptible delay for the user.
-        QTimer::singleShot(200, this, [this, pos, dur]() {
-            doHeadlessRestore(pos, dur);
+        QTimer::singleShot(200, this, [this, pos, dur, naturalEof]() {
+            doHeadlessRestore(pos, dur, naturalEof);
         });
     } else {
         if (exitCode == 2)
             emit playbackFailed();
+        else if (naturalEof)
+            emit playbackFinishedNaturally(pos, dur);
         else
             emit playbackFinished(pos, dur);
     }
 }
 
-void MpvController::doHeadlessRestore(int pos, int dur) {
+void MpvController::doHeadlessRestore(int pos, int dur, bool naturalEof) {
 #ifdef Q_OS_LINUX
     if (m_qtDrmFd >= 0) {
         if (::ioctl(m_qtDrmFd, DRM_IOCTL_SET_MASTER, 0) < 0) {
@@ -407,7 +424,10 @@ void MpvController::doHeadlessRestore(int pos, int dur) {
         switchToVt(prevVt);
     }
     m_headlessMode = false;
-    emit playbackFinished(pos, dur);
+    if (naturalEof)
+        emit playbackFinishedNaturally(pos, dur);
+    else
+        emit playbackFinished(pos, dur);
 }
 
 void MpvController::sendCommand(const QJsonArray &args) {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -328,15 +328,16 @@ void MpvController::onIpcReadyRead() {
         const QJsonObject obj = QJsonDocument::fromJson(line).object();
         if (obj.isEmpty()) continue;
         const QString event = obj["event"].toString();
-        if (event == "end-file") {
+        // property-change is the hot path (fires many times per second), so test
+        // it first; only other events pay for the end-file check below.
+        if (event != "property-change") {
             // mpv reports why playback ended: "eof" (played to the end),
             // "quit"/"stop" (user exited), "error", etc. Remember the last one
             // so onProcessFinished can distinguish a natural finish from a quit.
-            m_lastEndFileReason = obj["reason"].toString();
+            if (event == "end-file")
+                m_lastEndFileReason = obj["reason"].toString();
             continue;
         }
-        if (event != "property-change")
-            continue;
 
         m_lastIpcEventMs = QDateTime::currentMSecsSinceEpoch();
 
@@ -368,6 +369,13 @@ void MpvController::onProcessFinished() {
         qWarning("[MpvController] mpv exited with code %d", exitCode);
     m_connectTimer->stop();
     m_watchdogTimer->stop();
+    // Drain any buffered-but-unread IPC data before tearing the socket down.
+    // readyRead and QProcess::finished are independent event-loop signals with
+    // no ordering guarantee, so mpv's final "end-file" event may still be sitting
+    // in the socket buffer here. Flushing it now ensures m_lastEndFileReason is
+    // accurate, so a natural EOF reliably triggers autoplay-next.
+    if (m_ipc->state() == QLocalSocket::ConnectedState)
+        onIpcReadyRead();
     m_ipc->abort();
     QFile::remove(m_socketPath);
     const int pos = m_position;

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -52,8 +52,11 @@ signals:
     void positionChanged(int ms);
     void durationChanged(int ms);
     void playlistPosChanged(int pos);
-    // Emitted when mpv exits normally (user quit or end of file).
+    // Emitted when mpv exits because the user quit/stopped playback before the end.
     void playbackFinished(int finalPositionMs, int finalDurationMs);
+    // Emitted when mpv exits because the file played to its natural end (mpv's
+    // end-file event reported reason "eof"). Used to trigger autoplay-next.
+    void playbackFinishedNaturally(int finalPositionMs, int finalDurationMs);
     // Emitted when mpv exits with an error (code 2 — file could not be played).
     // Player.qml uses this to retry with transcoding.
     void playbackFailed();
@@ -65,7 +68,7 @@ private slots:
 
 private:
     void sendCommand(const QJsonArray &args);
-    void doHeadlessRestore(int pos, int dur);
+    void doHeadlessRestore(int pos, int dur, bool naturalEof);
     bool detectHeadlessMode() const;
     int  getActiveVt() const;
     int  findFreeVt() const;
@@ -85,6 +88,7 @@ private:
     QString       m_socketPath;
     QString       m_inputConfPath;
     QString       m_logFilePath;
+    QString       m_lastEndFileReason;  // mpv end-file "reason" for the current session
     int           m_position     = 0;
     int           m_duration     = 0;
     int           m_playlistPos  = -1;


### PR DESCRIPTION
## Summary

Adds an optional "Autoplay Next Episode" setting to the Plex module. 
When enabled, whenever an episode finishes on its own the next episode of the current season will launch automatically. At the end of the season, the usual "exit to episode screen" behavior returns, as if seasons were playlists. Subtitles and audio selection will carry over based on language if they're available in the next episode. 

## AI involvement

The code was written by Claude Opus 4.8.
The testing was done manually

## Testing
Tested on both Raspberry Pi (through CRT) and MacBook (using the laptop's screen).
Tested on both regular episodes and stacked (multi-episode) files.
Verified: 
 - Natural EOF advances. User-quit (ESC/stop) does not advance.
 - The last episode in a season falls back to the detail view.
 - Transcoded episodes advance correctly.
 - Pressing "back" after several auto-advances returns to the correct episode's detail.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
