### PR TITLE
fix: local files freeze when playback ends on its own

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,7 +176,12 @@ The current MPV implementation is a good reference implementation of the "browse
 1. **Launch** — `loadAndPlay(url, startSeconds, audioTrack, subTrack, ...)` starts mpv as a `QProcess`. Playback parameters are passed as mpv command-line flags: `--start=<sec>` (resume offset), `--playlist-start=<n>`, `--loop-playlist=inf`, and so on. mpv is found on `PATH` — the app never links libmpv.
 2. **Control channel** — mpv is started with `--input-ipc-server=<socket>` (a Unix domain socket at `/tmp/240mp-mpv.sock`). `MpvController` connects to it with a `QLocalSocket` and sends JSON commands via `sendCommand(QJsonArray)`. `seekTo()` and `sendKey()` (which sends mpv a `keypress` command) go over this channel — that's how the USB remote / keyboard drives mpv's OSC while it's fullscreen.
 3. **State back to QML** — `MpvController` issues `observe_property` for `time-pos`, `duration`, and `playlist-pos`, and re-publishes them as `Q_PROPERTY`s + the `positionChanged` / `durationChanged` / `playlistPosChanged` signals. A watchdog timer logs a warning if no `time-pos` event arrives for ~10 s (freeze detection).
-4. **Exit** — when mpv quits, `MpvController` emits **`playbackFinished(finalPos, finalDur)`** on a normal exit (used to record resume position), or **`playbackFailed()`** when mpv exits with code 2 (file couldn't be played) — `Player.qml` listens for this to retry with transcoding.
+4. **Exit** — when mpv quits, `MpvController` emits a single signal, **`playbackEnded(finalPos, finalDur, reason)`**, where `reason` is one of:
+    - `"eof"` — the file played to its natural end. What happens next is the module's call: most just return to the menu.  For example: Plex may autoplay the next episode (based on the user's autoplay setting, and fall back to a normal return when there is no next episode, e.g. a movie or the last episode of a season).
+    - `"stopped"` — the user quit/stopped before the end (also the safe default for a crash/kill with no end-file event). Record the resume position and return.
+    - `"failed"` — mpv exited with code 2 (file couldn't be played). A module may attempt recovery first.  For example: Plex retries with transcoding — otherwise it just returns.
+
+    **The baseline for every module to keep in mind:** by the time `playbackEnded` fires, mpv has already exited, so a handler that returns without either calling `goBack()` or starting fresh playback (`loadAndPlay`, e.g. in an autoplay/retry scenario) will leave the now-defunct Player view focused over a dead subprocess which will cause the app to freeze. So please handle the one signal, then branch on `reason` only where you have special behavior, and make sure no branch falls through.
 
 ### Per-device video decode profiles
 

--- a/modules/ambient_mode/views/Player.qml
+++ b/modules/ambient_mode/views/Player.qml
@@ -43,7 +43,10 @@ FocusScope {
 
     Connections {
         target: mpvController
-        function onPlaybackFinished(finalPositionMs, finalDurationMs) {
+        // Ambient clips loop, so in practice mpv only exits on a user quit; handle
+        // the single playbackEnded signal regardless of reason — stop the companion
+        // audio and return to the menu.
+        function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
             ambientModeBackend.stopAudio()
             goBack()
         }

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -107,24 +107,37 @@ FocusScope {
             }
         }
 
+        // mpv exited because the user quit/stopped before the end.
         function onPlaybackFinished(finalPositionMs, finalDurationMs) {
-            var pos   = lastKnownPositionMs  || finalPositionMs
-            var dur   = lastKnownDurationMs  || finalDurationMs
-            var plPos = lastKnownPlaylistPos
-
-            if (isPlaylist(filePath)) {
-                // Always save playlist state — skip completion detection
-                if (pos > 0 || plPos >= 0)
-                    localFilesBackend.savePosition(filePath, pos, plPos)
-            } else {
-                // Single file: clear if near completion, save otherwise
-                if (dur > 0 && pos >= dur * 0.95)
-                    localFilesBackend.clearPosition(filePath)
-                else if (pos > 5000)
-                    localFilesBackend.savePosition(filePath, pos, -1)
-            }
-            goBack()
+            finishPlayback(finalPositionMs, finalDurationMs)
         }
+        // mpv exited because the file played to its natural end (reason "eof").
+        // Local Files has no autoplay-next, so this behaves the same as a quit:
+        // save/clear resume position and return to the menu. Without this handler
+        // the signal is dropped, goBack() never runs, and the app freezes on the
+        // defunct Player view.
+        function onPlaybackFinishedNaturally(finalPositionMs, finalDurationMs) {
+            finishPlayback(finalPositionMs, finalDurationMs)
+        }
+    }
+
+    function finishPlayback(finalPositionMs, finalDurationMs) {
+        var pos   = lastKnownPositionMs  || finalPositionMs
+        var dur   = lastKnownDurationMs  || finalDurationMs
+        var plPos = lastKnownPlaylistPos
+
+        if (isPlaylist(filePath)) {
+            // Always save playlist state — skip completion detection
+            if (pos > 0 || plPos >= 0)
+                localFilesBackend.savePosition(filePath, pos, plPos)
+        } else {
+            // Single file: clear if near completion, save otherwise
+            if (dur > 0 && pos >= dur * 0.95)
+                localFilesBackend.clearPosition(filePath)
+            else if (pos > 5000)
+                localFilesBackend.savePosition(filePath, pos, -1)
+        }
+        goBack()
     }
 
     Component.onCompleted: {

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -107,37 +107,29 @@ FocusScope {
             }
         }
 
-        // mpv exited because the user quit/stopped before the end.
-        function onPlaybackFinished(finalPositionMs, finalDurationMs) {
-            finishPlayback(finalPositionMs, finalDurationMs)
-        }
-        // mpv exited because the file played to its natural end (reason "eof").
-        // Local Files has no autoplay-next, so this behaves the same as a quit:
-        // save/clear resume position and return to the menu. Without this handler
-        // the signal is dropped, goBack() never runs, and the app freezes on the
-        // defunct Player view.
-        function onPlaybackFinishedNaturally(finalPositionMs, finalDurationMs) {
-            finishPlayback(finalPositionMs, finalDurationMs)
-        }
-    }
+        // mpv exited for any reason ("eof"/"stopped"/"failed"). Local Files has no
+        // autoplay-next or transcode-retry, so every exit is handled the same way:
+        // save/clear the resume position and return to the menu. Handling the single
+        // playbackEnded signal here is what keeps the app from freezing on a natural
+        // end-of-file (the original bug was a missing per-reason handler).
+        function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            var pos   = lastKnownPositionMs  || finalPositionMs
+            var dur   = lastKnownDurationMs  || finalDurationMs
+            var plPos = lastKnownPlaylistPos
 
