### PR TITLE
feat: smooth-playback toggle to restore crop on Pi 3

### DIFF
--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -528,7 +528,7 @@ void MpvController::appendVideoArgs(QStringList &args) const {
             if (smoothPlaybackEnabled())
                 args << "--vo=gpu" << "--gpu-context=drm" << "--hwdec=v4l2m2m";
             else
-                args << "--vo=drm" << "--hwdec=auto-safe";
+                args << "--vo=drm" << "--hwdec=v4l2m2m-copy";
         } else {
             // Pi 5 (Full KMS) and the safe fallback for unknown headless Linux.
             args << "--vo=drm" << "--hwdec=auto-safe";

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -522,7 +522,13 @@ void MpvController::appendVideoArgs(QStringList &args) const {
             // straight to a DRM overlay plane for the lowest possible CPU (~15%) with
             // smooth playback. The one trade-off: the overlay plane can't zoom/crop,
             // so mpv's --panscan (the OSC crop button) blanks the video on this path.
-            args << "--vo=gpu" << "--gpu-context=drm" << "--hwdec=v4l2m2m";
+            // The "smooth_playback" setting (default ON) lets the user opt out: when
+            // OFF we fall back to the crop-capable scaler path (--vo=drm) at the cost
+            // of higher CPU and less smooth cadence.
+            if (smoothPlaybackEnabled())
+                args << "--vo=gpu" << "--gpu-context=drm" << "--hwdec=v4l2m2m";
+            else
+                args << "--vo=drm" << "--hwdec=auto-safe";
         } else {
             // Pi 5 (Full KMS) and the safe fallback for unknown headless Linux.
             args << "--vo=drm" << "--hwdec=auto-safe";
@@ -534,6 +540,24 @@ void MpvController::appendVideoArgs(QStringList &args) const {
 #endif
         // Other desktop (X11/Wayland dev): leave mpv's defaults untouched.
     }
+}
+
+bool MpvController::smoothPlaybackEnabled() const {
+    // Default ON: only an explicit "Off" opts out. Stored by Settings as a string
+    // ("On"/"Off") via the list_single row, so compare on the string form.
+    if (!m_appCore)
+        return true;
+    const QVariant v = m_appCore->get_setting(QString(), "smooth_playback");
+    if (!v.isValid() || v.toString().isEmpty())
+        return true;
+    return v.toString().compare(QStringLiteral("Off"), Qt::CaseInsensitive) != 0;
+}
+
+bool MpvController::hasSmoothPlaybackTradeoff() const {
+    // Only the Pi 3 overlay path sacrifices crop/zoom for smoothness. Every other
+    // profile (Pi 4 copy path, Pi 5/generic --vo=drm, desktop) can already crop, so
+    // the toggle would be a no-op there and is hidden.
+    return m_videoProfile == VideoProfile::Pi3;
 }
 
 int MpvController::getActiveVt() const {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -52,6 +52,11 @@ public:
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);
 
+    // True only on devices whose smooth-playback decode path can't crop/zoom (the
+    // Pi 3 DRM-overlay path). Settings uses this to show the "Smooth Playback"
+    // toggle only where the smoothness-vs-crop trade-off actually exists.
+    Q_INVOKABLE bool hasSmoothPlaybackTradeoff() const;
+
 signals:
     void positionChanged(int ms);
     void durationChanged(int ms);
@@ -81,6 +86,9 @@ private:
     // Appends the profile-specific --vo/--gpu-context/--hwdec flags (honouring the
     // app-level "mpv_video_args" override) to a forming mpv argument list.
     void appendVideoArgs(QStringList &args) const;
+    // App-level "smooth_playback" setting (default ON). On the Pi 3 this selects the
+    // smooth zero-copy overlay path; turning it OFF restores the crop-capable scaler path.
+    bool smoothPlaybackEnabled() const;
     int  getActiveVt() const;
     int  findFreeVt() const;
     int  findQtDrmFd() const;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -58,10 +58,9 @@ FocusScope {
             items.push({
                 type: "list_single",
                 key: "smooth_playback",
-                label: "Smooth Playback",
+                label: "1080p Playback",
                 options: ["On", "Off"],
                 value: appSettings["smooth_playback"] || "On",
-                description: "On: smoothest video, but the CROP button can't zoom. Off: enables cropping (uses more CPU). Applies to the next video.",
                 moduleId: ""
             })
         }
@@ -73,7 +72,7 @@ FocusScope {
         }
 
         if (hasModuleSettings) {
-            items.push({ type: "section", label: "Modules:" })
+            items.push({ type: "section", label: "Modules" })
             for (var j = 0; j < installedModules.length; j++) {
                 var m = installedModules[j]
                 if (m.has_settings) {
@@ -83,7 +82,7 @@ FocusScope {
         }
 
         // SYSTEM section
-        items.push({ type: "section", label: "System:" })
+        items.push({ type: "section", label: "System" })
         items.push({ type: "quit", label: "Quit 240-MP" })
 
         settingsItems = items
@@ -281,22 +280,6 @@ FocusScope {
                 }
             }
         }
-    }
-
-    // --- PER-ROW HELP TEXT --- (shown when the focused row carries a description)
-    Text {
-        id: rowHelp
-        property var currentRow: settingsRoot.settingsItems[settingsList.currentIndex]
-        text: (currentRow && currentRow.description) ? currentRow.description : ""
-        visible: text !== ""
-        color: root.secondaryColor
-        font.family: root.globalFont
-        font.pixelSize: root.sh * 0.0291667 //14
-        wrapMode: Text.WordWrap
-        anchors.top: settingsList.bottom
-        anchors.left: settingsList.left
-        anchors.topMargin: root.sh * 0.025 //12
-        width: settingsList.width
     }
 
     // --- FOOTER ---

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -58,9 +58,10 @@ FocusScope {
             items.push({
                 type: "list_single",
                 key: "smooth_playback",
-                label: "1080p Playback",
+                label: "Smooth Playback",
                 options: ["On", "Off"],
                 value: appSettings["smooth_playback"] || "On",
+                description: "On: smoothest video, but the CROP button can't zoom. Off: enables cropping (uses more CPU). Applies to the next video.",
                 moduleId: ""
             })
         }
@@ -72,7 +73,7 @@ FocusScope {
         }
 
         if (hasModuleSettings) {
-            items.push({ type: "section", label: "Modules" })
+            items.push({ type: "section", label: "Modules:" })
             for (var j = 0; j < installedModules.length; j++) {
                 var m = installedModules[j]
                 if (m.has_settings) {
@@ -82,7 +83,7 @@ FocusScope {
         }
 
         // SYSTEM section
-        items.push({ type: "section", label: "System" })
+        items.push({ type: "section", label: "System:" })
         items.push({ type: "quit", label: "Quit 240-MP" })
 
         settingsItems = items
@@ -280,6 +281,22 @@ FocusScope {
                 }
             }
         }
+    }
+
+    // --- PER-ROW HELP TEXT --- (shown when the focused row carries a description)
+    Text {
+        id: rowHelp
+        property var currentRow: settingsRoot.settingsItems[settingsList.currentIndex]
+        text: (currentRow && currentRow.description) ? currentRow.description : ""
+        visible: text !== ""
+        color: root.secondaryColor
+        font.family: root.globalFont
+        font.pixelSize: root.sh * 0.0291667 //14
+        wrapMode: Text.WordWrap
+        anchors.top: settingsList.bottom
+        anchors.left: settingsList.left
+        anchors.topMargin: root.sh * 0.025 //12
+        width: settingsList.width
     }
 
     // --- FOOTER ---

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -51,6 +51,21 @@ FocusScope {
             moduleId: ""
         })
 
