### PR TITLE
feat: pi5 support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,14 +6,14 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
 ### Requirements
 
-- A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/) - These are the only models I've tested with, it may work on others but sorry I can't say for sure
+- A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/) - These are the models I've tested most and are my recommendation. The [5](https://www.raspberrypi.com/products/raspberry-pi-5/) also works but **over HDMI only** — the Pi 5 has no composite output, so it can't drive a CRT. It may work on other models too but sorry I can't say for sure
 - SD Card (minimum of 4GB)
 - A keyboard to navigate
 - Internet Access (either WiFi or network cable will work)
 
 ### Optional
 
-- A CRT TV and a composite cable - Composite out is my recommended way to use 240-MP but it will also work over HDMI as well so just select the config that works for your setup in step 2 below.  This is the composite cable I use if you happen to have a CRT: https://www.adafruit.com/product/2881
+- A CRT TV and a composite cable - Composite out is my recommended way to use 240-MP but it will also work over HDMI as well so just select the config that works for your setup in step 2 below.  This is the composite cable I use if you happen to have a CRT: https://www.adafruit.com/product/2881 (note: composite is only available on the Pi 3/4 — the Pi 5 is HDMI-only.)
 - USB remote control - Keyboard input works well but if you want that experience of sitting back and playing video on a VCR then a remote will definitely help with that.  I use this one: https://www.amazon.com/dp/B01FVUGPE8
 - USB game controller - Most controllers (Xbox, PlayStation, 8BitDo, NES-style, etc.) should work out of the box: D-pad/left stick to navigate, A to select, B to go back, Start for play/pause.  Controllers can be plugged in at any time, and the button mapping can be customized — see [BUILDING.md → Gamepad input](BUILDING.md#gamepad-input-inputcfg).  If a controller isn't detected, make sure your user is in the `input` group: `sudo usermod -aG input $USER` then reboot.
 
@@ -135,6 +135,13 @@ The following steps will set up an image for your Raspberry Pi with the latest v
     arm_freq=1500
     core_freq=500
     sdram_freq=500
+    
+    # --- Pi 5 ---
+    [pi5]
+    
+    # Drivers & Video (Pi 5 requires full KMS — fkms is not supported, and
+    # there is no hardware H.264 block so video uses fast software decode)
+    dtoverlay=vc4-kms-v3d
     
     # --- Global ---
     [all]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,14 +6,21 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
 ### Requirements
 
-- A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/) - These are the models I've tested most and are my recommendation. The [5](https://www.raspberrypi.com/products/raspberry-pi-5/) also works but **over HDMI only** — the Pi 5 has no composite output, so it can't drive a CRT. It may work on other models too but sorry I can't say for sure
-- SD Card (minimum of 4GB)
+- A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/).
+    - These are the models I've tested with. The Pi 4 fits in a nice sweet spot of performance + composite out so that is the model I use daily.  
+    The [5](https://www.raspberrypi.com/products/raspberry-pi-5/) also works but I've only tested **over HDMI** to a modern TV (the Pi 5 has no composite output port and I don't have the hardware to test direct video over HDMI to a CRT). 
+    = It may work on other models too, but sorry I can't say for sure.
+    - I've started a [hardware testing](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) page on the wiki with more details
+- SD Card (minimum of 4GB) with RaspberryPi OS already set up
+    - Note: 240-MP is only an application, it's not an OS so you will need to make sure you have an OS setup and working with the display you'd like to use. 
+    - In the below steps I provide an example using Raspberry Pi OS Lite that you can use to create a fresh SD card along with configs i've tested for CRT and HDMI output.
+    - The 240-MP specific steps start at step 5 so you can skip to that if you already have an OS running.
 - A keyboard to navigate
 - Internet Access (either WiFi or network cable will work)
 
 ### Optional
 
-- A CRT TV and a composite cable - Composite out is my recommended way to use 240-MP but it will also work over HDMI as well so just select the config that works for your setup in step 2 below.  This is the composite cable I use if you happen to have a CRT: https://www.adafruit.com/product/2881 (note: composite is only available on the Pi 3/4 — the Pi 5 is HDMI-only.)
+- A CRT TV and a composite cable - Composite out is my recommended way to use 240-MP but it will also work over HDMI as well so just select the config that works for your setup in step 2 below.  This is the composite cable I use if you happen to have a CRT: https://www.adafruit.com/product/2881 (note: composite is only available on the Pi 3/4 — the Pi 5 works well over HDMI.)
 - USB remote control - Keyboard input works well but if you want that experience of sitting back and playing video on a VCR then a remote will definitely help with that.  I use this one: https://www.amazon.com/dp/B01FVUGPE8
 - USB game controller - Most controllers (Xbox, PlayStation, 8BitDo, NES-style, etc.) should work out of the box: D-pad/left stick to navigate, A to select, B to go back, Start for play/pause.  Controllers can be plugged in at any time, and the button mapping can be customized — see [BUILDING.md → Gamepad input](BUILDING.md#gamepad-input-inputcfg).  If a controller isn't detected, make sure your user is in the `input` group: `sudo usermod -aG input $USER` then reboot.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,25 +2,29 @@
 
 ## On a Raspberry Pi
 
-The following steps will set up an image for your Raspberry Pi with the latest version of 240-MP (and optionally set it up to autostart after boot)
+The following steps will set up an SD card for your Raspberry Pi with the latest version of 240-MP (and optionally set it up to autostart after boot).  
+
+Steps 1-4 are focused on setting up a new card with Raspberry Pi OS Lite (64-Bit) and include options for writing a config.txt that will output to a CRT or modern TV.  
+
+However, if you already have Raspberry Pi OS set up and working on your TV then the specific 240-MP install steps start at step 5.
 
 ### Requirements
 
 - A RaspberryPi [4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) or [3B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/).
     - These are the models I've tested with. The Pi 4 fits in a nice sweet spot of performance + composite out so that is the model I use daily.  
     The [5](https://www.raspberrypi.com/products/raspberry-pi-5/) also works but I've only tested **over HDMI** to a modern TV (the Pi 5 has no composite output port and I don't have the hardware to test direct video over HDMI to a CRT). 
-    = It may work on other models too, but sorry I can't say for sure.
-    - I've started a [hardware testing](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) page on the wiki with more details
+    - It may work on other models too, but I'm sorry I can't say for sure.
+    - I've started a [hardware testing](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) page on the wiki with more details.  If you have a setup that is working for you and would like to help out others please start [a discussion](https://github.com/anthonycaccese/240-MP/discussions/categories/q-a) so we can add it to the wiki.
 - SD Card (minimum of 4GB) with RaspberryPi OS already set up
     - Note: 240-MP is only an application, it's not an OS so you will need to make sure you have an OS setup and working with the display you'd like to use. 
-    - In the below steps I provide an example using Raspberry Pi OS Lite that you can use to create a fresh SD card along with configs i've tested for CRT and HDMI output.
+    - In the below steps I provide an example using Raspberry Pi OS Lite that you can use to create a fresh SD card along with configs I've tested for CRT and HDMI output.
     - The 240-MP specific steps start at step 5 so you can skip to that if you already have an OS running.
 - A keyboard to navigate
 - Internet Access (either WiFi or network cable will work)
 
 ### Optional
 
-- A CRT TV and a composite cable - Composite out is my recommended way to use 240-MP but it will also work over HDMI as well so just select the config that works for your setup in step 2 below.  This is the composite cable I use if you happen to have a CRT: https://www.adafruit.com/product/2881 (note: composite is only available on the Pi 3/4 — the Pi 5 works well over HDMI.)
+- A CRT TV and a composite cable - Composite out is my recommended way to use 240-MP but it will also work over HDMI as well so just select the config that works for your setup in step 2 below.  This is the composite cable I use if you happen to have a CRT: https://www.adafruit.com/product/2881 (note: I've only tested composite on the Pi 3/4 - the Pi 5 works well over HDMI)
 - USB remote control - Keyboard input works well but if you want that experience of sitting back and playing video on a VCR then a remote will definitely help with that.  I use this one: https://www.amazon.com/dp/B01FVUGPE8
 - USB game controller - Most controllers (Xbox, PlayStation, 8BitDo, NES-style, etc.) should work out of the box: D-pad/left stick to navigate, A to select, B to go back, Start for play/pause.  Controllers can be plugged in at any time, and the button mapping can be customized — see [BUILDING.md → Gamepad input](BUILDING.md#gamepad-input-inputcfg).  If a controller isn't detected, make sure your user is in the `input` group: `sudo usermod -aG input $USER` then reboot.
 
@@ -35,6 +39,8 @@ The following steps will set up an image for your Raspberry Pi with the latest v
     | OS > Raspberry Pi OS (other) | Raspberry Pi OS Lite (64-bit) |
     | --- | --- |
     | <img src="https://github.com/user-attachments/assets/bb9f7a47-12b7-4580-abf4-ec8ad22153ba" /> | <img src="https://github.com/user-attachments/assets/30c39fce-99f8-48c9-9ad0-2b39b52690c1" /> |
+
+    I would also suggest filling out Hostname, User and Wifi in the customization section as it will you save you from having to set them up manually later.
 
 2) After the write is complete, reconnect the card to your PC and update your boot/config.txt to one of the following (please make sure to choose the one that best matches your TV):
 
@@ -156,7 +162,7 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
 3) Place the SD card in your Raspberry Pi and let it run through its first boot sequence
 
-4) Once complete SSH in and run `sudo raspi-config`
+4) Once complete, SSH in and run `sudo raspi-config`
 
     - Turn on Auto Login: `System Options > Auto Login > Yes`
     - Expand filesystem: `Advanced Options > Expand Filesystem > Yes`
