### PR TITLE
fix(local): Add auto subtitles setting

### DIFF
--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "key": "auto_subtitles",
-      "label": "Automatically Show Subtitles",
+      "label": "Auto Show Subtitles",
       "type": "toggle",
       "default": "OFF"
     }

--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -35,6 +35,12 @@
       "options_source": "dynamic",
       "options_slot": "get_resume_playback_options",
       "default": "ask"
+    },
+    {
+      "key": "auto_subtitles",
+      "label": "Automatically Show Subtitles",
+      "type": "toggle",
+      "default": "OFF"
     }
   ]
 }

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -18,6 +18,8 @@ FocusScope {
     property bool   shuffleOn:           false
     property string resumeSetting:       "ask"
 
+    property bool   subtitlesOn:       false
+
     // Track last non-null values during playback for robust save on exit
     property int    lastKnownPositionMs:  0
     property int    lastKnownDurationMs:  0
@@ -33,6 +35,8 @@ FocusScope {
     focus: true
 
     Keys.onPressed: function(event) {
+        subtitlesOn = !!appCore.get_setting(moduleRoot.moduleId, "auto_subtitles")
+
         if (overlayVisible) {
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
                 goBack()
@@ -49,7 +53,7 @@ FocusScope {
                 if (choiceIndex === 0 && startPlPos >= 0)
                     resumedFromPlaylistPos = startPlPos
                 overlayVisible = false
-                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, -1, [], loopOn, startPlPos)
+                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, subtitlesOn ? 0 : -1, [], loopOn, startPlPos)
                 event.accepted = true
             }
         } else {
@@ -130,17 +134,18 @@ FocusScope {
         if (filePath === "") return
         loopOn        = !!appCore.get_setting(moduleRoot.moduleId, "loop_playback")
         shuffleOn     = !!appCore.get_setting(moduleRoot.moduleId, "shuffle_playback")
+        subtitlesOn   = !!appCore.get_setting(moduleRoot.moduleId, "auto_subtitles")
         resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
 
         // Shuffle wins: a shuffled playlist starts fresh & random; resume position
         // (a sequential item index) is meaningless once order is randomized.
         if (shuffleOn && isPlaylist(filePath)) {
-            mpvController.loadAndPlay(filePath, 0.0, 0, -1, [], loopOn, -1, 0.0, "", false, "", true)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subtitlesOn ? 0 : -1, [], loopOn, -1, 0.0, "", false, "", true)
             return
         }
 
         if (resumeSetting === "no") {
-            mpvController.loadAndPlay(filePath, 0.0, 0, -1, [], loopOn, -1)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subtitlesOn ? 0 : -1, [], loopOn, -1)
             return
         }
 
@@ -152,14 +157,14 @@ FocusScope {
             if (savedPos > 0 && savedPl >= 0)
                 resumedFromPlaylistPos = savedPl
             mpvController.loadAndPlay(filePath, savedPos > 0 ? savedPos / 1000.0 : 0.0,
-                                      0, -1, [], loopOn, savedPos > 0 ? savedPl : -1)
+                                      0, subtitlesOn ? 0 : -1, [], loopOn, savedPos > 0 ? savedPl : -1)
         } else {
             if (savedPos > 0) {
                 savedPositionMs  = savedPos
                 savedPlaylistPos = savedPl
                 overlayVisible   = true
             } else {
-                mpvController.loadAndPlay(filePath, 0.0, 0, -1, [], loopOn, -1)
+                mpvController.loadAndPlay(filePath, 0.0, 0, subtitlesOn ? 0 : -1, [], loopOn, -1)
             }
         }
     }

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -17,8 +17,7 @@ FocusScope {
     property bool   loopOn:              false
     property bool   shuffleOn:           false
     property string resumeSetting:       "ask"
-
-    property bool   subtitlesOn:       false
+    property bool   subtitlesOn:         false
 
     // Track last non-null values during playback for robust save on exit
     property int    lastKnownPositionMs:  0
@@ -35,8 +34,6 @@ FocusScope {
     focus: true
 
     Keys.onPressed: function(event) {
-        subtitlesOn = !!appCore.get_setting(moduleRoot.moduleId, "auto_subtitles")
-
         if (overlayVisible) {
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
                 goBack()

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -184,8 +184,12 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         args << QString("--sub-file=%1").arg(sf);
     if (subTrack > 0)
         args << QString("--sid=%1").arg(subTrack);
-    else if (subFiles.isEmpty() || subTrack < 0)
+    else if (subTrack < 0)
+        // subs disabled or provided via transcode
         args << QStringLiteral("--sid=no");
+    else if (subFiles.isEmpty() && subTrack == 0)
+        // use embedded or auto-matched sub
+        args << QStringLiteral("--sid=auto");
     // else: external sub(s) loaded, subTrack==0 → mpv auto-selects first loaded sub
 
     if (transcodeOffsetSec > 0.5f)


### PR DESCRIPTION
## Summary

This adds a setting to automatically show subtitles (when enabled) for the local player.

It also includes a small change to the subtitle logic in `MpvController.cpp`. It now assumes/asserts that subtitles should always be disabled when `subTrack` is negative, but an empty `subFiles` list doesn't mean there are no embedded subtitles available/desired, nor that MPV shouldn't look for local subtitles on its own.

Together, these changes allow improved QOL for those with hearing disorders (deaf, hard of hearing, auditory processing disorder, etc) or in settings where sound is off, but dialogue is still desired.

## AI involvement

No AI used.

## Testing

- Platform(s) tested: Pi 5 (no Mac, sorry, and my other Pi boards were thefted a few years back :( )
- Display / output tested: HDMI

Steps to test:
- Started a video known to contain embedded subtitles and confirmed they were not automatically displayed
- Stopped the video, toggled the setting, and resumed playback, confirming the subtitles are now, indeed, shown automatically
- Just for good measure, stopped playback and toggled the setting off again, then resumed playback once more to confirm the setting is still honored when toggled off manually. Just in case.

All tests worked as expected!

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