+        // Smooth Playback — only shown on devices whose smooth decode path can't
+        // crop/zoom (the Pi 3 overlay path). Default ON; turning it off restores the
+        // crop-capable video output. Takes effect on the next video.
+        if (mpvController.hasSmoothPlaybackTradeoff()) {
+            items.push({
+                type: "list_single",
+                key: "smooth_playback",
+                label: "Smooth Playback",
+                options: ["On", "Off"],
+                value: appSettings["smooth_playback"] || "On",
+                description: "On: smoothest video, but the CROP button can't zoom. Off: enables cropping (uses more CPU). Applies to the next video.",
+                moduleId: ""
+            })
+        }
+
         // MODULES section — only show modules with has_settings
         var hasModuleSettings = false
         for (var i = 0; i < installedModules.length; i++) {
@@ -266,6 +281,22 @@ FocusScope {
                 }
             }
         }
+    }
+
+    // --- PER-ROW HELP TEXT --- (shown when the focused row carries a description)
+    Text {
+        id: rowHelp
+        property var currentRow: settingsRoot.settingsItems[settingsList.currentIndex]
+        text: (currentRow && currentRow.description) ? currentRow.description : ""
+        visible: text !== ""
+        color: root.secondaryColor
+        font.family: root.globalFont
+        font.pixelSize: root.sh * 0.0291667 //14
+        wrapMode: Text.WordWrap
+        anchors.top: settingsList.bottom
+        anchors.left: settingsList.left
+        anchors.topMargin: root.sh * 0.025 //12
+        width: settingsList.width
     }
 
     // --- FOOTER ---

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -48,6 +48,7 @@ FocusScope {
             label: "Color Scheme",
             options: colorOpts,
             value: appSettings["color_scheme"] || "Video 1",
+            description: "Choose your prefered color scheme\nPlease see the wiki for details on adding a custom one",
             moduleId: ""
         })
 
