### PR TITLE
Fix module settings auth-state lookup for non-auth modules

### DIFF
--- a/src/AppCore.cpp
+++ b/src/AppCore.cpp
@@ -262,6 +262,10 @@ void AppCore::onBackendAuthStateChanged() {
 QString AppCore::get_module_auth_state(const QString &moduleId) {
     auto it = m_backends.find(moduleId);
     if (it == m_backends.end()) return QString{};
+    if (it.value()->metaObject()->indexOfMethod(
+            QMetaObject::normalizedSignature("get_auth_state()")) < 0) {
+        return QString{};
+    }
     QString result;
     bool ok = QMetaObject::invokeMethod(
         it.value(), "get_auth_state",

--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -31,7 +31,14 @@ FocusScope {
 
     function buildModel() {
         var schema = appCore.get_module_settings_schema(moduleId)
-        authState = appCore.get_module_auth_state(moduleId)
+        var needsAuthState = false
+        for (var n = 0; n < schema.length; n++) {
+            if (schema[n].requires_auth) {
+                needsAuthState = true
+                break
+            }
+        }
+        authState = needsAuthState ? appCore.get_module_auth_state(moduleId) : ""
         var filtered = []
         for (var i = 0; i < schema.length; i++) {
             var item = schema[i]


### PR DESCRIPTION
## Summary

Fixes the Ambient Mode auth-state crash tracked in AMB-69 / AMB-68 by avoiding `get_auth_state()` calls for modules that do not expose auth-gated settings.

## Root Cause

The shared module settings view requested `appCore.get_module_auth_state(moduleId)` while building every module settings model. Ambient Mode has settings but does not expose a `get_auth_state()` method, so the settings path could attempt to invoke a missing backend method.

## Changes

- In `views/ModuleSettings.qml`, only request module auth state when the module settings schema contains at least one `requires_auth` entry.
- In `src/AppCore.cpp`, defensively check the backend meta-object before invoking `get_auth_state()` and return an empty auth state when the method is absent.

## Validation

- Rebased onto latest upstream `main`.
- Confirmed the PR diff only touches:
  - `src/AppCore.cpp`
  - `views/ModuleSettings.qml`
- Ran `git diff --check origin/main...HEAD`.
- Built successfully on the Raspberry Pi dev checkout with CMake after syncing the rebased branch.
- Previously launched the staged Ambient Mode Prelinger file from the source-built Pi dev service and confirmed the old `AmbientModeBackend::get_auth_state()` error was absent from playback logs.
- Restored the Pi to normal production `240mp.service` after testing.

## Jira

AMB-69: https://snkinard.atlassian.net/browse/AMB-69

## AI Use

This change and PR text were prepared with Codex assistance. The branch was inspected and validated before submission.
