### PR TITLE
fix: local files symlink support

### DIFF
--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -100,9 +100,14 @@ QVariantList LocalFilesBackend::getItems(const QString &path) {
         qWarning("[LocalFiles] directory not found: %s", qPrintable(path));
         return result;
     }
-    QString canonical = QDir(path).canonicalPath();
-    QString root      = QDir(m_mediaRoot).canonicalPath();
-    if (!canonical.startsWith(root)) {
+    // Validate against the media root lexically (absolutePath cleans "." / ".."
+    // without resolving symlinks) so intentional symlinks placed inside the media
+    // root are followed, while ".." traversal out of the root is still blocked.
+    QString clean = QDir(path).absolutePath();
+    QString root  = QDir(m_mediaRoot).absolutePath();
+    bool inside = (clean == root) ||
+                  clean.startsWith(root.endsWith('/') ? root : root + '/');
+    if (!inside) {
         qWarning("[LocalFiles] path escapes media root: %s", qPrintable(path));
         return result;
     }


### PR DESCRIPTION
## Summary

fixes https://github.com/anthonycaccese/240-MP/issues/60 and adds support for symlinks in the local files media directory

getItems() now validates lexically (absolutePath()) instead of canonicalPath(), so symlinks under the media root are followed while .. escapes stay blocked, plus the prefix-boundary bug is fixed

## AI involvement

Used to validate and check blindspots with adding symlink support

## Testing

- Platform(s) tested: Raspberry Pi 4, set up a symlink to a networked folder under the local files media directory and verified that content could be played back by pathing through the link
- Display / output tested: CRT

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
