### PR TITLE
fix: local files - auto subtitle help text length

### DIFF
--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -43,7 +43,7 @@
       "options_source": "dynamic",
       "options_slot": "get_auto_subtitles_options",
       "default": "forced",
-      "description": "Whether to automatically show subtitles when a video starts.\n[FORCED ONLY] displays for foreign dialogue only, when available."
+      "description": "Choose to automatically show subtitles when a video starts.\n[FORCED ONLY] displays for foreign dialogue only."
     },
     {
       "key": "sub_lang",


### PR DESCRIPTION
## Summary

Shortens the `auto show subtitle` help text to fit on 2 lines (sorry I missed testing this on the CRT previously)

## AI involvement

None

## Testing

- Platform(s) tested: MacOS, RPi
- Display / output tested: Monitor, CRT

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
