### PR TITLE
fix: settings - Support module-level help text

### DIFF
--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -321,6 +321,33 @@ FocusScope {
         }
     }
 
+    // --- HELP TEXT --- (shown when a focused row has a description)
+    Rectangle {
+        id: rowHelpBackground
+        property var currentRow: moduleSettingsRoot.schemaItems[settingsList.currentIndex]
+        visible: !!(currentRow && currentRow.description)
+        color: root.accentColor
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1583333 //76
+        anchors.leftMargin: root.sw * 0.125 //80
+        width: root.sw * 0.75 //480
+        height: root.sh * 0.0583333 //28
+        clip: true
+        Text {
+            id: rowHelp
+            text: (rowHelpBackground.currentRow && rowHelpBackground.currentRow.description) || ""
+            color: root.surfaceColor
+            font.family: root.globalFont
+            font.pixelSize: root.sh * 0.0291667 //14
+            wrapMode: Text.WordWrap
+            anchors.fill: parent
+            anchors.margins: root.sw * 0.0125 //6
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+
     // --- FOOTER ---
     Text {
         id: footer


### PR DESCRIPTION
## Summary

The new settings "help" feature is currently only available on the main Settings screen. This limits the ability to assist users with more-obscure settings within module settings pages, so I went ahead and added support for module settings as well.

~~Also tweaked the display sizing a bit to support `description` text longer (or shorter) than two lines. It doesn't take wrapping into account at the moment, though, so it's recommended to keep individual help lines short.~~

## AI involvement

No AI used.

## Testing

- Platform(s) tested: Pi 5
- Display / output tested: HDMI

Added a `description` value to `local_files.auto_subtitles`. This change is not included here since it isn't directly related, and makes more sense in another already-open PR or two.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)