### PR TITLE
feat: quit to terminal

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -219,7 +219,7 @@ How you read logs depends on whether you installed the autostart service:
     journalctl -u 240mp -b        # logs from this boot
     journalctl -u 240mp -f        # follow live
     ```
-    Heads-up: the autostart service runs `ExecStopPost=240mp-stop`, which **powers the Pi off when you quit** (exit 0) — the console disappears with it. To debug without powering off, either pick **Exit to Terminal** in the Quit dialog (drops to a login shell on `tty1` without removing the service — type `240mp`, `sudo systemctl start 240mp`, or `sudo reboot` to return), or stop the service and run the binary directly:
+    Heads-up: the autostart service runs `ExecStopPost=240mp-stop`, which **powers the Pi off when you quit** (exit 0) — the console disappears with it. To debug without powering off, either pick **Exit to Terminal** in the Quit dialog (drops to a login shell on `tty1` without removing the service — `sudo systemctl start 240mp` or `sudo reboot` to return to the service), or stop the service and run the binary directly:
     ```bash
     sudo systemctl stop 240mp
     240mp

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -219,7 +219,7 @@ How you read logs depends on whether you installed the autostart service:
     journalctl -u 240mp -b        # logs from this boot
     journalctl -u 240mp -f        # follow live
     ```
-    Heads-up: the autostart service runs `ExecStopPost=systemctl poweroff`, so **quitting the app powers the Pi off** — the console disappears with it. To debug, stop the service and run the binary directly instead:
+    Heads-up: the autostart service runs `ExecStopPost=240mp-stop`, which **powers the Pi off when you quit** (exit 0) — the console disappears with it. To debug without powering off, either pick **Exit to Terminal** in the Quit dialog (drops to a login shell on `tty1` without removing the service — type `240mp`, `sudo systemctl start 240mp`, or `sudo reboot` to return), or stop the service and run the binary directly:
     ```bash
     sudo systemctl stop 240mp
     240mp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,7 +183,9 @@ However, if you already have Raspberry Pi OS set up and working on your TV then 
 
     At this point you can type `240mp` at any time to start up the app.  And if you installed the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
 
-    **Exit to Terminal (autostart only):** with the autostart service installed, the Quit dialog gains an `Exit to Terminal` option alongside `Power Off`. Choosing it drops you to a login shell on the Pi instead of powering off, and leaves autostart intact. To get back into 240-MP from that shell you can type `240mp`, run `sudo systemctl start 240mp`, or `sudo reboot` — any of the three reopens the app.
+    **Exit to Terminal (autostart only):** with the autostart service installed, the Quit dialog gains an `Exit to Terminal` option alongside `Power Off`. Choosing it drops you to a login shell on the Pi instead of powering off, and leaves autostart intact. To get back into 240-MP from that shell you can:
+        - `sudo systemctl start 240mp` (or `sudo reboot`) — returns to the autostart service, so quitting again powers off as usual.
+        - type `240mp` — relaunches the app unmanaged in your shell; here the Quit dialog shows the plain Yes/No menu and quitting just returns you to the shell rather than powering off.
 
 ### Update
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,6 +183,8 @@ However, if you already have Raspberry Pi OS set up and working on your TV then 
 
     At this point you can type `240mp` at any time to start up the app.  And if you installed the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
 
+    **Exit to Terminal (autostart only):** with the autostart service installed, the Quit dialog gains an `Exit to Terminal` option alongside `Power Off`. Choosing it drops you to a login shell on the Pi instead of powering off, and leaves autostart intact. To get back into 240-MP from that shell you can type `240mp`, run `sudo systemctl start 240mp`, or `sudo reboot` — any of the three reopens the app.
+
 ### Update
 
 To update to the latest release on Raspberry Pi please follow these steps (your settings will be retained):
