### PR TITLE
Fix: allow rewinding past the resume point on transcoded playback

### DIFF
--- a/modules/plex/views/Item.qml
+++ b/modules/plex/views/Item.qml
@@ -171,7 +171,10 @@ FocusScope {
             sessionId = newSessionId()
 
             if (detail.forceTranscode) {
-                plexBackend.request_transcode(detail.ratingKey, detail.partKey, sessionId, audioId, subId, detail.viewOffset || 0)
+                // Always transcode from the start so the full timeline is seekable.
+                // The Player resumes by seeking mpv to viewOffset (see doStartPlayback),
+                // which lets the user rewind past the resume point.
+                plexBackend.request_transcode(detail.ratingKey, detail.partKey, sessionId, audioId, subId, 0)
             } else {
                 plexBackend.build_stream_url(detail.ratingKey, detail.partKey, sessionId)
             }

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -33,7 +33,6 @@ FocusScope {
     property bool overlayVisible:     false
     property int  choiceIndex:        0
     property string resumeSetting:    "ask"
-    property bool pendingZeroStart:   false
     property bool pendingRetryTranscode: false
 
     // Autoplay-next-episode. When enabled, a natural end-of-file advances to the
@@ -42,11 +41,6 @@ FocusScope {
     property bool   pendingNextEpisode: false
     property string carryAudioLang:     ""        // language code of the chosen audio track
     property string carrySubLang:       "__off__" // language code, or "__off__" when subtitles are off
-
-    // For transcoded streams, Plex HLS segments have timestamps starting at 0
-    // relative to the transcode offset. We add this to every position we report
-    // so Plex receives the true absolute position in the video.
-    property int transcodeStartOffset: 0
 
     property int lastKnownPositionMs: 0
     property int lastKnownDurationMs: 0
@@ -109,16 +103,12 @@ FocusScope {
         return id
     }
 
-    function absPos(streamPosMs) {
-        return transcodeStartOffset + streamPosMs
-    }
-
     // Report the final "stopped" timeline for the current episode exactly once.
     // The fallback position/duration are used only when no live value is known.
     function reportStopped(finalPositionMs, finalDurationMs) {
         if (stoppedReported) return
         stoppedReported = true
-        var pos = lastKnownPositionMs || absPos(finalPositionMs)
+        var pos = lastKnownPositionMs || finalPositionMs
         var dur = lastKnownDurationMs || finalDurationMs
         plexBackend.update_timeline(ratingKey, partKey, "stopped", pos, dur)
     }
@@ -207,9 +197,10 @@ FocusScope {
 
     function doStartPlayback(offsetMs) {
         if (isTranscoding) {
-            // Transcode URL already encodes the offset from Item.qml; mpv starts at stream position 0.
-            // Pass transcodeStartOffset so the OSC Lua script can display accurate wall-clock time.
-            mpvController.loadAndPlay(streamUrl, 0.0, 0, -1, [], false, -1, transcodeStartOffset / 1000.0, plexToken)
+            // Transcode covers the full timeline (requested at offset 0), so seek mpv
+            // to the resume point. This keeps everything before offsetMs seekable, so
+            // the user can rewind past the resume point.
+            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0, 0, -1, [], false, -1, 0.0, plexToken)
         } else {
             var sub = buildSubArgs()
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
@@ -218,16 +209,9 @@ FocusScope {
     }
 
     function startFromBeginning() {
-        if (isTranscoding) {
-            // Transcode URL is baked with viewOffset — request a new session at offset 0.
-            // Reset the offset so future position reports are relative to the new start.
-            transcodeStartOffset = 0
-            pendingZeroStart = true
-            plexBackend.request_transcode(ratingKey, partKey, sessionId,
-                                          selectedAudioId, selectedSubtitleId, 0)
-        } else {
-            beginPlayback(0)
-        }
+        // Transcode already starts at 0, so both paths simply play from the start.
+        // Use beginPlayback so the loading indicator shows while mpv spins up.
+        beginPlayback(0)
     }
 
     function formatTime(ms) {
@@ -255,15 +239,12 @@ FocusScope {
             if (pendingRetryTranscode) {
                 pendingRetryTranscode = false
                 isTranscoding = true
-                transcodeStartOffset = viewOffset
+                // Fallback transcode was requested at offset 0 (full timeline), so seek
+                // mpv to the resume point — keeps everything before it seekable.
                 var sub = buildSubArgs()
-                mpvController.loadAndPlay(url, 0.0, audioIdx + 1, sub.track, sub.urls, false, -1, transcodeStartOffset / 1000.0, plexToken)
+                mpvController.loadAndPlay(url, viewOffset / 1000.0, audioIdx + 1, sub.track, sub.urls, false, -1, 0.0, plexToken)
                 return
             }
-            if (!pendingZeroStart) return
-            pendingZeroStart = false
-            var sub = buildSubArgs()
-            mpvController.loadAndPlay(url, 0.0, audioIdx + 1, sub.track, sub.urls, false, -1, 0.0, plexToken)
         }
 
         function onNextEpisodeReady(detail) {
@@ -301,7 +282,6 @@ FocusScope {
 
         // Fresh-start state for the new episode.
         viewOffset           = 0
-        transcodeStartOffset = 0
         stoppedReported      = false
         lastKnownPositionMs  = 0
         lastKnownDurationMs  = 0
@@ -350,7 +330,7 @@ FocusScope {
 
         function onPositionChanged(ms) {
             if (ms > 0) {
-                playerRoot.lastKnownPositionMs = playerRoot.absPos(ms)
+                playerRoot.lastKnownPositionMs = ms
                 // First position update means mpv is up and playing — drop the
                 // loading indicator (mpv's own window now covers the screen).
                 playerRoot.playbackStarted = true
@@ -382,7 +362,7 @@ FocusScope {
                 pendingRetryTranscode = true
                 plexBackend.request_transcode(ratingKey, partKey, sessionId,
                                               selectedAudioId, selectedSubtitleId,
-                                              viewOffset)
+                                              0)
             } else {
                 goBack()
             }
@@ -396,7 +376,7 @@ FocusScope {
         onTriggered: {
             if (mpvController.position > 0)
                 plexBackend.update_timeline(ratingKey, partKey, "playing",
-                                            absPos(mpvController.position), mpvController.duration)
+                                            mpvController.position, mpvController.duration)
         }
     }
 
@@ -408,10 +388,6 @@ FocusScope {
         // once the user touches it, but accept the legacy "ON" string too.
         var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
         autoplayNext  = (autoplayRaw === true || autoplayRaw === "ON")
-
-        // Plex HLS transcode segments start at time 0 regardless of viewOffset.
-        // Track the offset so every reported position is absolute in the video.
-        transcodeStartOffset = isTranscoding ? viewOffset : 0
 
         if (resumeSetting === "ask" && viewOffset > 0) {
             overlayVisible = true


### PR DESCRIPTION
## Bug

When you resume a video partway through (RESUME from a saved `viewOffset`), you couldn't rewind or seek to any point *before* the resume position. The video's timeline effectively began where you resumed — scrubbing back past that point did nothing. This only affected **transcoded** playback; direct play was fine.

## Cause

For a resume, the transcode session was requested with the resume offset baked in (`request_transcode(..., viewOffset)`). Plex's HLS stream then starts at that offset, so mpv only ever receives the portion of the video from the resume point onward — there is literally nothing earlier in the stream to seek back to. (Direct play was unaffected because mpv loads the whole file and just uses `--start`.)

## Fix

Always request the transcode at offset `0` (full timeline) and have the Player seek mpv to the resume position via `--start` instead. The entire video before the resume point stays in the stream, so rewinding works. `fastSeek=1` is already set on the transcode request, so Plex seeks to the resume position rather than transcoding linearly up to it.

- `Item.qml`: request the transcode at offset 0 instead of `viewOffset`.
- `Player.qml`: `doStartPlayback` seeks mpv to the offset for the transcode path (previously it started the offset-baked stream at 0). The direct-play→transcode fallback gets the same treatment, and `startFromBeginning` simplifies to a plain start-at-0 (no re-request needed).
- Because the transcoded stream's timeline now matches the video's, the position-reporting adjustment (`transcodeStartOffset` / `absPos`) and the `pendingZeroStart` re-request path are no longer needed and were removed. Rebased on top of the autoplay-next-episode change; that feature's paths are preserved.

## Testing

Human-tested on a Raspberry Pi 3B+ driving a CRT, and on the macOS build: resuming a transcoded video and rewinding to before the resume point now works, and start-from-beginning / direct play / the direct-play→transcode fallback all behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)