@@ -58,10 +59,10 @@ FocusScope {
             items.push({
                 type: "list_single",
                 key: "smooth_playback",
-                label: "Smooth Playback",
+                label: "1080p Playback",
                 options: ["On", "Off"],
                 value: appSettings["smooth_playback"] || "On",
-                description: "On: smoothest video, but the CROP button can't zoom. Off: enables cropping (uses more CPU). Applies to the next video.",
+                description: "[ON] Enable 1080p content playback, crop will not function\n[OFF] Enable crop, 1080p content playback will stutter",
                 moduleId: ""
             })
         }
@@ -73,7 +74,7 @@ FocusScope {
         }
 
         if (hasModuleSettings) {
-            items.push({ type: "section", label: "Modules:" })
+            items.push({ type: "section", label: "Modules" })
             for (var j = 0; j < installedModules.length; j++) {
                 var m = installedModules[j]
                 if (m.has_settings) {
@@ -83,7 +84,7 @@ FocusScope {
         }
 
         // SYSTEM section
-        items.push({ type: "section", label: "System:" })
+        items.push({ type: "section", label: "System" })
         items.push({ type: "quit", label: "Quit 240-MP" })
 
         settingsItems = items
@@ -283,20 +284,31 @@ FocusScope {
         }
     }
 
-    // --- PER-ROW HELP TEXT --- (shown when the focused row carries a description)
-    Text {
-        id: rowHelp
+    // --- HELP TEXT --- (shown when a focused row has a description)
+    Rectangle {
+        id: rowHelpBackground
         property var currentRow: settingsRoot.settingsItems[settingsList.currentIndex]
-        text: (currentRow && currentRow.description) ? currentRow.description : ""
-        visible: text !== ""
-        color: root.secondaryColor
-        font.family: root.globalFont
-        font.pixelSize: root.sh * 0.0291667 //14
-        wrapMode: Text.WordWrap
-        anchors.top: settingsList.bottom
-        anchors.left: settingsList.left
-        anchors.topMargin: root.sh * 0.025 //12
-        width: settingsList.width
+        visible: !!(currentRow && currentRow.description)
+        color: root.accentColor
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1583333 //76
+        anchors.leftMargin: root.sw * 0.125 //80
+        width: root.sw * 0.75 //480
+        height: root.sh * 0.0583333 //28
+        clip: true
+        Text {
+            id: rowHelp
+            text: (rowHelpBackground.currentRow && rowHelpBackground.currentRow.description) || ""
+            color: root.surfaceColor
+            font.family: root.globalFont
+            font.pixelSize: root.sh * 0.0291667 //14
+            wrapMode: Text.WordWrap
+            anchors.fill: parent
+            anchors.margins: root.sw * 0.0125 //6
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
     }
 
     // --- FOOTER ---


### PR DESCRIPTION
## Problem

On the Pi 3, the OSC **CROP** button blanks the screen instead of cropping (reproduces on real hardware/CRT, not on desktop).

Root cause: `e6ae377` ("mpv playback improvements") switched the Pi 3 to a zero-copy DRM-**overlay** decode path (`--vo=gpu --gpu-context=drm --hwdec=v4l2m2m`) for smoother playback. That plane can't zoom/scale, so mpv's `--panscan` (what CROP triggers) produces a black frame. Before that commit the Pi 3 used `--vo=drm --hwdec=auto-safe`, which goes through the normal scaler — so crop worked. Crop capability was the (documented) trade-off of the new path.

## Change

Adds a user-facing **Smooth Playback** setting (default **On**) so the user can choose:

- **On** (default) — keeps the smooth zero-copy overlay path; CROP can't zoom.
- **Off** — falls back to the crop-capable scaler path (`--vo=drm --hwdec=auto-safe`) at higher CPU / slightly less smooth cadence.

Details:
- App-level `smooth_playback` setting; read when mpv launches, so it applies to the next video.
- `MpvController::hasSmoothPlaybackTradeoff()` gates the toggle to the only profile where the conflict exists (Pi 3). On Pi 4 / Pi 5 / desktop crop already works, so the toggle is hidden there.
- Settings shows the toggle with a help line noting it disables cropping. Adds a generic per-row `description` field to the Application section for this.

## Testing

- **Manually tested on a Raspberry Pi 3B+**: with Smooth Playback **Off**, the CROP button zooms correctly instead of blanking; with it **On**, playback uses the smooth overlay path as before.
- **On macOS the Smooth Playback setting does not appear** — this is expected: the toggle is gated to the Pi 3 profile via `hasSmoothPlaybackTradeoff()`, since every other profile can already crop and the setting would be a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)