### PR TITLE
feat: Support loading *multiple* custom themes

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -94,7 +94,7 @@ Window {
 
         var cThemes = appCore.getCustomColorSchemes()
         if (Object.keys(cThemes).length > 0) {
-            var t = Object.assign({}, themes)
+            var t = Object.assign({}, themes, root.allThemes)
             for (var cTheme in cThemes) {
                 if (Object.keys(cThemes[cTheme]).length === 5) {
                     t[cTheme] = cThemes[cTheme]
@@ -105,7 +105,7 @@ Window {
 
         var custom = appCore.getCustomColorScheme()
         if (Object.keys(custom).length === 5) {
-            var t = Object.assign({}, themes)
+            var t = Object.assign({}, themes, root.allThemes)
             t["Custom"] = custom
             root.allThemes = t
         }

--- a/Main.qml
+++ b/Main.qml
@@ -92,6 +92,17 @@ Window {
     Component.onCompleted: {
         var cfg = appCore.get_settings()
 
+        var cThemes = appCore.getCustomColorSchemes()
+        if (Object.keys(cThemes).length > 0) {
+            var t = Object.assign({}, themes)
+            for (var cTheme in cThemes) {
+                if (Object.keys(cThemes[cTheme]).length === 5) {
+                    t[cTheme] = cThemes[cTheme]
+                }
+            }
+            root.allThemes = t
+        }
+
         var custom = appCore.getCustomColorScheme()
         if (Object.keys(custom).length === 5) {
             var t = Object.assign({}, themes)

--- a/src/AppCore.cpp
+++ b/src/AppCore.cpp
@@ -286,22 +286,10 @@ QVariant AppCore::get_installed_modules() {
     return result;
 }
 
-QVariantMap AppCore::getCustomColorScheme() const {
+QVariantMap AppCore::importColorScheme(QJsonObject &obj) const {
     static const QStringList kRequiredKeys = {"primary","secondary","tertiary","surface","accent"};
     static const QRegularExpression kHexColor("^#[0-9A-Fa-f]{6}$");
 
-    QFile f(m_dataRoot + "/custom_color_scheme.json");
-    if (!f.exists()) return {};
-    if (!f.open(QIODevice::ReadOnly)) return {};
-
-    QJsonParseError err;
-    QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
-    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
-        qWarning("[AppCore] custom_color_scheme.json: invalid JSON");
-        return {};
-    }
-
-    QJsonObject obj = doc.object();
     QVariantMap result;
     for (const QString &key : kRequiredKeys) {
         if (!obj.contains(key) || !obj[key].isString()) {
@@ -315,6 +303,55 @@ QVariantMap AppCore::getCustomColorScheme() const {
             return {};
         }
         result[key] = value;
+    }
+    return result;
+}
+
+QVariantMap AppCore::getCustomColorScheme() const {
+    QFile f(m_dataRoot + "/custom_color_scheme.json");
+    if (!f.exists()) return {};
+    if (!f.open(QIODevice::ReadOnly)) return {};
+
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qWarning("[AppCore] custom_color_scheme.json: invalid JSON");
+        return {};
+    }
+
+    QJsonObject obj = doc.object();
+    QVariantMap result = this->importColorScheme(obj);
+    return result;
+}
+
+QVariantMap AppCore::getCustomColorSchemes() const {
+    static const QRegularExpression validThemeName("^[\\w\\d !#-/:-@\\[-_{-~]{3,28}$", QRegularExpression::CaseInsensitiveOption);
+
+    QFile f(m_dataRoot + "/custom_color_schemes.json");
+    if (!f.exists()) return {};
+    if (!f.open(QIODevice::ReadOnly)) return {};
+
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qWarning("[AppCore] custom_color_schemes.json: invalid JSON");
+        return {};
+    }
+
+    QJsonObject obj = doc.object();
+    QVariantMap result;
+    for (const QString &theme : obj.keys()) {
+        if (!validThemeName.match(theme).hasMatch()) {
+            qWarning("[AppCore] custom_color_schemes.json: invalid theme name '%s' detected - only 28 letters, numbers, and ASCII symbols (other than backtick and double-quote)",
+                    qPrintable(theme));
+            continue;
+        }
+        QJsonObject tObj = obj[theme].toObject();
+        QVariantMap tResult = this->importColorScheme(tObj);
+        if (tResult.count() == 5) {
+            result[theme] = tResult;
+            qDebug("[AppCore] custom_color_schemes.json: loaded '%s' custom theme", qPrintable(theme));
+        }
     }
     return result;
 }

--- a/src/AppCore.h
+++ b/src/AppCore.h
@@ -41,6 +41,7 @@ public:
     Q_INVOKABLE void invoke_module_action(const QString &moduleId, const QString &slotName);
     Q_INVOKABLE QVariant get_installed_modules();
     Q_INVOKABLE QVariantMap getCustomColorScheme() const;
+    Q_INVOKABLE QVariantMap getCustomColorSchemes() const;
     Q_INVOKABLE QVariantList listDirectories(const QString &path);
     Q_INVOKABLE QString parentDirectory(const QString &path);
     Q_INVOKABLE QString homePath();
@@ -74,6 +75,7 @@ private:
     // Resolve a module's enabled state: config override if present, else the
     // manifest default (an "enabled" setting whose default is "OFF"), else true.
     bool isModuleEnabled(const ModuleEntry &m, const QJsonObject &modulesConfig) const;
+    QVariantMap importColorScheme(QJsonObject &obj) const;
 
     QString m_appRoot;
     QString m_dataRoot;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -40,6 +40,14 @@ FocusScope {
 
         // APPLICATION section
         var colorOpts = ["Video 1","Late Night","Synthwave","Terminal","T-120","Amber","Kinescope","SMPTE ECR 1-1978"]
+        // Adding a new approach to add multiple custom themes at once
+        var cThemes = appCore.getCustomColorSchemes()
+        if (Object.keys(cThemes).length > 0) {
+            for (var cTheme in cThemes) {
+                if (Object.keys(cThemes[cTheme]).length === 5) colorOpts.push(cTheme)
+            }
+        }
+        // Still support the single-theme approach
         var custom = appCore.getCustomColorScheme()
         if (Object.keys(custom).length === 5) colorOpts.push("Custom")
         items.push({

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -44,12 +44,12 @@ FocusScope {
         var cThemes = appCore.getCustomColorSchemes()
         if (Object.keys(cThemes).length > 0) {
             for (var cTheme in cThemes) {
-                if (Object.keys(cThemes[cTheme]).length === 5) colorOpts.push(cTheme)
+                if (!colorOpts.includes(cTheme) && Object.keys(cThemes[cTheme]).length === 5) colorOpts.push(cTheme)
             }
         }
         // Still support the single-theme approach
         var custom = appCore.getCustomColorScheme()
-        if (Object.keys(custom).length === 5) colorOpts.push("Custom")
+        if (!colorOpts.includes("Custom") && Object.keys(custom).length === 5) colorOpts.push("Custom")
         items.push({
             type: "list_single",
             key: "color_scheme",


### PR DESCRIPTION
## Summary

The custom theme support is pretty nice, but does have the drawback of assuming that users will either never want to change their theme once set, or at least that they are happy to edit hex codes any time they want to switch. This change adds support for an alternate config file that supports multiple custom themes being loaded simultaneously, complete with custom names. It uses the same format, with just an extra layer to provide names as keys. It does *not* remove support for the existing single-Custom configuration.

The actual code changes are fairly simple. One new method in `AppCore` to load the themes from disk, a new codeblock in `Main.qml` to call it and add the themes to the UI, and one new codeblock in `Settings.qml` to expand the list to be able to select them. Validation in `AppCore` includes a regex to limit supported characters and lengths, in addition to the existing validation logic from the single-theme config - which has been refactored, to avoid unnecessary code duplication, into a separate (private) method.

## AI involvement

No AI used.

## Testing

- Platform(s) tested: Pi 5
- Display / output tested: HDMI
- Custom Color Schemes Config Tested:
  ```json
  {
      "Abberation": {
          "primary": "#d8544f",
          "secondary": "#efa44d",
          "tertiary": "#6b6e9c",
          "surface": "#2b2d3b",
          "accent": "#8e5f95"
      },
      "Lo-Fi 90s Lighter": {
          "primary": "#f9c54e",
          "secondary": "#e76e50",
          "tertiary": "#f4a462",
          "surface": "#274754",
          "accent": "#2a9d90"
      },
      "Deliberately-Too-Long Theme Name": {
          "primary": "#66ff66",
          "secondary": "#33ff33",
          "tertiary": "#00ff00",
          "surface": "#666666",
          "accent": "#ff6666"
      },
      "\"`ILLEGAL`\" Theme Name": {
          "primary": "#ff6666",
          "secondary": "#ff3333",
          "tertiary": "#ff0000",
          "surface": "#333333",
          "accent": "#6666ff"
      }
  }
  ```

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)