### PR TITLE
Add SMPTE ECR 1-1978 theme

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -62,6 +62,13 @@ Window {
             "tertiary": "#424242",
             "surface": "#121212",
             "accent": "#FFFFFF"
+        },
+        "SMPTE ECR 1-1978": {  // 75% max 0xFF == 0xBF, 40% max 0xFF == 0x66, 7.5% max 0xFF == 0x13; 75/7.5 targets per https://en.wikipedia.org/wiki/SMPTE_color_bars#Analog_NTSC - mixed with 40% in "off channels" to both wash out and improve contrast
+            "primary": "#BFBFBF",
+            "secondary": "#66BF66",
+            "tertiary": "#6666BF",
+            "surface": "#131313",
+            "accent": "#BF6666"
         }
     })
     property var allThemes: themes  // may gain a "Custom" entry on startup

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -39,7 +39,7 @@ FocusScope {
         var items = []
 
         // APPLICATION section
-        var colorOpts = ["Video 1","Late Night","Synthwave","Terminal","T-120","Amber","Kinescope"]
+        var colorOpts = ["Video 1","Late Night","Synthwave","Terminal","T-120","Amber","Kinescope","SMPTE ECR 1-1978"]
         var custom = appCore.getCustomColorScheme()
         if (Object.keys(custom).length === 5) colorOpts.push("Custom")
         items.push({


### PR DESCRIPTION
## Summary

For those who remember the days of CRT TVs, the various NTSC/PAL test patterns are likely part of the nostalgia. So it only made sense, IMO, to use the most prevalent of those patterns, specifically the one defined by the Society of Motion Picture and Television Engineers in the late 70s, as the base of a theme in 240-MP! This introduces that theme for everyone's enjoyment.

Notably, the 1978 spec does *not* include RGB values. The broadcast/composite color space (YIQ, for luma/In-phase/Quadrature - roughly, black-white/orange- blue/purple-green) used by NTSC in particular is used instead, and as an analog system, converting to digitized "steps" isn't necessarily straightforward nor consistent. (For reference, PAL used YUV, where Y is still luma, but U and V are blue-minus-luma and red-minus-luma, respectively. Many videos are encoded in YUV today!) So a conversion to RGB became necessary.

There is a 2002 spec that defines RGB values for digital "equivalent" colors, but it was defined alongside HD, and thus doesn't accurately retain any analog features from NTSC, so I opted not to use those values (though I did start with them, to be clear). Instead, I used the test pattern's own 75/7.5% targets for maximum-per-channel/black values, and the 40% gray for minimum-per-channel values. This last adjustment was made because the contrast between 7.5% black and 75% blue is nowhere near high enough to be readable, at least on my aging HDMI TV. (Regrettably, my CRTs were all thefted since I acquired them in the 90s and 00s, so I no longer have any with which to test.)

I am open to further refinement of the exact values, and of course I don't have (nor seek) final say on anything here, but I hope this is at least a solid starting point for adding this classic theme to the 240-MP repertoire.

## AI involvement

No AI used

## Testing

- Platform(s) tested: Raspberry Pi 5
- Display / output tested: HDMI

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)