-    function finishPlayback(finalPositionMs, finalDurationMs) {
-        var pos   = lastKnownPositionMs  || finalPositionMs
-        var dur   = lastKnownDurationMs  || finalDurationMs
-        var plPos = lastKnownPlaylistPos
-
-        if (isPlaylist(filePath)) {
-            // Always save playlist state — skip completion detection
-            if (pos > 0 || plPos >= 0)
-                localFilesBackend.savePosition(filePath, pos, plPos)
-        } else {
-            // Single file: clear if near completion, save otherwise
-            if (dur > 0 && pos >= dur * 0.95)
-                localFilesBackend.clearPosition(filePath)
-            else if (pos > 5000)
-                localFilesBackend.savePosition(filePath, pos, -1)
+            if (isPlaylist(filePath)) {
+                // Always save playlist state — skip completion detection
+                if (pos > 0 || plPos >= 0)
+                    localFilesBackend.savePosition(filePath, pos, plPos)
+            } else {
+                // Single file: clear if near completion, save otherwise
+                if (dur > 0 && pos >= dur * 0.95)
+                    localFilesBackend.clearPosition(filePath)
+                else if (pos > 5000)
+                    localFilesBackend.savePosition(filePath, pos, -1)
+            }
+            goBack()
         }
-        goBack()
     }
 
     Component.onCompleted: {

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -340,32 +340,35 @@ FocusScope {
             if (ms > 0) playerRoot.lastKnownDurationMs = ms
         }
 
-        function onPlaybackFinished(finalPositionMs, finalDurationMs) {
-            // mpv exited because the user quit/stopped — return to the detail view.
-            reportStopped(finalPositionMs, finalDurationMs)
-            goBack()
-        }
-
-        function onPlaybackFinishedNaturally(finalPositionMs, finalDurationMs) {
-            // mpv reached the end of the file. Mark it stopped (watched) in Plex,
-            // then auto-advance to the next episode if the feature is enabled.
-            reportStopped(finalPositionMs, finalDurationMs)
-            if (!autoplayNext) { goBack(); return }
-            pendingNextEpisode = true
-            plexBackend.load_next_episode(ratingKey)
-        }
-
-        function onPlaybackFailed() {
-            if (!isTranscoding) {
-                // Direct play failed (e.g. HTTP 500 from PMS on WAN). Retry
-                // transparently with transcoding at the same resume offset.
-                pendingRetryTranscode = true
-                plexBackend.request_transcode(ratingKey, partKey, sessionId,
-                                              selectedAudioId, selectedSubtitleId,
-                                              0)
-            } else {
-                goBack()
+        function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            if (reason === "failed") {
+                if (!isTranscoding) {
+                    // Direct play failed (e.g. HTTP 500 from PMS on WAN). Retry
+                    // transparently with transcoding at the same resume offset.
+                    pendingRetryTranscode = true
+                    plexBackend.request_transcode(ratingKey, partKey, sessionId,
+                                                  selectedAudioId, selectedSubtitleId,
+                                                  0)
+                } else {
+                    goBack()
+                }
+                return
             }
+
+            // Both a natural end ("eof") and a user quit ("stopped") mark the item
+            // stopped in Plex. A natural end only *attempts* to auto-advance, and
+            // only when the user has autoplay enabled — and even then it's just a
+            // request: load_next_episode returns an empty detail when there is no
+            // next episode (a movie, or the last episode of a season), in which case
+            // onNextEpisodeReady falls back to goBack(). Everything else returns to
+            // the detail view here.
+            reportStopped(finalPositionMs, finalDurationMs)
+            if (reason === "eof" && autoplayNext) {
+                pendingNextEpisode = true
+                plexBackend.load_next_episode(ratingKey)
+                return
+            }
+            goBack()
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ static QString resolveDataRoot() {
 int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
     app.setApplicationName("240-MP");
-    app.setApplicationVersion("2026.06.22");
+    app.setApplicationVersion("2026.06.23");
 
     // Hide cursor — 240-MP is keyboard-only so the cursor serves no purpose.
     // On Linux, only hide on headless EGLFS (not desktop X11/Wayland sessions).

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -139,7 +139,9 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     const QString bin = QStandardPaths::findExecutable("mpv");
     if (bin.isEmpty()) {
         qWarning("[MpvController] mpv not found in PATH");
-        QTimer::singleShot(0, this, [this]() { emit playbackFinished(0, 0); });
+        QTimer::singleShot(0, this, [this]() {
+            emit playbackEnded(0, 0, QStringLiteral("stopped"));
+        });
         return;
     }
 
@@ -405,10 +407,15 @@ void MpvController::onProcessFinished() {
     m_position = 0;
     m_duration = 0;
 
-    // mpv reports reason "eof" only when the file played to its natural end.
-    // Any other reason (quit/stop/error) or a missing end-file event (crash/kill)
-    // is treated as a non-natural exit — the safe default that never auto-advances.
-    const bool naturalEof = (m_lastEndFileReason == "eof");
+    // Classify why mpv exited, once, so both the headless and desktop paths emit
+    // the same playbackEnded reason:
+    //   exit code 2          -> "failed"  (file could not be played; up to the module as to what to do. As an example: Plex attemps a retry in this case)
+    //   end-file reason "eof"-> "eof"     (natural end; up to the module as to what to do. As an example: Plex autoplays next)
+    //   anything else        -> "stopped" (user quit/stop, crash, or kill; a safe default)
+    QString reason;
+    if (exitCode == 2)                    reason = QStringLiteral("failed");
+    else if (m_lastEndFileReason == "eof") reason = QStringLiteral("eof");
+    else                                   reason = QStringLiteral("stopped");
 
     if (m_headlessMode) {
         // Defer DRM restore and VT switch by 200 ms. mpv's last KMS atomic
@@ -418,20 +425,15 @@ void MpvController::onProcessFinished() {
         // the kernel falls back to showing the text console on Qt's VT.
         // 200 ms is more than three VSync periods at 60 Hz — enough to clear
         // any in-flight commit without a perceptible delay for the user.
-        QTimer::singleShot(200, this, [this, pos, dur, naturalEof]() {
-            doHeadlessRestore(pos, dur, naturalEof);
+        QTimer::singleShot(200, this, [this, pos, dur, reason]() {
+            doHeadlessRestore(pos, dur, reason);
         });
     } else {
-        if (exitCode == 2)
-            emit playbackFailed();
-        else if (naturalEof)
-            emit playbackFinishedNaturally(pos, dur);
-        else
-            emit playbackFinished(pos, dur);
+        emit playbackEnded(pos, dur, reason);
     }
 }
 
-void MpvController::doHeadlessRestore(int pos, int dur, bool naturalEof) {
+void MpvController::doHeadlessRestore(int pos, int dur, const QString &reason) {
 #ifdef Q_OS_LINUX
     if (m_qtDrmFd >= 0) {
         if (::ioctl(m_qtDrmFd, DRM_IOCTL_SET_MASTER, 0) < 0) {
@@ -454,10 +456,7 @@ void MpvController::doHeadlessRestore(int pos, int dur, bool naturalEof) {
         switchToVt(prevVt);
     }
     m_headlessMode = false;
-    if (naturalEof)
-        emit playbackFinishedNaturally(pos, dur);
-    else
-        emit playbackFinished(pos, dur);
+    emit playbackEnded(pos, dur, reason);
 }
 
 void MpvController::sendCommand(const QJsonArray &args) {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -61,14 +61,17 @@ signals:
     void positionChanged(int ms);
     void durationChanged(int ms);
     void playlistPosChanged(int pos);
-    // Emitted when mpv exits because the user quit/stopped playback before the end.
-    void playbackFinished(int finalPositionMs, int finalDurationMs);
-    // Emitted when mpv exits because the file played to its natural end (mpv's
-    // end-file event reported reason "eof"). Used to trigger autoplay-next.
-    void playbackFinishedNaturally(int finalPositionMs, int finalDurationMs);
-    // Emitted when mpv exits with an error (code 2 — file could not be played).
-    // Player.qml uses this to retry with transcoding.
-    void playbackFailed();
+    // Emitted exactly once when mpv exits, with the reason it ended:
+    //   "eof"     — file played to its natural end. (What a module does with this
+    //               is its own concern.  as an example: Plex may autoplay the next episode)
+    //   "stopped" — user quit/stopped before the end (also the safe default for a
+    //               crash/kill with no end-file event).
+    //   "failed"  — mpv exited with an error (code 2 — file could not be played;
+    //               Up to the module as to when/how to use; for example Plex retries when transcoding).
+    // A single signal (rather than one per reason) is deliberate: a Player view
+    // connects one handler and branches on `reason`, so it can never silently drop
+    // a case the way an unhandled per-reason signal would.
+    void playbackEnded(int finalPositionMs, int finalDurationMs, const QString &reason);
 
 private slots:
     void onProcessFinished();
@@ -80,7 +83,7 @@ private:
     enum class VideoProfile { Pi3, Pi4, PiFullKms, Generic };
 
     void sendCommand(const QJsonArray &args);
-    void doHeadlessRestore(int pos, int dur, bool naturalEof);
+    void doHeadlessRestore(int pos, int dur, const QString &reason);
     bool detectHeadlessMode() const;
     VideoProfile detectVideoProfile() const;
     // Appends the profile-specific --vo/--gpu-context/--hwdec flags (honouring the


### PR DESCRIPTION
## Summary

Fixes: https://github.com/anthonycaccese/240-MP/issues/68

After "playbackFinishedNaturally" was added to the Plex module for handling auto play next episode (https://github.com/anthonycaccese/240-MP/pull/33) I missed handling it in Local Files module.  

Because of that; goBack() never ran and the app froze when playback of a video in local files ended on its own (user quit worked well and loop too so the freeze was only on natural playback end). 

So this fixes that and also refactors the three mpv exit signals (playbackFinished / playbackFinishedNaturally / playbackFailed) into one playbackEnded(pos, dur, reason)

With this a view can connect to a single handler now and can't silently drop a case (so no more freeze possibility for future cases as long as playbackEnded is used). 

This migrates Plex, Local Files, and Ambient Mode to the new logic.

FYI: @danhunsaker, @tmcleroy, @Biduleman... I apologize for missing this before but the good news is it helped harden things a bit, so hopefully this consolidated approach for playbackEnded simplifies things for any playback complete logic you may try out  in the future.  @RP2, this will need updating your Jellyfin PR likely, I'll take a look this week.

## AI involvement

Used to plan the refactor of playbackFinished / playbackFinishedNaturally / playbackFailed into playbackEnded

## Testing

Tested on RPi and MacOS for the following use cases:
- Local Files: Direct file playback (Loop off) = exits back to 240-MP correctly now
- Local Files: Direct file playback (Loop on) = works as previously, continues to loop until user exit
- Local Files: Playlist playback (Loop off) = exits back to 240-MP correctly now
- Local Files: Playlist playback (Loop on) = works as previously, continues to loop until user exit
- Plex: Episode (autoplay off) = works as previously, exits back to to item.qml
- Plex: Episode (autoplay off) = works as previously, moves to next episode until end of season or user quit
- Plex: Movie = works as previously, exits back to to item.qml
- Ambient Mode = works as previously, continues to loop until user exit

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)