@@ -170,13 +176,12 @@ The following steps will set up an image for your Raspberry Pi with the latest v
 
     This will install all of the needed dependencies (note: over WiFi it will take about 20 mins to complete) 
 
-    You will get an option at the end of the install script that asks: `Install systemd autostart service? [y/N]` 
+    **[Optional]** 
+    - You will get an option at the end of the install script that asks: `Install systemd autostart service? [y/N]` 
+    - If you type `Y` and press enter it will set up 240-MP to autostart when your Raspberry Pi boots which creates a nice appliance experience (bascially a dedicated 240-MP device).
+    - If you choose that option please make sure to enter your primary user for the pi at the next prompt.  If you don't provide one it will set it up for the `Pi` user.
 
-    If you type `Y` and press enter it will set up 240-MP to autostart when your Raspberry Pi boots which creates a nice appliance experience (bascially a dedicated 240-MP device).  
-
-    If you choose that option please make sure to enter your primary user for the pi at the next prompt.  If you don't provide one it will set it up for the `Pi` user.
-
-    At this point you can type `240mp` to start up the app.  If you chose to install the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
+    At this point you can type `240mp` at any time to start up the app.  And if you installed the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
 
 ### Update
 
@@ -187,22 +192,22 @@ To update to the latest release on Raspberry Pi please follow these steps (your 
     ```bash
     bash <(curl -fsSL https://github.com/anthonycaccese/240-mp/releases/latest/download/install.sh)
     ```
-3) When it asks to `Install systemd autostart service? [y/N]`
-    - if you already have autostart set up you can press either Y or N, it will keep your current autostart
-    - if you don't have autostart installed and want to keep it that way just answer N
-    - and if you want to turn on autostart just answer Y
+3) When it asks to "`Install systemd autostart service? [y/N]`"
+    - If you already have autostart set up you can press either Y or N, it will keep your current autostart
+    - If you don't have autostart installed and want to keep it that way just answer `N`
+    - And if you want to turn on autostart please answer `Y`
 4) Once that completes just run `sudo reboot` and when your pi restarts you'll be on the latest version
 
 ### Uninstall
 
