### PR TITLE
fix: settings - help text ui tweaks

### DIFF
--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -326,7 +326,8 @@ FocusScope {
         id: rowHelpBackground
         property var currentRow: moduleSettingsRoot.schemaItems[settingsList.currentIndex]
         visible: !!(currentRow && currentRow.description)
-        color: root.accentColor
+        property color baseColor: root.primaryColor
+        color: Qt.rgba(baseColor.r, baseColor.g, baseColor.b, 0.2)
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.bottomMargin: root.sh * 0.1583333 //76
@@ -337,7 +338,7 @@ FocusScope {
         Text {
             id: rowHelp
             text: (rowHelpBackground.currentRow && rowHelpBackground.currentRow.description) || ""
-            color: root.surfaceColor
+            color: root.primaryColor
             font.family: root.globalFont
             font.pixelSize: root.sh * 0.0291667 //14
             wrapMode: Text.WordWrap

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -334,7 +334,8 @@ FocusScope {
         id: rowHelpBackground
         property var currentRow: settingsRoot.settingsItems[settingsList.currentIndex]
         visible: !!(currentRow && currentRow.description)
-        color: root.accentColor
+        property color baseColor: root.primaryColor
+        color: Qt.rgba(baseColor.r, baseColor.g, baseColor.b, 0.2)
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.bottomMargin: root.sh * 0.1583333 //76
@@ -345,7 +346,7 @@ FocusScope {
         Text {
             id: rowHelp
             text: (rowHelpBackground.currentRow && rowHelpBackground.currentRow.description) || ""
-            color: root.surfaceColor
+            color: root.primaryColor
             font.family: root.globalFont
             font.pixelSize: root.sh * 0.0291667 //14
             wrapMode: Text.WordWrap


### PR DESCRIPTION
## Summary

Tweaks the UI the help text UI just a bit color wise 

## AI involvement

None used

## Testing

Verified on MacOS and RPi via a CRT to check colors

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
