### PR TITLE
Maintain crop setting across autoplay-next Plex episodes

### DIFF
--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -44,6 +44,10 @@ FocusScope {
 
     property int lastKnownPositionMs: 0
     property int lastKnownDurationMs: 0
+    // Live mpv crop (panscan, 0..1) set via the OSC CROP button. Tracked so it can
+    // be carried into the next episode — autoplay-next spawns a fresh mpv per episode,
+    // which would otherwise reset the crop the viewer chose.
+    property real lastKnownCrop: 0
 
     focus: true
 
@@ -195,16 +199,21 @@ FocusScope {
         startTimer.restart()
     }
 
-    function doStartPlayback(offsetMs) {
+    // crop (panscan 0..1) launches mpv pre-cropped — used to carry the OSC CROP
+    // selection into an autoplay-advanced episode. Defaults to 0 (no crop).
+    function doStartPlayback(offsetMs, crop) {
+        crop = crop || 0
         if (isTranscoding) {
             // Transcode covers the full timeline (requested at offset 0), so seek mpv
             // to the resume point. This keeps everything before offsetMs seekable, so
             // the user can rewind past the resume point.
-            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0, 0, -1, [], false, -1, 0.0, plexToken)
+            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0, 0, -1, [], false, -1, 0.0, plexToken,
+                                       false, "", false, crop)
         } else {
             var sub = buildSubArgs()
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                       audioIdx + 1, sub.track, sub.urls, false, -1, 0.0, plexToken)
+                                       audioIdx + 1, sub.track, sub.urls, false, -1, 0.0, plexToken,
+                                       false, "", false, crop)
         }
     }
 