-1) If you'd like to remove 240-MP and continue to use your SD card for other things you can run the following commands via terminal or over SSH:
+1) If you'd like to remove 240-MP and continue to use your SD card for other things then you can run the following commands via terminal or over SSH:
 
     ```bash
     sudo rm -rf /opt/240mp
     sudo rm /usr/local/bin/240mp
     ```
 
-2) And if you installed the systemd autostart service then be sure to remove it by running the following commands:
+2) If you installed the autostart service and want to remove it then please run the running the following commands:
 
     ```bash
     sudo systemctl unmask getty@tty1.service autovt@.service

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,32 @@ else
     QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-eglfs}"
     export QT_QPA_EGLFS_ALWAYS_SET_MODE=1
     export QT_QPA_EGLFS_KMS_ATOMIC=1
+
+    # Point Qt EGLFS at the DRM card that has a real display pipeline. Render-
+    # only nodes (v3d) have no connector dirs under /sys/class/drm and make Qt
+    # fail with "drmModeGetResources failed (Operation not supported)". On
+    # Pi3B+/Pi4 the display card happens to be card0 (auto-pick works), but on
+    # Pi5 the v3d render node often enumerates first, so we must select the
+    # right card explicitly. Prefer a connected connector; fall back to the
+    # first card that has any connector at all.
+    KMS_CARD=""
+    for s in /sys/class/drm/card*-*/status; do
+        [ -e "$s" ] || continue
+        if [ "$(cat "$s")" = "connected" ]; then
+            n=$(basename "$(dirname "$s")"); KMS_CARD="${n%%-*}"; break
+        fi
+    done
+    if [ -z "$KMS_CARD" ]; then
+        for d in /sys/class/drm/card*-*; do
+            [ -e "$d" ] || continue
+            n=$(basename "$d"); KMS_CARD="${n%%-*}"; break
+        done
+    fi
+    if [ -n "$KMS_CARD" ] && [ -e "/dev/dri/$KMS_CARD" ]; then
+        KMS_CONF="${XDG_RUNTIME_DIR:-/tmp}/240mp-kms.json"
+        printf '{ "device": "/dev/dri/%s" }\n' "$KMS_CARD" > "$KMS_CONF"
+        export QT_QPA_EGLFS_KMS_CONFIG="$KMS_CONF"
+    fi
 fi
 
 export QT_QPA_PLATFORM
@@ -118,6 +144,7 @@ SupplementaryGroups=tty video input
 AmbientCapabilities=CAP_SYS_TTY_CONFIG
 Environment=QT_QPA_PLATFORM=eglfs
 Environment=QT_QPA_EGLFS_ALWAYS_SET_MODE=1
+Environment=QT_QPA_EGLFS_KMS_ATOMIC=1
 Environment=QML2_IMPORT_PATH=/usr/lib/aarch64-linux-gnu/qt6/qml
 ExecStart=${LAUNCHER}
 Restart=on-failure


### PR DESCRIPTION
## Summary

Updates the install script to support pi5.  In the previous install script I had made an assumption based on the pi3/pi4 as to what screen to output to but for the pi5 that assumption didn't hold true.

The fix was to update the install script to add a check to the launcher so that so that when 240mp is run it does a check through the available displays to find the correct one to output to (instead of how i was assuming it before)

## AI involvement

Used to work through the auto display logic in the launcher created by the install script

## Testing

- Platform(s) tested: Raspberry Pi 5 (both lite and full OS variants over HDMI) and regression tested on Raspberry Pi 4 and 3+ 
- Display / output tested: HDMI out to a modern TV (RPi5), Composite out to a CRT (RPi4/3)

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
