### PR TITLE
Add Plex Live TV channel watching

### DIFF
--- a/modules/plex/views/LiveChannels.qml
+++ b/modules/plex/views/LiveChannels.qml
@@ -1,9 +1,10 @@
 import QtQuick
 import Components
 
-// Main Plex home screen: Continue Watching + library list
+// Live TV channel list. Lists the tunable channels of the server's DVR; selecting
+// one hands off to LivePlayer.qml, which tunes it and can switch channels in place.
 FocusScope {
-    id: browseRoot
+    id: channelsRoot
 
     property var navParams: ({})
     property var navListState: navParams.navListState || ({})
@@ -11,44 +12,29 @@ FocusScope {
     signal navigateTo(string path, var params, var listState)
     signal goBack()
 
-    property var libraries: []
-    property string serverName: ""
-    property string userName: ""
-    // Servers the active user can switch to from the main menu. More than one
-    // means the quick-switch action (◄/►) is offered.
-    property var switchableServers: []
-    property bool canSwitchServer: switchableServers.length > 1
+    property string libraryName: navParams.libraryName || "LIVE TV"
+    property var channels: []
+    property bool loaded: false
 
     Connections {
         target: plexBackend
 
-        function onLibrariesLoaded(items) {
-            browseRoot.libraries = items
+        function onLiveChannelsLoaded(items) {
+            channelsRoot.channels = items
+            channelsRoot.loaded = true
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
-                libraryList.currentIndex = Math.min(restore, items.length - 1)
-                libraryList.positionViewAtIndex(libraryList.currentIndex, ListView.Contain)
+                channelList.currentIndex = Math.min(restore, items.length - 1)
+                channelList.positionViewAtIndex(channelList.currentIndex, ListView.Contain)
             }
         }
 
         function onErrorOccurred(msg) {
-            console.log("[Library] Error: " + msg)
+            console.log("[LiveChannels] Error: " + msg)
         }
     }
 
-    Component.onCompleted: {
-        browseRoot.serverName = plexBackend.get_active_server_name()
-        browseRoot.userName = plexBackend.get_active_user_name()
-        browseRoot.switchableServers = plexBackend.get_switchable_servers()
-        plexBackend.load_libraries()
-    }
-
-    function openServerSwitch() {
-        if (!canSwitchServer) return
-        browseRoot.navigateTo("ServerSelect.qml",
-                              { servers: switchableServers, switching: true },
-                              { currentIndex: libraryList.currentIndex })
-    }
+    Component.onCompleted: plexBackend.load_live_channels()
 
     focus: true
 
@@ -60,17 +46,17 @@ FocusScope {
     AppBar {
         iconSource: moduleRoot.moduleIcon
         title: moduleRoot.moduleName
-        subtitle: browseRoot.serverName + (browseRoot.userName ? " (" + browseRoot.userName + ")" : "")
+        subtitle: channelsRoot.libraryName
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: root.sh * 0.125 //60
         anchors.leftMargin: root.sw * 0.125 //80
     }
 
-    // Loading Indicator
+    // Loading / empty indicator
     Text {
-        visible: libraries.length === 0
-        text: "LOADING..."
+        visible: channels.length === 0
+        text: channelsRoot.loaded ? "NO CHANNELS" : "LOADING..."
         color: root.tertiaryColor
         font.family: root.globalFont
         anchors.centerIn: parent
@@ -79,8 +65,8 @@ FocusScope {
 
     // Body
     ListView {
-        id: libraryList
-        model: libraries
+        id: channelList
+        model: channels
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: root.sh * 0.25 //120
@@ -92,59 +78,41 @@ FocusScope {
 
         Keys.onUpPressed: if (currentIndex > 0) currentIndex--
         Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
-        Keys.onLeftPressed: browseRoot.openServerSwitch()
-        Keys.onRightPressed: browseRoot.openServerSwitch()
 
         Keys.onReturnPressed: {
-            var lib = libraries[currentIndex]
-            if (!lib) return
-
-            if (lib.key === "continue_watching") {
-                browseRoot.navigateTo("Items.qml", {
-                    listType: "continue_watching",
-                    title: "CONTINUE WATCHING",
-                    libraryName: lib.title
-                }, { currentIndex: libraryList.currentIndex })
-            } else if (lib.key === "live_tv") {
-                browseRoot.navigateTo("LiveChannels.qml", {
-                    libraryName: lib.title
-                }, { currentIndex: libraryList.currentIndex })
-            } else {
-                browseRoot.navigateTo("Library.qml", {
-                    libraryName: lib.title,
-                    sectionId: lib.sectionId,
-                    sectionType: lib.sectionType
-                }, { currentIndex: libraryList.currentIndex })
-            }
+            if (channels.length === 0) return
+            channelsRoot.navigateTo("LivePlayer.qml", {
+                channel: channels[currentIndex]
+            }, { currentIndex: channelList.currentIndex })
         }
 
         Keys.onPressed: function(event) {
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
-                browseRoot.goBack()
+                channelsRoot.goBack()
                 event.accepted = true
             }
         }
 
         delegate: Item {
-            width: libraryList.width
+            width: channelList.width
             height: root.sh * 0.0583333 //28
 
             Item {
                 id: textClip
-                width: Math.min(rowText.implicitWidth, libraryList.width)
+                width: Math.min(rowText.implicitWidth, channelList.width)
                 height: parent.height
                 clip: true
 
                 Rectangle {
                     color: root.accentColor
                     anchors.fill: rowText
-                    visible: libraryList.currentIndex === index
+                    visible: channelList.currentIndex === index
                 }
 
                 Text {
                     id: rowText
-                    text: modelData.title || ""
-                    color: libraryList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                    text: (modelData.number ? modelData.number + "  " : "") + (modelData.title || "")
+                    color: channelList.currentIndex === index ? root.surfaceColor : root.primaryColor
                     font.family: root.globalFont
                     font.capitalization: Font.AllUppercase
                     anchors.verticalCenter: parent.verticalCenter
@@ -157,7 +125,7 @@ FocusScope {
                 }
 
                 SequentialAnimation {
-                    running: (libraryList.currentIndex === index) &&
+                    running: (channelList.currentIndex === index) &&
                              (rowText.implicitWidth > textClip.width)
                     loops: Animation.Infinite
                     onRunningChanged: if (!running) rowText.x = 0
@@ -177,8 +145,7 @@ FocusScope {
     // Footer
     Text {
         id: footer
-        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":SELECT"
-              + (browseRoot.canSwitchServer ? " " + root.hints.change + ":SERVER" : "")
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":WATCH"
         color: root.tertiaryColor
         font.family: root.globalFont
         anchors.bottom: parent.bottom

--- a/modules/plex/views/LiveChannels.qml
+++ b/modules/plex/views/LiveChannels.qml
@@ -15,6 +15,7 @@ FocusScope {
     property string libraryName: navParams.libraryName || "LIVE TV"
     property var channels: []
     property bool loaded: false
+    property string errorMessage: ""
 
     Connections {
         target: plexBackend
@@ -31,6 +32,8 @@ FocusScope {
 
         function onErrorOccurred(msg) {
             console.log("[LiveChannels] Error: " + msg)
+            channelsRoot.loaded = true
+            channelsRoot.errorMessage = msg
         }
     }
 
@@ -53,13 +56,17 @@ FocusScope {
         anchors.leftMargin: root.sw * 0.125 //80
     }
 
-    // Loading / empty indicator
+    // Loading / empty / error indicator
     Text {
         visible: channels.length === 0
-        text: channelsRoot.loaded ? "NO CHANNELS" : "LOADING..."
+        text: channelsRoot.errorMessage !== "" ? channelsRoot.errorMessage
+              : (channelsRoot.loaded ? "NO CHANNELS" : "LOADING...")
         color: root.tertiaryColor
         font.family: root.globalFont
         anchors.centerIn: parent
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        width: root.sw * 0.6
         font.pixelSize: root.sh * 0.05 //24
     }
 

--- a/modules/plex/views/LivePlayer.qml
+++ b/modules/plex/views/LivePlayer.qml
@@ -113,12 +113,15 @@ FocusScope {
         }
     }
 
-    // Keep-alive: a live tuner is released if the client stops pinging the timeline.
+    // Keep-alive: Plex reaps the DVR grab (and then 404s the stream) if the client
+    // stops reporting the timeline. Ping from the moment we're tuned — not gated on
+    // playbackStarted — since the grab is rolling before mpv reports its first frame.
+    // update_live_timeline no-ops until a channel is tuned.
     Timer {
-        interval: 10000
+        interval: 8000
         repeat:   true
         running:  true
-        onTriggered: if (playbackStarted) plexBackend.update_live_timeline("playing")
+        onTriggered: plexBackend.update_live_timeline("playing")
     }
 
     Component.onCompleted: tune()

--- a/modules/plex/views/LivePlayer.qml
+++ b/modules/plex/views/LivePlayer.qml
@@ -48,6 +48,10 @@ FocusScope {
         mpvController.stop()
     }
 
+    // Forward keys to mpv (the same set Player.qml forwards) so its OSC works on
+    // the Pi, where the Qt app owns the keyboard and relays via sendKey. On desktop
+    // mpv has focus and handles these directly. Up/Down drive the OSC here, not
+    // channel changes — to switch channels the user exits back to the channel list.
     Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
             // Quit mpv; onPlaybackEnded drives the teardown + goBack.
@@ -55,6 +59,18 @@ FocusScope {
             event.accepted = true
         } else if (event.key === Qt.Key_Backspace) {
             mpvController.sendKey("BS")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Up) {
+            mpvController.sendKey("UP")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Down) {
+            mpvController.sendKey("DOWN")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Left) {
+            mpvController.sendKey("LEFT")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Right) {
+            mpvController.sendKey("RIGHT")
             event.accepted = true
         } else if (event.key === Qt.Key_Space) {
             mpvController.sendKey("SPACE")

--- a/modules/plex/views/LivePlayer.qml
+++ b/modules/plex/views/LivePlayer.qml
@@ -88,7 +88,7 @@ FocusScope {
             livePlayerRoot.streamUrl = url
             livePlayerRoot.plexToken = plexToken
             // Live always transcodes (HLS): no separate audio/sub tracks to pick.
-            mpvController.loadAndPlay(url, 0, 0, -1, [], false, -1, 0.0, plexToken)
+            mpvController.loadAndPlay(url, 0, 0, -1, [], [], false, -1, 0.0, plexToken)
         }
 
         function onErrorOccurred(msg) {

--- a/modules/plex/views/LivePlayer.qml
+++ b/modules/plex/views/LivePlayer.qml
@@ -1,0 +1,128 @@
+import QtQuick
+
+// Live TV player. A slimmed sibling of Player.qml — live channels have no
+// resume/duration/seek/autoplay-next semantics, so this drops all of that. It
+// tunes the selected channel, hands the HLS stream to mpv, and keeps the tuner
+// alive with a timeline ping. To watch a different channel the user exits back to
+// the channel list and picks another (in-player channel switching is not wired up
+// yet — pending a maintainer discussion on how to route keys past mpv).
+FocusScope {
+    id: livePlayerRoot
+
+    property var navParams: ({})
+
+    signal navigateTo(string path, var params)
+    signal goBack()
+
+    // The channel to watch: { channelId, number, title }.
+    property var    channel:   navParams.channel || ({})
+
+    property string sessionId:     ""
+    property string streamUrl:     ""
+    property string plexToken:     ""
+    property bool   playbackStarted: false
+    property bool   exiting:        false
+
+    focus: true
+
+    function newSessionId() {
+        var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var id = ""
+        for (var i = 0; i < 12; i++) id += chars[Math.floor(Math.random() * chars.length)]
+        return id
+    }
+
+    // Tune the channel. tune_channel resolves asynchronously through
+    // onStreamUrlReady, which loads the resulting HLS stream into mpv.
+    function tune() {
+        if (!channel.channelId) { goBack(); return }
+        playbackStarted = false
+        sessionId = newSessionId()
+        plexBackend.tune_channel(channel.channelId, sessionId)
+    }
+
+    function teardown() {
+        if (exiting) return
+        exiting = true
+        plexBackend.stop_live_session(sessionId)
+        mpvController.stop()
+    }
+
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+            // Quit mpv; onPlaybackEnded drives the teardown + goBack.
+            mpvController.sendKey("ESC")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Backspace) {
+            mpvController.sendKey("BS")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Space) {
+            mpvController.sendKey("SPACE")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            mpvController.sendKey("ENTER")
+            event.accepted = true
+        }
+    }
+
+    Connections {
+        target: plexBackend
+
+        function onStreamUrlReady(url, plexToken) {
+            livePlayerRoot.streamUrl = url
+            livePlayerRoot.plexToken = plexToken
+            // Live always transcodes (HLS): no separate audio/sub tracks to pick.
+            mpvController.loadAndPlay(url, 0, 0, -1, [], false, -1, 0.0, plexToken)
+        }
+
+        function onErrorOccurred(msg) {
+            console.log("[LivePlayer] Backend error: " + msg)
+            // A tune/stream failure leaves nothing playing — bail back to the list.
+            if (!playbackStarted) { teardown(); goBack() }
+        }
+    }
+
+    Connections {
+        target: mpvController
+
+        function onPositionChanged(ms) {
+            if (ms > 0) livePlayerRoot.playbackStarted = true
+        }
+
+        function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            // Any end (user quit, stream failure, or rare eof) tears down the tuner
+            // and returns to the channel list.
+            teardown()
+            goBack()
+        }
+    }
+
+    // Keep-alive: a live tuner is released if the client stops pinging the timeline.
+    Timer {
+        interval: 10000
+        repeat:   true
+        running:  true
+        onTriggered: if (playbackStarted) plexBackend.update_live_timeline("playing")
+    }
+
+    Component.onCompleted: tune()
+
+    // Black backdrop + loading text, shown until mpv's window takes over (mirrors
+    // Player.qml).
+    Rectangle {
+        anchors.fill: parent
+        color: "black"
+
+        Text {
+            text: "TUNING " + ((livePlayerRoot.channel.number
+                                 ? livePlayerRoot.channel.number + "  " : "")
+                               + (livePlayerRoot.channel.title || "")) + "..."
+            color: "white"
+            font.family: root.globalFont
+            font.capitalization: Font.AllUppercase
+            anchors.centerIn: parent
+            font.pixelSize: root.sh * 0.05 //24
+            visible: !livePlayerRoot.playbackStarted
+        }
+    }
+}

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -1966,25 +1966,48 @@ void PlexBackend::load_live_channels() {
             return;
         }
 
-        // Resolve channel names/numbers from the EPG lineup.
-        QUrl chUrl(uri + "/livetv/epg/lineupchannels");
-        QUrlQuery cq; cq.addQueryItem("lineup", lineup); chUrl.setQuery(cq);
-        auto *chReply = plexGet(chUrl, token);
-        connect(chReply, &QNetworkReply::finished, this, [this, chReply]() {
-            chReply->deleteLater();
-            if (chReply->error() != QNetworkReply::NoError) {
-                emit errorOccurred("LOAD CHANNELS FAILED: " + chReply->errorString()); return;
+        // Resolve channel names/numbers via the EPG media provider's proxied
+        // "lineups/dvr/channels" route — the same one Plex Web uses. PMS forbids
+        // managed/restricted Home users from the raw /livetv/epg/* endpoints (403),
+        // but routes everyone through this provider-proxy path uniformly, so it
+        // works regardless of account type.
+        auto *provReply = plexGet(QUrl(uri + "/media/providers"), token);
+        connect(provReply, &QNetworkReply::finished, this, [this, uri, token, provReply]() {
+            provReply->deleteLater();
+            if (provReply->error() != QNetworkReply::NoError) {
+                emit errorOccurred("LOAD PROVIDERS FAILED: " + provReply->errorString()); return;
             }
-            QByteArray body = chReply->readAll();
-            QJsonObject cmc = QJsonDocument::fromJson(body)
-                              .object()["MediaContainer"].toObject();
-            QVariantList channels;
-            for (const auto &lv : cmc["Lineup"].toArray()) {
-                for (const auto &cv : lv.toObject()["Channel"].toArray()) {
+            QJsonArray providers = QJsonDocument::fromJson(provReply->readAll())
+                                    .object()["MediaContainer"].toObject()["MediaProvider"].toArray();
+            QString providerId;
+            for (const auto &pv : providers) {
+                QJsonObject p = pv.toObject();
+                if (p["protocols"].toString().contains("livetv")) {
+                    providerId = p["identifier"].toString();
+                    break;
+                }
+            }
+            if (providerId.isEmpty()) {
+                qDebug() << "[Plex] No livetv media provider in /media/providers";
+                emit liveChannelsLoaded(QVariantList{});
+                return;
+            }
+
+            auto *chReply = plexGet(QUrl(uri + "/" + providerId + "/lineups/dvr/channels"), token);
+            connect(chReply, &QNetworkReply::finished, this, [this, chReply]() {
+                chReply->deleteLater();
+                if (chReply->error() != QNetworkReply::NoError) {
+                    emit errorOccurred("LOAD CHANNELS FAILED: " + chReply->errorString()); return;
+                }
+                QByteArray body = chReply->readAll();
+                QJsonObject cmc = QJsonDocument::fromJson(body)
+                                  .object()["MediaContainer"].toObject();
+                QVariantList channels;
+                for (const auto &cv : cmc["Channel"].toArray()) {
                     QJsonObject c = cv.toObject();
-                    QString id    = c["key"].toString();
+                    QString id    = c["id"].toString();
                     if (id.isEmpty()) continue;
-                    QString number = c["channelVcn"].toString();
+                    QString number = c["vcn"].toString();
                     QString name   = c["title"].toString(c["callSign"].toString());
                     channels.append(QVariantMap{
                         {"channelId", id},
@@ -1992,10 +2015,10 @@ void PlexBackend::load_live_channels() {
                         {"title",     name.toUpper()},
                     });
                 }
-            }
-            if (channels.isEmpty())
-                qDebug() << "[Plex] Live lineup parsed empty — raw:" << body.left(800);
-            emit liveChannelsLoaded(channels);
+                if (channels.isEmpty())
+                    qDebug() << "[Plex] Live lineup parsed empty — raw:" << body.left(800);
+                emit liveChannelsLoaded(channels);
+            });
         });
     });
 }

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -1222,7 +1222,30 @@ void PlexBackend::load_libraries_impl() {
                     {"sectionType", s["type"].toString()},
                 });
             }
-            emit librariesLoaded(items);
+
+            // Probe for a live-TV DVR. When present, inject a synthetic "LIVE TV"
+            // row right after CONTINUE WATCHING (mirrors that synthetic row). The
+            // emit is deferred into this callback so the row's position is stable.
+            QString uri = serverUrl(), token = serverToken();
+            bool hadCw = hasCw;
+            auto *dvrReply = plexGet(QUrl(uri + "/livetv/dvrs"), token);
+            connect(dvrReply, &QNetworkReply::finished, this,
+                    [this, dvrReply, items, hadCw]() mutable {
+                dvrReply->deleteLater();
+                bool hasLive = false;
+                if (dvrReply->error() == QNetworkReply::NoError) {
+                    QJsonArray dvrs = QJsonDocument::fromJson(dvrReply->readAll())
+                                      .object()["MediaContainer"].toObject()["Dvr"].toArray();
+                    for (const auto &dv : dvrs)
+                        if (!dv.toObject()["lineup"].toString().isEmpty()) { hasLive = true; break; }
+                }
+                if (hasLive) {
+                    items.insert(hadCw ? 1 : 0, QVariantMap{
+                        {"key","live_tv"},{"title","LIVE TV"},
+                        {"sectionId",QVariant()},{"sectionType",QVariant()}});
+                }
+                emit librariesLoaded(items);
+            });
         });
     });
 }
@@ -1897,6 +1920,210 @@ void PlexBackend::set_subtitle_stream(const QString &streamId, const QString &pa
     QUrl url(uri + "/library/parts/" + partId);
     QUrlQuery q; q.addQueryItem("subtitleStreamID", streamId); url.setQuery(q);
     auto *reply = plexPut(url, token);
+    connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
+}
+
+// ---------------------------------------------------------------------------
+// Live TV (minimal — watch live channels only, no DVR/recording features)
+//
+// NOTE: the live endpoints below are reverse-engineered/version-sensitive (the
+// bundled openapi documents the shapes but real PMS responses vary). Each parse
+// logs its raw input on miss so field mappings can be confirmed against a live
+// DVR server (see the plan's verification step). The channel list is built from
+// the EPG lineup; tuning produces an HLS transcode reusing the same master-m3u8
+// parse + streamUrlReady hand-off as request_transcode.
+// ---------------------------------------------------------------------------
+
+void PlexBackend::load_live_channels() {
+    QString uri = serverUrl(), token = serverToken();
+    if (uri.isEmpty()) { emit errorOccurred("NO SERVER CONFIGURED"); return; }
+
+    auto *reply = plexGet(QUrl(uri + "/livetv/dvrs"), token);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, uri, token]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                handle498([this]{ load_live_channels(); }); return;
+            }
+            emit errorOccurred("LOAD DVRS FAILED: " + reply->errorString()); return;
+        }
+        QJsonObject mc = QJsonDocument::fromJson(reply->readAll())
+                         .object()["MediaContainer"].toObject();
+        // The Dvr array can mix the EPG-backed DVR (carries a "lineup" URI) with
+        // raw tuner devices. Pick the one with a lineup — that's what we tune.
+        QString lineup;
+        for (const auto &dv : mc["Dvr"].toArray()) {
+            QJsonObject d = dv.toObject();
+            if (!d["lineup"].toString().isEmpty()) {
+                m_liveDvrId = d["key"].toString();
+                lineup      = d["lineup"].toString();
+                break;
+            }
+        }
+        if (m_liveDvrId.isEmpty() || lineup.isEmpty()) {
+            qDebug() << "[Plex] No tunable DVR/lineup in /livetv/dvrs";
+            emit liveChannelsLoaded(QVariantList{});
+            return;
+        }
+
+        // Resolve channel names/numbers from the EPG lineup.
+        QUrl chUrl(uri + "/livetv/epg/lineupchannels");
+        QUrlQuery cq; cq.addQueryItem("lineup", lineup); chUrl.setQuery(cq);
+        auto *chReply = plexGet(chUrl, token);
+        connect(chReply, &QNetworkReply::finished, this, [this, chReply]() {
+            chReply->deleteLater();
+            if (chReply->error() != QNetworkReply::NoError) {
+                emit errorOccurred("LOAD CHANNELS FAILED: " + chReply->errorString()); return;
+            }
+            QByteArray body = chReply->readAll();
+            QJsonObject cmc = QJsonDocument::fromJson(body)
+                              .object()["MediaContainer"].toObject();
+            QVariantList channels;
+            for (const auto &lv : cmc["Lineup"].toArray()) {
+                for (const auto &cv : lv.toObject()["Channel"].toArray()) {
+                    QJsonObject c = cv.toObject();
+                    QString id    = c["key"].toString();
+                    if (id.isEmpty()) continue;
+                    QString number = c["channelVcn"].toString();
+                    QString name   = c["title"].toString(c["callSign"].toString());
+                    channels.append(QVariantMap{
+                        {"channelId", id},
+                        {"number",    number},
+                        {"title",     name.toUpper()},
+                    });
+                }
+            }
+            if (channels.isEmpty())
+                qDebug() << "[Plex] Live lineup parsed empty — raw:" << body.left(800);
+            emit liveChannelsLoaded(channels);
+        });
+    });
+}
+
+void PlexBackend::tune_channel(const QString &channelId, const QString &sessionId) {
+    QString uri = serverUrl(), token = serverToken();
+    if (m_liveDvrId.isEmpty()) { emit errorOccurred("NO LIVE DVR"); return; }
+
+    QUrl url(uri + "/livetv/dvrs/" + m_liveDvrId + "/channels/" + channelId + "/tune");
+    QUrlQuery q;
+    q.addQueryItem("X-Plex-Client-Identifier",  clientId());
+    q.addQueryItem("X-Plex-Session-Identifier", sessionId);
+    url.setQuery(q);
+    auto *reply = plexPost(url, token);
+    connect(reply, &QNetworkReply::finished, this,
+            [this, reply, channelId, sessionId]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                handle498([this, channelId, sessionId]{ tune_channel(channelId, sessionId); }); return;
+            }
+            emit errorOccurred("TUNE FAILED: " + reply->errorString()); return;
+        }
+        QByteArray body = reply->readAll();
+        QJsonObject mc = QJsonDocument::fromJson(body).object()["MediaContainer"].toObject();
+
+        // The grab operation's Metadata (a single object, not an array) carries the
+        // playable live-session key, e.g. "/livetv/sessions/{uuid}". That's the path
+        // we hand to the universal transcoder and report the timeline against. A
+        // failed tune (busy tuner / no signal) returns size 0 with a "message".
+        QString livePath;
+        QJsonArray subs = mc["MediaSubscription"].toArray();
+        if (!subs.isEmpty()) {
+            QJsonArray ops = subs[0].toObject()["MediaGrabOperation"].toArray();
+            if (!ops.isEmpty())
+                livePath = ops[0].toObject()["Metadata"].toObject()["key"].toString();
+        }
+        if (livePath.isEmpty()) {
+            QString msg = mc["message"].toString();
+            qDebug() << "[Plex] Tune produced no stream — raw:" << body.left(600);
+            emit errorOccurred("TUNE FAILED: " + (msg.isEmpty() ? QString("no playable stream") : msg));
+            return;
+        }
+        m_liveTimelineKey = livePath;
+
+        // Start the HLS transcode against the tuned path. Reuses the universal
+        // transcoder + master-m3u8 parse from request_transcode.
+        QString uri = serverUrl(), token = serverToken();
+        QString quality = videoQuality();
+        QUrl startUrl(uri + "/video/:/transcode/universal/start.m3u8");
+        QUrlQuery sq;
+        sq.addQueryItem("hasMDE",       "1");
+        sq.addQueryItem("path",         livePath);
+        sq.addQueryItem("mediaIndex",   "0");
+        sq.addQueryItem("partIndex",    "0");
+        sq.addQueryItem("protocol",     "hls");
+        sq.addQueryItem("directPlay",   "0");
+        sq.addQueryItem("directStream", "0");
+        // Live always transcodes; cap bitrate when the user picked a fixed quality.
+        if (quality != "auto") sq.addQueryItem("maxVideoBitrate", quality);
+        sq.addQueryItem("subtitleSize", "100");
+        sq.addQueryItem("audioBoost",   "100");
+        sq.addQueryItem("session",      sessionId);
+        sq.addQueryItem("X-Plex-Platform", "Chrome");
+        sq.addQueryItem("X-Plex-Client-Identifier",  clientId());
+        sq.addQueryItem("X-Plex-Session-Identifier", sessionId);
+        startUrl.setQuery(sq);
+
+        QNetworkRequest req = plexRequest(startUrl, token);
+        req.setRawHeader("X-Plex-Platform", "Chrome");
+        auto *startReply = m_nam->get(req);
+        ignoreSslErrors(startReply);
+        connect(startReply, &QNetworkReply::finished, this, [this, startReply, token]() {
+            startReply->deleteLater();
+            if (startReply->error() != QNetworkReply::NoError) {
+                emit errorOccurred("LIVE STREAM FAILED: " + startReply->errorString()); return;
+            }
+            QByteArray sbody = startReply->readAll();
+            QString variantPath;
+            for (const QString &line : QString::fromUtf8(sbody).split('\n')) {
+                QString t = line.trimmed();
+                if (!t.isEmpty() && !t.startsWith('#')) { variantPath = t; break; }
+            }
+            QString streamUrl;
+            if (!variantPath.isEmpty()) {
+                QUrl base = startReply->url();
+                base.setQuery(QString());
+                streamUrl = base.resolved(QUrl(variantPath)).toString();
+            } else {
+                streamUrl = startReply->url().toString();
+            }
+            qDebug() << "[Plex] Live stream URL for mpv:" << streamUrl;
+            emit streamUrlReady(streamUrl, token);
+        });
+    });
+}
+
+void PlexBackend::update_live_timeline(const QString &state) {
+    if (m_liveTimelineKey.isEmpty()) return;
+    QString uri = serverUrl(), token = serverToken();
+    QUrl url(uri + "/:/timeline");
+    QUrlQuery q;
+    q.addQueryItem("key",      m_liveTimelineKey);
+    q.addQueryItem("state",    state);
+    q.addQueryItem("time",     "0");
+    q.addQueryItem("duration", "0");
+    q.addQueryItem("X-Plex-Client-Identifier", clientId());
+    url.setQuery(q);
+    auto *reply = plexGet(url, token);
+    connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
+    // Releasing the tuner ends this session; forget the key so a stray timer tick
+    // can't re-ping a dead session.
+    if (state == "stopped") m_liveTimelineKey.clear();
+}
+
+void PlexBackend::stop_live_session(const QString &sessionId) {
+    QString uri = serverUrl(), token = serverToken();
+    // Stop the universal transcode consuming the tuner. Also report the timeline
+    // stopped (best effort) before forgetting the key, so the server reclaims the
+    // tuner promptly instead of waiting for the idle timeout.
+    update_live_timeline("stopped");
+    if (sessionId.isEmpty()) return;
+    QUrl url(uri + "/video/:/transcode/universal/stop");
+    QUrlQuery q;
+    q.addQueryItem("session", sessionId);
+    q.addQueryItem("X-Plex-Client-Identifier", clientId());
+    url.setQuery(q);
+    auto *reply = plexGet(url, token);
     connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
 }
 

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -2024,15 +2024,16 @@ void PlexBackend::tune_channel(const QString &channelId, const QString &sessionI
 
         // The grab operation's Metadata (a single object, not an array) carries the
         // playable live-session key, e.g. "/livetv/sessions/{uuid}". That's the path
-        // we hand to the universal transcoder and report the timeline against. A
-        // failed tune (busy tuner / no signal) returns size 0 with a "message".
-        QString livePath;
+        // we hand to the universal transcoder and report the timeline against, plus
+        // the airing's ratingKey/duration that the keep-alive needs. A failed tune
+        // (busy tuner / no signal) returns size 0 with a "message".
+        QJsonObject meta;
         QJsonArray subs = mc["MediaSubscription"].toArray();
         if (!subs.isEmpty()) {
             QJsonArray ops = subs[0].toObject()["MediaGrabOperation"].toArray();
-            if (!ops.isEmpty())
-                livePath = ops[0].toObject()["Metadata"].toObject()["key"].toString();
+            if (!ops.isEmpty()) meta = ops[0].toObject()["Metadata"].toObject();
         }
+        QString livePath = meta["key"].toString();
         if (livePath.isEmpty()) {
             QString msg = mc["message"].toString();
             qDebug() << "[Plex] Tune produced no stream — raw:" << body.left(600);
@@ -2040,6 +2041,10 @@ void PlexBackend::tune_channel(const QString &channelId, const QString &sessionI
             return;
         }
         m_liveTimelineKey = livePath;
+        m_liveRatingKey   = meta["ratingKey"].toVariant().toString();
+        m_liveDurationMs  = meta["duration"].toInt();
+        m_liveSessionId   = sessionId;
+        m_liveStartedMs   = QDateTime::currentMSecsSinceEpoch();
 
         // Start the HLS transcode against the tuned path. Reuses the universal
         // transcoder + master-m3u8 parse from request_transcode.
@@ -2096,13 +2101,22 @@ void PlexBackend::tune_channel(const QString &channelId, const QString &sessionI
 void PlexBackend::update_live_timeline(const QString &state) {
     if (m_liveTimelineKey.isEmpty()) return;
     QString uri = serverUrl(), token = serverToken();
+    // The ratingKey + session + an advancing time are what let Plex match this
+    // timeline to the active airing and keep the DVR grab rolling. Without them the
+    // grab is reaped after a few minutes and the HLS playlist starts returning 404.
+    qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - m_liveStartedMs;
+    if (elapsed < 0) elapsed = 0;
+    if (m_liveDurationMs > 0 && elapsed > m_liveDurationMs) elapsed = m_liveDurationMs;
     QUrl url(uri + "/:/timeline");
     QUrlQuery q;
-    q.addQueryItem("key",      m_liveTimelineKey);
-    q.addQueryItem("state",    state);
-    q.addQueryItem("time",     "0");
-    q.addQueryItem("duration", "0");
-    q.addQueryItem("X-Plex-Client-Identifier", clientId());
+    q.addQueryItem("ratingKey", m_liveRatingKey);
+    q.addQueryItem("key",       m_liveTimelineKey);
+    q.addQueryItem("state",     state);
+    q.addQueryItem("time",      QString::number(elapsed));
+    q.addQueryItem("duration",  QString::number(m_liveDurationMs));
+    q.addQueryItem("hasMDE",    "1");
+    q.addQueryItem("X-Plex-Session-Identifier", m_liveSessionId);
+    q.addQueryItem("X-Plex-Client-Identifier",  clientId());
     url.setQuery(q);
     auto *reply = plexGet(url, token);
     connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -208,9 +208,17 @@ private:
     bool    m_refreshInFlight  = false;
     bool    m_deviceVerified   = false; // set after first successful plex.tv check per session
 
-    // Live TV session state. m_liveDvrId is cached from the last load_live_channels;
-    // m_liveTimelineKey is the grabbed media part key from the last tune_channel,
-    // used as the /:/timeline key for keep-alive (live has no rating key).
+    // Live TV session state. m_liveDvrId is cached from the last load_live_channels.
+    // The rest are set by tune_channel and drive the timeline keep-alive that stops
+    // Plex from reaping the DVR grab (which would 404 the stream after a few
+    // minutes): m_liveTimelineKey is the grabbed live-session key, m_liveRatingKey
+    // and m_liveDurationMs identify the airing, m_liveSessionId ties the timeline to
+    // the transcode session, and m_liveStartedMs gives the keep-alive an advancing
+    // playback time.
     QString m_liveDvrId;
     QString m_liveTimelineKey;
+    QString m_liveRatingKey;
+    QString m_liveSessionId;
+    int     m_liveDurationMs = 0;
+    qint64  m_liveStartedMs  = 0;
 };

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -62,6 +62,18 @@ public:
     Q_INVOKABLE void set_audio_stream(const QString &streamId, const QString &partId);
     Q_INVOKABLE void set_subtitle_stream(const QString &streamId, const QString &partId);
 
+    // Live TV — minimal "watch live channels" support (no DVR/recording features).
+    // load_live_channels lists the channel lineup of the first available DVR;
+    // tune_channel allocates a tuner + HLS transcode session and emits streamUrlReady;
+    // update_live_timeline keeps that tuner alive (state "playing") or releases it
+    // (state "stopped"). The grabbed media key is remembered between calls.
+    Q_INVOKABLE void load_live_channels();
+    Q_INVOKABLE void tune_channel(const QString &channelId, const QString &sessionId);
+    Q_INVOKABLE void update_live_timeline(const QString &state);
+    // Stops the live transcode for sessionId and forgets the tuned key, so the
+    // server can release the tuner. Called on exit and before a channel change.
+    Q_INVOKABLE void stop_live_session(const QString &sessionId);
+
     // Settings dynamic options
     Q_INVOKABLE void getUsers();
     Q_INVOKABLE void getServers();
@@ -95,6 +107,8 @@ signals:
     void childrenLoaded(const QVariant &items);
     void inProgressEpisodeLoaded(const QVariant &item);
     void nextEpisodeReady(const QVariant &detail);
+
+    void liveChannelsLoaded(const QVariant &channels);
 
     void dynamicOptionsReady(const QString &key, const QVariant &options);
 
@@ -193,4 +207,10 @@ private:
     QString m_clientId;          // cached after first load
     bool    m_refreshInFlight  = false;
     bool    m_deviceVerified   = false; // set after first successful plex.tv check per session
+
+    // Live TV session state. m_liveDvrId is cached from the last load_live_channels;
+    // m_liveTimelineKey is the grabbed media part key from the last tune_channel,
+    // used as the /:/timeline key for keep-alive (live has no rating key).
+    QString m_liveDvrId;
+    QString m_liveTimelineKey;
 };


### PR DESCRIPTION
## What

Adds a minimal **Live TV** experience to the Plex module — watch currently-live channels from a server that has a tuner + DVR. No DVR/recording features.

A synthetic **LIVE TV** row appears on the Plex home screen when the active server has a DVR. Selecting it lists the channel lineup; choosing a channel tunes it and plays the live HLS stream through mpv.

## How it works

- **Channels:** `GET /livetv/dvrs` finds the DVR + its EPG lineup, then `GET /livetv/epg/lineupchannels` provides named channels (number + title).
- **Tuning:** `POST /livetv/dvrs/{id}/channels/{channelKey}/tune` allocates a tuner; the playable path comes from the grab operation's `Metadata.key` (`/livetv/sessions/{uuid}`). That path is fed to the universal transcoder for an HLS URL, reusing the existing master-m3u8 parse and `streamUrlReady` → `mpvController.loadAndPlay` hand-off.
- **Tuner lifecycle:** a timeline keep-alive ping while watching, and an explicit transcode-stop on exit so the tuner is released.

## Changes

- `PlexBackend`: `load_live_channels`, `tune_channel`, `update_live_timeline`, `stop_live_session`; a `/livetv/dvrs` probe in `load_libraries_impl` that injects the synthetic home row only when a DVR exists.
- QML: a `live_tv` branch in `Libraries.qml`, a new `LiveChannels.qml` channel list (modeled on `Libraries.qml`), and a new slimmed `LivePlayer.qml`.

## Not included (on purpose)

In-player channel switching is intentionally left out for now — to change channels you exit back to the channel list and pick another. Routing channel-change keys past mpv during fullscreen playback needs a design decision, so that's deferred for discussion.

## Testing notes

Requires a Plex server with a configured tuner + DVR. The live-endpoint response shapes were confirmed against a real server.

Manually human-tested on both targets: a Mac, and a Raspberry Pi 3B+ hooked up to a CRT. On each, the LIVE TV home row appears, channels list, a selected channel tunes and plays, the mpv OSC works during playback, and exiting releases the tuner.

[Demo video](https://drive.google.com/file/d/13C96kSUpa-ZdAiCXqTIzBubEhbyfkoE3/view?usp=sharing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)