@@ -212,7 +214,7 @@ To update to the latest release on Raspberry Pi please follow these steps (your 
     ```bash
     sudo systemctl unmask getty@tty1.service autovt@.service
     sudo systemctl disable 240mp.service
-    sudo rm /etc/systemd/system/240mp.service
+    sudo rm -f /etc/systemd/system/240mp.service /etc/systemd/system/240mp-terminal.service /usr/local/bin/240mp-stop
     sudo systemctl daemon-reload
     ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,16 +146,53 @@ Environment=QT_QPA_PLATFORM=eglfs
 Environment=QT_QPA_EGLFS_ALWAYS_SET_MODE=1
 Environment=QT_QPA_EGLFS_KMS_ATOMIC=1
 Environment=QML2_IMPORT_PATH=/usr/lib/aarch64-linux-gnu/qt6/qml
+Environment=MP240_AUTOSTART=1
+ExecStartPre=+-/usr/bin/systemctl stop 240mp-terminal.service
 ExecStart=${LAUNCHER}
 Restart=on-failure
 RestartSec=5s
-ExecStopPost=+systemctl poweroff
+RestartPreventExitStatus=10
+ExecStopPost=+/usr/local/bin/240mp-stop
 StandardOutput=journal
 StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
 UNIT
+
+    # ExecStopPost helper: normal quit (exit 0) or a crash powers the Pi off as
+    # before; exit 10 means the user chose "Exit to Terminal", so instead spawn a
+    # login shell on tty1 (see views/Settings.qml). RestartPreventExitStatus=10
+    # keeps Restart=on-failure from relaunching the app over that shell.
+    sudo tee /usr/local/bin/240mp-stop > /dev/null << 'STOP_HELPER'
+#!/usr/bin/env bash
+# Called by 240mp.service ExecStopPost. systemd sets $EXIT_STATUS to the app's exit code.
+if [ "${EXIT_STATUS:-}" = "10" ]; then
+    systemctl start 240mp-terminal.service
+else
+    systemctl poweroff
+fi
+STOP_HELPER
+    sudo chmod +x /usr/local/bin/240mp-stop
+
+    # On-demand login shell for "Exit to Terminal". Not enabled (no boot race with
+    # 240mp.service); getty@tty1 stays masked. Started only by 240mp-stop, and
+    # stopped again by 240mp.service's ExecStartPre when the app comes back.
+    sudo tee /etc/systemd/system/240mp-terminal.service > /dev/null << 'TERMINAL_UNIT'
+[Unit]
+Description=240-MP exit-to-terminal login shell
+
+[Service]
+Type=idle
+ExecStart=-/sbin/agetty --noclear tty1 linux
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+KillMode=process
+Restart=no
+TERMINAL_UNIT
 
     sudo systemctl mask getty@tty1.service autovt@.service
     sudo systemctl daemon-reload

--- a/src/AppCore.h
+++ b/src/AppCore.h
@@ -25,6 +25,13 @@ public:
 
     QString appVersion() const { return QCoreApplication::applicationVersion(); }
 
+    // True when launched by the autostart systemd service (which injects MP240_AUTOSTART=1).
+    // Gates the quit overlay's "Exit to Terminal" option, which only makes sense on a
+    // headless RPi running under the service. See scripts/install.sh and 240mp-stop.
+    Q_INVOKABLE bool isAutostartSession() const {
+        return qEnvironmentVariableIsSet("MP240_AUTOSTART");
+    }
+
     Q_INVOKABLE void scan_for_modules();
     Q_INVOKABLE QVariant get_settings();
     Q_INVOKABLE QVariant get_setting(const QString &moduleId, const QString &key);

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -19,12 +19,9 @@ FocusScope {
     property bool quitOverlayVisible: false
     property int quitChoiceIndex: 0
 
-    // Quit overlay choices. Under the autostart service (headless RPi) we offer an
+    // Quit overlay choices. Under the autostart service (headless RPi) the quit menu has an
     // "Exit to Terminal" option that drops to a tty1 login without powering off; that
-    // option is meaningless on macOS/Desktop and when run by hand, so it's hidden there.
-    // autostartSession is cached once in buildModel() (not bound to appCore directly):
-    // a live binding on the appCore context property throws a TypeError when this view's
-    // Loader tears down — e.g. during the Qt.exit(10) the "terminal" choice triggers.
+    // option is not needed on macOS/Desktop or when run by hand, so it's yes/no for that case.
     property bool autostartSession: false
     property var quitOptions: settingsRoot.autostartSession
         ? [{ label: "Power Off",        action: "quit"     },

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -19,10 +19,25 @@ FocusScope {
     property bool quitOverlayVisible: false
     property int quitChoiceIndex: 0
 
+    // Quit overlay choices. Under the autostart service (headless RPi) we offer an
+    // "Exit to Terminal" option that drops to a tty1 login without powering off; that
+    // option is meaningless on macOS/Desktop and when run by hand, so it's hidden there.
+    // autostartSession is cached once in buildModel() (not bound to appCore directly):
+    // a live binding on the appCore context property throws a TypeError when this view's
+    // Loader tears down — e.g. during the Qt.exit(10) the "terminal" choice triggers.
+    property bool autostartSession: false
+    property var quitOptions: settingsRoot.autostartSession
+        ? [{ label: "Power Off",        action: "quit"     },
+           { label: "Exit to Terminal", action: "terminal" },
+           { label: "Cancel",           action: "cancel"   }]
+        : [{ label: "Yes", action: "quit" },
+           { label: "No",  action: "cancel" }]
+
     function buildModel() {
         var cfg = appCore.get_settings()
         appSettings = cfg.app || {}
         installedModules = appCore.get_installed_modules()
+        autostartSession = appCore.isAutostartSession()
 
         var items = []
 
@@ -276,10 +291,12 @@ FocusScope {
         visible: quitOverlayVisible
         focus: quitOverlayVisible
 
-        Keys.onUpPressed:   { quitChoiceIndex = 0 }
-        Keys.onDownPressed: { quitChoiceIndex = 1 }
+        Keys.onUpPressed:   { quitChoiceIndex = Math.max(0, quitChoiceIndex - 1) }
+        Keys.onDownPressed: { quitChoiceIndex = Math.min(quitOptions.length - 1, quitChoiceIndex + 1) }
         Keys.onReturnPressed: {
-            if (quitChoiceIndex === 0) Qt.quit()
+            var act = quitOptions[quitChoiceIndex].action
+            if (act === "quit")          Qt.quit()
+            else if (act === "terminal") Qt.exit(10)   // matches EXIT_STATUS check in 240mp-stop
             else { quitOverlayVisible = false; settingsList.forceActiveFocus() }
         }
         Keys.onPressed: function(event) {
@@ -311,7 +328,7 @@ FocusScope {
 
                 Column {
                     Repeater {
-                        model: ["Yes", "No"]
+                        model: quitOptions
                         delegate: Item {
                             width: quitDialogColumn.width
                             height: root.sh * 0.0583333 //28
@@ -326,7 +343,7 @@ FocusScope {
                                 id: quitOptionText
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.horizontalCenter: parent.horizontalCenter
-                                text: modelData
+                                text: modelData.label
                                 color: index === quitChoiceIndex ? root.surfaceColor : root.primaryColor
                                 font.family: root.globalFont
                                 font.capitalization: Font.AllUppercase


### PR DESCRIPTION
## Summary

Resolves: https://github.com/anthonycaccese/240-MP/discussions/37 by adding a new "Exit to terminal" option to the quit menu when 240-MP is started via the autostart service.

## AI involvement

Used to help plan an approach that worked with the autostart service but not with desktop or manual start use cases.

## Testing

- Platform(s) tested: MacOS, tested via console exit commands / Raspberry Pi tested via RC1 release with latest changes
- Display / output tested: N/A

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
