### PR TITLE
feat: plex module - add loading states when launching playback

### DIFF
--- a/modules/plex/views/Item.qml
+++ b/modules/plex/views/Item.qml
@@ -18,6 +18,11 @@ FocusScope {
     // Focus rows: 0=play button, 1=audio, 2=subtitles
     property int focusRow: 0
 
+    // True from when PLAY is pressed until we navigate to the Player (or error
+    // out). Plex can take a few seconds to hand back a stream/transcode URL, so
+    // we show a LOADING overlay instead of leaving the screen looking frozen.
+    property bool isLaunching: false
+
     // Current stream selections (indices into stream lists)
     property int audioIdx: 0
     property int subtitleIdx: 0
@@ -102,6 +107,7 @@ FocusScope {
 
         function onErrorOccurred(msg) {
             console.log("[Item] Error: " + msg)
+            detailRoot.isLaunching = false
         }
     }
 
@@ -113,9 +119,11 @@ FocusScope {
     focus: true
 
     Keys.onUpPressed: {
+        if (isLaunching) return
         if (focusRow > 0) focusRow--
     }
     Keys.onDownPressed: {
+        if (isLaunching) return
         if (detail) {
             var maxRow = 0
             if (detail.audioStreams && detail.audioStreams.length > 0) maxRow = 1
@@ -124,6 +132,7 @@ FocusScope {
         }
     }
     Keys.onLeftPressed: {
+        if (isLaunching) return
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1)
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
@@ -131,6 +140,7 @@ FocusScope {
             subtitleIdx = (subtitleIdx - 1 + detail.subtitleStreams.length) % detail.subtitleStreams.length
     }
     Keys.onRightPressed: {
+        if (isLaunching) return
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1)
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
@@ -138,7 +148,10 @@ FocusScope {
             subtitleIdx = (subtitleIdx + 1) % detail.subtitleStreams.length
     }
     Keys.onReturnPressed: {
+        if (isLaunching) return
         if (focusRow === 0 && detail) {
+            // Show the loading overlay immediately; clears on navigate or error.
+            isLaunching = true
             var audioId = detail.audioStreams && detail.audioStreams[audioIdx]
                 ? detail.audioStreams[audioIdx].id : ""
             var subId = detail.subtitleStreams && detail.subtitleStreams[subtitleIdx]
@@ -451,5 +464,32 @@ FocusScope {
         anchors.bottomMargin: root.sh * 0.1041667 //50
         anchors.leftMargin: root.sw * 0.125 //80
         font.pixelSize: root.sh * 0.0333333 //16
+    }
+
+    // Launch overlay — covers the detail screen while Plex prepares the stream
+    // so a slow server doesn't make the app look frozen after pressing PLAY.
+    Rectangle {
+        anchors.fill: parent
+        color: root.surfaceColor
+        visible: isLaunching
+        z: 100
+
+        Text {
+            text: "LOADING..."
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            anchors.centerIn: parent
+            font.pixelSize: root.sh * 0.05 //24
+        }
+
+        Text {
+            text: root.hints.back + ":CANCEL"
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: root.sh * 0.1041667 //50
+            font.pixelSize: root.sh * 0.0333333 //16
+        }
     }
 }

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -26,6 +26,7 @@ FocusScope {
     property string selectedSubtitleId: navParams.selectedSubtitleId || "0"
 
     property bool stoppedReported:    false
+    property bool playbackStarted:    false
     property bool overlayVisible:     false
     property int  choiceIndex:        0
     property string resumeSetting:    "ask"
@@ -203,7 +204,12 @@ FocusScope {
         target: mpvController
 
         function onPositionChanged(ms) {
-            if (ms > 0) playerRoot.lastKnownPositionMs = playerRoot.absPos(ms)
+            if (ms > 0) {
+                playerRoot.lastKnownPositionMs = playerRoot.absPos(ms)
+                // First position update means mpv is up and playing — drop the
+                // loading indicator (mpv's own window now covers the screen).
+                playerRoot.playbackStarted = true
+            }
         }
         function onDurationChanged(ms) {
             if (ms > 0) playerRoot.lastKnownDurationMs = ms
@@ -262,6 +268,18 @@ FocusScope {
     Rectangle {
         anchors.fill: parent
         color: "black"
+
+        // Shown while mpv launches and buffers the stream (before its window
+        // takes over). Hidden once the first position update arrives, or while
+        // the resume prompt is up.
+        Text {
+            text: "LOADING..."
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            anchors.centerIn: parent
+            font.pixelSize: root.sh * 0.05 //24
+            visible: streamUrl !== "" && !overlayVisible && !playbackStarted
+        }
     }
 
     Rectangle {

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -292,7 +292,8 @@ FocusScope {
         // the resume prompt is up.
         Text {
             text: "LOADING..."
-            color: root.tertiaryColor
+            // White to match mpv's own overlay text color.
+            color: "white"
             font.family: root.globalFont
             anchors.centerIn: parent
             font.pixelSize: root.sh * 0.05 //24

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -57,7 +57,7 @@ FocusScope {
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                 overlayVisible = false
                 if (choiceIndex === 0) {
-                    doStartPlayback(viewOffset)
+                    beginPlayback(viewOffset)
                 } else {
                     startFromBeginning()
                 }
@@ -146,6 +146,24 @@ FocusScope {
         return { urls: allSubUrls, track: subTrack }
     }
 
+    // Starting mpv runs synchronously and, on the Pi, immediately switches VT
+    // (suspending Qt's render thread) before the LOADING frame can paint. Defer
+    // the launch one tick so the loading indicator is rendered first — mirroring
+    // the async transcode path, which already yields to the event loop. Without
+    // this, RESUME/direct-play show no loading screen on the Pi.
+    Timer {
+        id: startTimer
+        interval: 50
+        repeat: false
+        property int pendingOffset: 0
+        onTriggered: doStartPlayback(pendingOffset)
+    }
+
+    function beginPlayback(offsetMs) {
+        startTimer.pendingOffset = offsetMs
+        startTimer.restart()
+    }
+
     function doStartPlayback(offsetMs) {
         if (isTranscoding) {
             // Transcode URL already encodes the offset from Item.qml; mpv starts at stream position 0.
@@ -167,7 +185,7 @@ FocusScope {
             plexBackend.request_transcode(ratingKey, partKey, sessionId,
                                           selectedAudioId, selectedSubtitleId, 0)
         } else {
-            doStartPlayback(0)
+            beginPlayback(0)
         }
     }
 
@@ -261,7 +279,7 @@ FocusScope {
         if (resumeSetting === "ask" && viewOffset > 0) {
             overlayVisible = true
         } else {
-            doStartPlayback(viewOffset)
+            beginPlayback(viewOffset)
         }
     }
 


### PR DESCRIPTION
## Summary

Playing a movie could appear frozen while Plex prepares the stream or while mpv starts up — after pressing PLAY nothing changed on screen for a while. This adds loading feedback covering both gaps, reusing the Plex module's existing `LOADING...` pattern (no new component).

## Changes

- **`Item.qml`** — show a full-screen `LOADING...` overlay (with a `BACK:CANCEL` hint) the moment PLAY is pressed, until we navigate to the player or hit a backend error. Nav keys are ignored mid-launch to avoid a double-launch / stream-switch race.
- **`Player.qml`** — show `LOADING...` on the black screen while mpv launches and buffers, cleared on the first position update. Also covers the transcode re-request and the direct-play→transcode failure retry. Stays hidden under the resume prompt.
- **`Player.qml` (Pi fix)** — starting mpv runs synchronously and, on the Pi, switches VT (suspending Qt's render thread) before the `LOADING` frame can paint. So only the async "start from beginning" transcode path (which yields to the event loop) showed loading. The synchronous launch paths (RESUME, the `Component.onCompleted` direct-play branch, and `startFromBeginning`'s non-transcode branch) now defer one tick via a short `Timer` so the loading frame renders before the mpv handoff. macOS is unaffected (no VT switch; the defer is imperceptible).

## Testing

Human-tested on both **macOS** and a **Raspberry Pi 3B+**:
- Item screen: `LOADING...` appears immediately on PLAY and `BACK` cancels it.
- Player: loading text shows during mpv startup and disappears once playback begins; not shown under the resume dialog.
- Confirmed RESUME (and direct play) now show the loading screen on the Pi, matching START FROM BEGINNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)