### PR TITLE
feat: add 'start on module' setting to skip module list on startup

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -135,6 +135,7 @@ Window {
     // --- APP-LEVEL NAV STACK ---
     property var appNavStack: []
     property var appCurrentParams: ({})
+    property bool _startupNavigated: false
 
     // --- MODULE LOADER ---
     Loader {
@@ -149,7 +150,21 @@ Window {
             }
         }
 
-        onLoaded: item.forceActiveFocus()
+        onLoaded: {
+            item.forceActiveFocus()
+            if (!root._startupNavigated) {
+                root._startupNavigated = true
+                var entryPoint = appCore.startupModuleEntryPoint()
+                if (entryPoint) {
+                    root.appNavStack.push({
+                        source: moduleLoader.source,
+                        params: root.appCurrentParams,
+                        listState: {}
+                    })
+                    moduleLoader.setSource(entryPoint, { "navParams": {} })
+                }
+            }
+        }
 
         Connections {
             target: moduleLoader.item

--- a/src/AppCore.cpp
+++ b/src/AppCore.cpp
@@ -337,3 +337,16 @@ QString AppCore::parentDirectory(const QString &path) {
 QString AppCore::homePath() {
     return QDir::homePath();
 }
+
+QString AppCore::startupModuleEntryPoint() const {
+    QJsonObject config = loadConfig();
+    QString moduleName = config["app"].toObject()["startup_module"].toString();
+    if (moduleName.isEmpty() || moduleName == "None") return {};
+
+    for (const auto &m : m_modules) {
+        if (m.name == moduleName) {
+            return QStringLiteral("modules/%1/%2").arg(m.folder, m.entryQml);
+        }
+    }
+    return {};
+}

--- a/src/AppCore.cpp
+++ b/src/AppCore.cpp
@@ -73,6 +73,19 @@ void AppCore::saveConfig(const QJsonObject &config) const {
     f.write(QJsonDocument(config).toJson(QJsonDocument::Indented));
 }
 
+bool AppCore::isModuleEnabled(const ModuleEntry &m, const QJsonObject &modulesConfig) const {
+    QJsonObject mCfg = modulesConfig[m.id].toObject();
+    bool manifestDefault = true;
+    for (const auto &sv : m.settings) {
+        QVariantMap s = sv.toMap();
+        if (s["key"].toString() == "enabled") {
+            manifestDefault = s["default"].toString().toUpper() != "OFF";
+            break;
+        }
+    }
+    return mCfg.contains("enabled") ? mCfg["enabled"].toBool(true) : manifestDefault;
+}
+
 // ---------------------------------------------------------------------------
 // Q_INVOKABLE slots
 // ---------------------------------------------------------------------------
@@ -84,17 +97,7 @@ void AppCore::scan_for_modules() {
     QVariantList displayData;
     for (const auto &m : m_modules) {
         // Respect "enabled" setting; fall back to manifest default, then true
-        QJsonObject mCfg = modulesConfig[m.id].toObject();
-        bool manifestDefault = true;
-        for (const auto &sv : m.settings) {
-            QVariantMap s = sv.toMap();
-            if (s["key"].toString() == "enabled") {
-                manifestDefault = s["default"].toString().toUpper() != "OFF";
-                break;
-            }
-        }
-        bool enabled = mCfg.contains("enabled") ? mCfg["enabled"].toBool(true) : manifestDefault;
-        if (!enabled) {
+        if (!isModuleEnabled(m, modulesConfig)) {
             qDebug("[AppCore] Module disabled: %s", qPrintable(m.name));
             continue;
         }
@@ -270,12 +273,14 @@ QString AppCore::get_module_auth_state(const QString &moduleId) {
 }
 
 QVariant AppCore::get_installed_modules() {
+    QJsonObject modulesConfig = loadConfig()["modules"].toObject();
     QVariantList result;
     for (const auto &m : m_modules) {
         result.append(QVariantMap{
             {"id",           m.id},
             {"name",         m.name},
-            {"has_settings", !m.settings.isEmpty()}
+            {"has_settings", !m.settings.isEmpty()},
+            {"enabled",      isModuleEnabled(m, modulesConfig)}
         });
     }
     return result;
@@ -340,11 +345,15 @@ QString AppCore::homePath() {
 
 QString AppCore::startupModuleEntryPoint() const {
     QJsonObject config = loadConfig();
-    QString moduleName = config["app"].toObject()["startup_module"].toString();
-    if (moduleName.isEmpty() || moduleName == "None") return {};
+    // Keyed by module id (robust to display-name changes); "None"/empty = disabled.
+    QString moduleId = config["app"].toObject()["startup_module"].toString();
+    if (moduleId.isEmpty() || moduleId == "None") return {};
 
+    QJsonObject modulesConfig = config["modules"].toObject();
     for (const auto &m : m_modules) {
-        if (m.name == moduleName) {
+        // Skip a disabled module so we never auto-launch into one that isn't
+        // present in the module list (e.g. set as startup, then disabled later).
+        if (m.id == moduleId && isModuleEnabled(m, modulesConfig)) {
             return QStringLiteral("modules/%1/%2").arg(m.folder, m.entryQml);
         }
     }

--- a/src/AppCore.h
+++ b/src/AppCore.h
@@ -44,6 +44,7 @@ public:
     Q_INVOKABLE QVariantList listDirectories(const QString &path);
     Q_INVOKABLE QString parentDirectory(const QString &path);
     Q_INVOKABLE QString homePath();
+    Q_INVOKABLE QString startupModuleEntryPoint() const;
     Q_INVOKABLE QString get_module_auth_state(const QString &moduleId);
 
     // Registers a module backend: stores it for action routing, exposes it to QML under

--- a/src/AppCore.h
+++ b/src/AppCore.h
@@ -71,6 +71,9 @@ private:
     QJsonObject loadConfig() const;
     void saveConfig(const QJsonObject &config) const;
     QString moduleIdForBackend(QObject *backend) const;
+    // Resolve a module's enabled state: config override if present, else the
+    // manifest default (an "enabled" setting whose default is "OFF"), else true.
+    bool isModuleEnabled(const ModuleEntry &m, const QJsonObject &modulesConfig) const;
 
     QString m_appRoot;
     QString m_dataRoot;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -52,6 +52,21 @@ FocusScope {
             moduleId: ""
         })
 
+        // Start on Module — pick a module to auto-launch into on startup
+        var moduleOpts = ["None"]
+        for (var mi = 0; mi < installedModules.length; mi++) {
+            moduleOpts.push(installedModules[mi].name)
+        }
+        items.push({
+            type: "list_single",
+            key: "startup_module",
+            label: "Start on Module",
+            options: moduleOpts,
+            value: appSettings["startup_module"] || "None",
+            description: "Directly launch into a specific module on startup",
+            moduleId: ""
+        })
+
         // Smooth Playback — only shown on devices whose smooth decode path can't
         // crop/zoom (the Pi 3 overlay path). Default ON; turning it off restores the
         // crop-capable video output. Takes effect on the next video.

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -52,17 +52,27 @@ FocusScope {
             moduleId: ""
         })
 
-        // Start on Module — pick a module to auto-launch into on startup
-        var moduleOpts = ["None"]
+        // Start on Module — pick a module to auto-launch into on startup.
+        // Only present enabled modules as options so disabled ones won't display.
+        // The setting is keyed by module id and the picker shows the display name
+        // If the stored id isn't an enabled module, the display falls back to None.
+        var moduleOpts = ["None"] // display labels
+        var moduleVals = ["None"] // stored values (module ids)
+        var startupId = appSettings["startup_module"] || "None"
+        var startupValue = "None"
         for (var mi = 0; mi < installedModules.length; mi++) {
+            if (!installedModules[mi].enabled) continue
             moduleOpts.push(installedModules[mi].name)
+            moduleVals.push(installedModules[mi].id)
+            if (installedModules[mi].id === startupId) startupValue = installedModules[mi].name
         }
         items.push({
             type: "list_single",
             key: "startup_module",
             label: "Start on Module",
             options: moduleOpts,
-            value: appSettings["startup_module"] || "None",
+            values: moduleVals,
+            value: startupValue,
             description: "Directly launch into a specific module on startup",
             moduleId: ""
         })
@@ -173,12 +183,14 @@ FocusScope {
                 var idx = opts.indexOf(row.value)
                 var newIdx = (idx - 1 + opts.length) % opts.length
                 var newVal = opts[newIdx]
+                // Display the label; persist the parallel value when one exists.
+                var savedVal = row.values ? row.values[newIdx] : newVal
                 var updated = settingsItems.slice()
                 updated[currentIndex] = Object.assign({}, row, { value: newVal })
                 var savedIndex = currentIndex
                 settingsItems = updated
                 currentIndex = savedIndex
-                appCore.save_setting(row.moduleId, row.key, newVal)
+                appCore.save_setting(row.moduleId, row.key, savedVal)
             }
         }
 
@@ -189,12 +201,14 @@ FocusScope {
                 var idx = opts.indexOf(row.value)
                 var newIdx = (idx + 1) % opts.length
                 var newVal = opts[newIdx]
+                // Display the label; persist the parallel value when one exists.
+                var savedVal = row.values ? row.values[newIdx] : newVal
                 var updated = settingsItems.slice()
                 updated[currentIndex] = Object.assign({}, row, { value: newVal })
                 var savedIndex = currentIndex
                 settingsItems = updated
                 currentIndex = savedIndex
-                appCore.save_setting(row.moduleId, row.key, newVal)
+                appCore.save_setting(row.moduleId, row.key, savedVal)
             }
         }
 


### PR DESCRIPTION
## Summary

Closes #54, adds an app-level setting to choose a default startup module. When set, the app skips the module list and launches directly into the chosen module. Pressing ESC/Back returns to the module list as normal. Instead of navigating from ModuleList's modulesLoaded signal (which fires during component initialization before the Loader is ready), the entry point is resolved via a C++ method and checked in the Loader's onLoaded handler after the view is fully constructed.

Changes:
- src/AppCore.h / src/AppCore.cpp - new Q_INVOKABLE startupModuleEntryPoint() resolves the saved module name to its entry point path
- Main.qml - checks the entry point in the Loader's onLoaded and auto-navigates (once per session, guarded by _startupNavigated flag)
- views/Settings.qml - new "Start on Module" list_single setting under APPLICATION section, dynamically populated from installed modules

## AI involvement

Entire implementation was AI-generated (opencode go with deepseek-v4-flash, kimi-k2.7-code, and mimo-v2.5). Human testing covered: setting the preference, restarting the app, verifying the target module loads directly, pressing ESC/Back to return to the module list, and confirming "None" preserves existing behavior.

## Testing

- Platform(s) tested: Desktop Arch Linux
- Display / output tested: HDMI desktop, DisplayPort desktop

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
