### PR TITLE
feat: settings - auto crop

### DIFF
--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -256,6 +256,15 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     if (QUrl(url).host().endsWith(QStringLiteral(".plex.direct")))
         args << QStringLiteral("--tls-verify=no");
 
+    // Auto Crop: start with panscan=1 unless the current decode path can't crop.
+    // The Pi3 overlay (smooth) path blanks video under panscan, so suppress there —
+    // matching the 1080p Playback trade-off. The OSC CROP button still toggles live.
+    if (autoCropEnabled()) {
+        const bool cropSafe = !(m_videoProfile == VideoProfile::Pi3 && smoothPlaybackEnabled());
+        if (cropSafe)
+            args << QStringLiteral("--panscan=1");
+    }
+
     m_process = new QProcess(this);
     m_process->setProcessChannelMode(QProcess::MergedChannels);
     connect(m_process,
@@ -602,6 +611,15 @@ bool MpvController::smoothPlaybackEnabled() const {
     if (!v.isValid() || v.toString().isEmpty())
         return true;
     return v.toString().compare(QStringLiteral("Off"), Qt::CaseInsensitive) != 0;
+}
+
+bool MpvController::autoCropEnabled() const {
+    // Default OFF: only an explicit "On" opts in. Stored by Settings as a string
+    // ("On"/"Off") via the list_single row, so compare on the string form.
+    if (!m_appCore)
+        return false;
+    const QVariant v = m_appCore->get_setting(QString(), "auto_crop");
+    return v.toString().compare(QStringLiteral("On"), Qt::CaseInsensitive) == 0;
 }
 
 bool MpvController::hasSmoothPlaybackTradeoff() const {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -94,6 +94,9 @@ private:
     // App-level "smooth_playback" setting (default ON). On the Pi 3 this selects the
     // smooth zero-copy overlay path; turning it OFF restores the crop-capable scaler path.
     bool smoothPlaybackEnabled() const;
+    // App-level "auto_crop" setting (default OFF). When ON, playback starts with
+    // panscan=1 so video fills a CRT/4:3 screen by default (still toggleable live).
+    bool autoCropEnabled() const;
     int  getActiveVt() const;
     int  findFreeVt() const;
     int  findQtDrmFd() const;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -108,6 +108,18 @@ FocusScope {
             })
         }
 
+        // Auto Crop — default crop (panscan) state for every video. Off by default;
+        // crop can still be toggled live during playback via the mpv OSC.
+        items.push({
+            type: "list_single",
+            key: "auto_crop",
+            label: "Auto Crop",
+            options: ["Off", "On"],
+            value: appSettings["auto_crop"] || "Off",
+            description: "[ON] Video starts cropped to fill screen\n[OFF] Video starts at its original aspect ratio",
+            moduleId: ""
+        })
+
         // MODULES section — only show modules with has_settings
         var hasModuleSettings = false
         for (var i = 0; i < installedModules.length; i++) {


### PR DESCRIPTION
## Summary

Addresses: https://github.com/anthonycaccese/240-MP/issues/77

1. views/Settings.qml — added an Auto Crop list_single toggle (options ["Off", "On"], default Off) right after the smooth-playback block.
2. src/player/MpvController.h — declared bool autoCropEnabled() const; next to smoothPlaybackEnabled().
3. src/player/MpvController.cpp — added an autoCropEnabled() helper (mirroring smoothPlaybackEnabled(), default OFF and reads the app-level auto_crop string). it injects --panscan=1 inside loadAndPlay() in the shared per-playback block and it has a guard for the cropSafe check so it's suppressed on the Pi3 when smooth playback is turned on (which should protect from users getting into an odd state on the pi3)

Since every playback start funnels through loadAndPlay, this covers Local Files, Plex, Jellyfin, Ambient Mode, transcode retries, and autoplay-next use case. Plus the OSC CROP button still toggles crop off live for in-video adjustments

## AI involvement

Used to validate the approach and the cleanest place to add this logic without regressions to each module

## Testing

Tested on MacOS and RPi across all modules on a modern tv and CRT.  Confirmed on Pi3 that the setting only takes effect when 1080p playback is turned off.  

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
