### PR TITLE
fix: settings - add back soft guard for start on

### DIFF
--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -68,20 +68,12 @@ FocusScope {
         var moduleVals = ["None"] // stored values (module ids)
         var startupId = appSettings["startup_module"] || "None"
         var startupValue = "None"
-        var foundMatch = false
         for (var mi = 0; mi < installedModules.length; mi++) {
             if (!installedModules[mi].enabled) continue
             moduleOpts.push(installedModules[mi].name)
             moduleVals.push(installedModules[mi].id)
-            if (installedModules[mi].id === startupId) {
-                startupValue = installedModules[mi].name
-                foundMatch = true
-            }
+            if (installedModules[mi].id === startupId) startupValue = installedModules[mi].name
         }
-        // If the stored module id is no longer enabled, reset so the config
-        // stays in sync with what the picker shows.
-        if (startupId !== "None" && !foundMatch)
-            appCore.save_setting("", "startup_module", "None")
         items.push({
             type: "list_single",
             key: "startup_module",


### PR DESCRIPTION
## Summary

I aim to keep explicit writes to config only on direct user action on a given setting.  in this case we have soft guard in place to work if a user happens to disable a module they have set as their start up so that if that was a mistake the setting is already there when they re-enable.  otherwise protected via a soft guard.

## AI involvement

None used

## Testing

tested on both macOS and RPi, set a module to start on, confirmed it displayed during start up, disabled the module, confirmed soft guard worked and prevented that module from starting, re-enabled the module confimred start up into that module worked again.  

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
