### PR TITLE
feat: local files module - upgrade auto subs to include forced-only option

### DIFF
--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -39,8 +39,11 @@
     {
       "key": "auto_subtitles",
       "label": "Auto Show Subtitles",
-      "type": "toggle",
-      "default": "OFF"
+      "type": "list_single",
+      "options_source": "dynamic",
+      "options_slot": "get_auto_subtitles_options",
+      "default": "forced",
+      "description": "Whether to automatically show subtitles when a video starts.\n[FORCED ONLY] displays for foreign dialogue only, when available."
     },
     {
       "key": "sub_lang",

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -17,7 +17,7 @@ FocusScope {
     property bool   loopOn:              false
     property bool   shuffleOn:           false
     property string resumeSetting:       "ask"
-    property bool   subtitlesOn:         false
+    property string subtitleMode:        "forced"
     property var    subtitleLangs:       []
 
     // Track last non-null values during playback for robust save on exit
@@ -51,7 +51,7 @@ FocusScope {
                 if (choiceIndex === 0 && startPlPos >= 0)
                     resumedFromPlaylistPos = startPlPos
                 overlayVisible = false
-                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, subtitlesOn ? 0 : -1, [], subtitleLangs, loopOn, startPlPos)
+                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, startPlPos)
                 event.accepted = true
             }
         } else {
@@ -137,7 +137,9 @@ FocusScope {
         if (filePath === "") return
         loopOn        = !!appCore.get_setting(moduleRoot.moduleId, "loop_playback")
         shuffleOn     = !!appCore.get_setting(moduleRoot.moduleId, "shuffle_playback")
-        subtitlesOn   = !!appCore.get_setting(moduleRoot.moduleId, "auto_subtitles")
+        // Some fancy logic to honor the old boolean setting until it gets updated to the new format
+        var autoSubs  = appCore.get_setting(moduleRoot.moduleId, "auto_subtitles")
+        subtitleMode  = (typeof autoSubs === "boolean") ? ((autoSubs === true) ? "on" : "forced") : (autoSubs || "forced")
         resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
 
         // Leaving this as an array since MPV - like most players - expects a *list* of languages
@@ -156,12 +158,12 @@ FocusScope {
         // Shuffle wins: a shuffled playlist starts fresh & random; resume position
         // (a sequential item index) is meaningless once order is randomized.
         if (shuffleOn && isPlaylist(filePath)) {
-            mpvController.loadAndPlay(filePath, 0.0, 0, subtitlesOn ? 0 : -1, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", true)
+            mpvController.loadAndPlay(filePath, 0.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, -1, 0.0, "", false, "", true)
             return
         }
 
         if (resumeSetting === "no") {
-            mpvController.loadAndPlay(filePath, 0.0, 0, subtitlesOn ? 0 : -1, [], subtitleLangs, loopOn, -1)
+            mpvController.loadAndPlay(filePath, 0.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, -1)
             return
         }
 
@@ -173,14 +175,14 @@ FocusScope {
             if (savedPos > 0 && savedPl >= 0)
                 resumedFromPlaylistPos = savedPl
             mpvController.loadAndPlay(filePath, savedPos > 0 ? savedPos / 1000.0 : 0.0,
-                                      0, subtitlesOn ? 0 : -1, [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1)
+                                      0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1)
         } else {
             if (savedPos > 0) {
                 savedPositionMs  = savedPos
                 savedPlaylistPos = savedPl
                 overlayVisible   = true
             } else {
-                mpvController.loadAndPlay(filePath, 0.0, 0, subtitlesOn ? 0 : -1, [], subtitleLangs, loopOn, -1)
+                mpvController.loadAndPlay(filePath, 0.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, -1)
             }
         }
     }

--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -69,6 +69,15 @@ void LocalFilesBackend::clearPosition(const QString &filePath) {
     saveHistory(history);
 }
 
+void LocalFilesBackend::get_auto_subtitles_options() {
+    QVariantList options;
+    QVariantMap forced; forced["id"] = "forced"; forced["label"] = "Forced Only"; forced["old"] = false;
+    QVariantMap on;     on["id"] = "on";         on["label"] = "On";              on["old"] = true;
+    QVariantMap off;    off["id"] = "off";       off["label"] = "Off";
+    options << forced << on << off;
+    emit dynamicOptionsReady("auto_subtitles", options);
+}
+
 void LocalFilesBackend::get_resume_playback_options() {
     QVariantList options;
     QVariantMap ask; ask["id"] = "ask"; ask["label"] = "Ask";

--- a/src/modules/local_files/LocalFilesBackend.h
+++ b/src/modules/local_files/LocalFilesBackend.h
@@ -17,6 +17,7 @@ public:
     Q_INVOKABLE void        savePosition(const QString &filePath, int positionMs, int playlistPos);
     Q_INVOKABLE void        clearPosition(const QString &filePath);
     Q_INVOKABLE void        get_resume_playback_options();
+    Q_INVOKABLE void        get_auto_subtitles_options();
     Q_INVOKABLE void        get_subtitle_languages();
 
 signals:

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -187,12 +187,19 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         args << QString("--sub-file=%1").arg(sf);
     if (subTrack > 0)
         args << QString("--sid=%1").arg(subTrack);
-    else if (subTrack < 0)
+    else if (subTrack < -1)
         // subs disabled or provided via transcode
         args << QStringLiteral("--sid=no");
-    else if (subFiles.isEmpty() && subTrack == 0)
-        // use embedded or auto-matched sub
-        args << QStringLiteral("--sid=auto");
+    else if (subTrack == -1)
+        // forced subs only
+        args << QStringLiteral("--subs-with-matching-audio=forced") << QStringLiteral("--subs-fallback-forced=always");
+    else if (subTrack == 0) {
+        // Always display subs, even if the audio and subtitle languages match
+        args << QStringLiteral("--subs-with-matching-audio=yes") << QStringLiteral("--subs-fallback=yes");
+        if (subFiles.isEmpty())
+            // use embedded or auto-matched sub
+            args << QStringLiteral("--sid=auto");
+    }
     // else: external sub(s) loaded, subTrack==0 → mpv auto-selects first loaded sub
     if (!subLangs.isEmpty())
         args << QString("--slang=%1").arg(subLangs.join(QStringLiteral(",")));

--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -62,7 +62,7 @@ FocusScope {
                 var opts = dynamicOptions[key] || []
                 var storedId = currentValues[key] || null
                 for (var i = 0; i < opts.length; i++) {
-                    if (opts[i].id === storedId) return opts[i].label
+                    if (opts[i].id === storedId || (storedId !== null && opts[i].old === storedId)) return opts[i].label
                 }
                 return opts.length > 0 ? opts[0].label : "---"
             }


### PR DESCRIPTION
## Summary

A few changes to make this work:

- Update `manifest.json` to use a `list_single` instead of a simple `toggle`, and `forced` instead of `off` as the default
- Update `LocalFilesBackend` to provide the updated options list ("Forced Only", in addition to the previous "On" and "Off"), complete with info on how to handle the old values in existing configs (though "Off" in the old config is mapped to "Forced Only" in the new, since this is what most folks actually want in the first place)
- Update `Player` to support both the old `boolean` and the new `string` values
- Update `ModuleSettings` to also support `old` settings alongside current ones, for any/all `list_single` settings that define them (currently just `auto_subtitles`, but flexible for any future settings that may also need to become `list_single` from something else)
- Update `MpvController` to treat `subTrack == -1` as forced-only, and `subTrack < -1` as off - all other values retain their previous meanings, though I noticed subtitles wouldn't load without a language selected in the `mpv.conf`, so I did update the `subTrack == 0` logic to pass two additional flags to correct that

Much simpler changes than the ones to add language selection support, but I'll definitely need to do some merge conflict resolution on whichever of the two gets merged second. :sweat-smile:

## AI involvement

No AI used

## Testing

- Platform(s) tested: Pi 5
- Display / output tested: HDMI (and RustDesk remote access, but that's functionally the same thing)

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)