@@ -229,11 +238,13 @@ FocusScope {
         function onErrorOccurred(msg) { console.log("[Player] Backend error: " + msg) }
         function onStreamUrlReady(url, plexToken) {
             if (pendingNextEpisode) {
-                // Stream URL for the auto-advanced next episode just arrived.
+                // Stream URL for the auto-advanced next episode just arrived. Carry
+                // the crop from the episode we just finished so the viewer's CROP
+                // choice survives the fresh mpv launch.
                 pendingNextEpisode = false
                 playerRoot.streamUrl = url
                 playerRoot.plexToken = plexToken
-                doStartPlayback(0)
+                doStartPlayback(0, lastKnownCrop)
                 return
             }
             if (pendingRetryTranscode) {
@@ -338,6 +349,9 @@ FocusScope {
         }
         function onDurationChanged(ms) {
             if (ms > 0) playerRoot.lastKnownDurationMs = ms
+        }
+        function onCropChanged(value) {
+            playerRoot.lastKnownCrop = value
         }
 
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -73,6 +73,7 @@ MpvController::MpvController(const QString &appRoot, AppCore *appCore, QObject *
         sendCommand({"observe_property", 1, "time-pos"});
         sendCommand({"observe_property", 2, "duration"});
         sendCommand({"observe_property", 3, "playlist-pos"});
+        sendCommand({"observe_property", 4, "panscan"});
     });
     connect(m_ipc, &QLocalSocket::readyRead, this, &MpvController::onIpcReadyRead);
 
@@ -106,7 +107,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
                                  const QStringList &subFiles, bool loop,
                                  int playlistStart, float transcodeOffsetSec,
                                  const QString &plexToken, bool muteAudio,
-                                 const QString &oscMode, bool shuffle) {
+                                 const QString &oscMode, bool shuffle, float crop) {
     if (m_process) {
         m_process->disconnect();
         if (m_process->state() != QProcess::NotRunning) {
@@ -123,6 +124,10 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     m_duration    = 0;
     m_playlistPos = -1;
     m_lastEndFileReason.clear();
+    // Reflect the launch crop immediately; mpv re-reports it once it connects and
+    // observes "panscan". Without this the property keeps the prior session's value
+    // until the new mpv attaches, briefly mismatching reality.
+    if (m_crop != double(crop)) { m_crop = crop; emit cropChanged(m_crop); }
 
 #ifdef Q_OS_MACOS
     // .app bundles launched via double-click get a minimal PATH that excludes
@@ -196,6 +201,12 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
 
     if (transcodeOffsetSec > 0.5f)
         args << QString("--script-opts=transcode-offset=%1").arg(double(transcodeOffsetSec), 0, 'f', 3);
+
+    // Carry the OSC crop (panscan) across a fresh launch — e.g. Plex autoplay-next,
+    // which spawns a new mpv per episode. mpv's default panscan is 0, so only pass
+    // it when cropped to keep the arg list clean.
+    if (crop > 0.001f)
+        args << QString("--panscan=%1").arg(double(crop), 0, 'f', 3);
 
     if (loop)
         args << QStringLiteral("--loop-playlist=inf");
@@ -378,6 +389,8 @@ void MpvController::onIpcReadyRead() {
         } else if (name == "playlist-pos") {
             m_playlistPos = int(val);
             emit playlistPosChanged(m_playlistPos);
+        } else if (name == "panscan") {
+            if (m_crop != val) { m_crop = val; emit cropChanged(m_crop); }
         }
     }
 }

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -28,6 +28,9 @@ class MpvController : public QObject {
     Q_PROPERTY(int position    READ position    NOTIFY positionChanged)
     Q_PROPERTY(int duration    READ duration    NOTIFY durationChanged)
     Q_PROPERTY(int playlistPos READ playlistPos NOTIFY playlistPosChanged)
+    // Live mpv "panscan" value (0..1) — the OSC CROP button toggles it 0↔1. Exposed
+    // so a module can carry the crop across a fresh mpv launch (Plex autoplay-next).
+    Q_PROPERTY(double crop     READ crop        NOTIFY cropChanged)
 
 public:
     explicit MpvController(const QString &appRoot, AppCore *appCore = nullptr,
@@ -37,6 +40,7 @@ public:
     int position()    const { return m_position;    }
     int duration()    const { return m_duration;    }
     int playlistPos() const { return m_playlistPos; }
+    double crop()     const { return m_crop;        }
 
     Q_INVOKABLE void loadAndPlay(const QString &url, float startSeconds,
                                   int audioTrack, int subTrack,
@@ -47,7 +51,8 @@ public:
                                   const QString &plexToken = {},
                                   bool muteAudio = false,
                                   const QString &oscMode = {},
-                                  bool shuffle = false);
+                                  bool shuffle = false,
+                                  float crop = 0.0f);
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);
@@ -61,6 +66,7 @@ signals:
     void positionChanged(int ms);
     void durationChanged(int ms);
     void playlistPosChanged(int pos);
+    void cropChanged(double value);
     // Emitted exactly once when mpv exits, with the reason it ended:
     //   "eof"     — file played to its natural end. (What a module does with this
     //               is its own concern.  as an example: Plex may autoplay the next episode)
@@ -116,6 +122,7 @@ private:
     int           m_position     = 0;
     int           m_duration     = 0;
     int           m_playlistPos  = -1;
+    double        m_crop         = 0.0;
     bool          m_headlessMode = false;
     int           m_previousVt   = -1;
     int           m_qtDrmFd      = -1;


### PR DESCRIPTION
## Problem

Each Plex episode launches a **fresh mpv subprocess**. The OSC **CROP** button only toggles mpv's runtime `panscan` property, which dies with the process — so when autoplay advanced to the next episode, the viewer's crop was lost and the episode started uncropped. (Local Files is unaffected: it uses a single mpv with an internal playlist, so panscan persists naturally.)

## Fix

Carry the crop across the relaunch, mirroring how the existing audio/subtitle language selection already survives an episode advance.

- **`MpvController`**: observe mpv's `panscan` property over IPC and expose it as a live `crop` QML property; add a `crop` launch parameter that emits `--panscan=<value>` so the next episode comes up already cropped (no flash of uncropped video).
- **`modules/plex/views/Player.qml`**: track the live crop via `onCropChanged` and pass it into the autoplay-advanced episode's launch.

## Behavior

- Crop set on episode 1 carries forward for as long as autoplay keeps advancing.
- Un-cropping mid-binge makes the next episode start uncropped.
- Crop does **not** leak across separate browse-and-play sessions — starting a new item from the menu creates a fresh `Player` with no crop.

## Notes

- The Pi 3 smooth-playback path can't crop at all (existing trade-off behind the Smooth Playback toggle); this applies wherever crop already works (Pi 4, Pi 5, desktop, Pi 3 with Smooth Playback off).

## Provenance & testing

AI-written by Opus 4.8 in Claude Code, then human-tested on macOS and on a Raspberry Pi 3B+ driving a CRT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)