### PR TITLE
feat: local files - add support for image playback

### DIFF
--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -53,6 +53,15 @@
       "options_slot": "get_subtitle_languages",
       "default": "-",
       "description": "Select which language to automatically load subtitles for.\n[Any] is the same as 'no preference'."
+    },
+    {
+      "key": "image_duration",
+      "label": "Image Duration",
+      "type": "list_single",
+      "options_source": "dynamic",
+      "options_slot": "get_image_duration_options",
+      "default": "5",
+      "description": "How long an image is shown before advancing.\nApplies to images in folders and playlists."
     }
   ]
 }

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -280,8 +280,7 @@ FocusScope {
     }
 
     function isPlaylist(path) {
-        var lower = path.toLowerCase()
-        return lower.endsWith(".m3u") || lower.endsWith(".m3u8")
+        return localFilesBackend.isPlaylist(path)
     }
 
     function isImage(path) {

--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -19,6 +19,10 @@ FocusScope {
     property string resumeSetting:       "ask"
     property string subtitleMode:        "forced"
     property var    subtitleLangs:       []
+    property int    imageDurationSec:    5
+
+    // mpv subtitle-track flag derived from subtitleMode: 0 = on, -1 = forced only, -2 = off.
+    property int    subFlag:             (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2)
 
     // Track last non-null values during playback for robust save on exit
     property int    lastKnownPositionMs:  0
@@ -51,7 +55,7 @@ FocusScope {
                 if (choiceIndex === 0 && startPlPos >= 0)
                     resumedFromPlaylistPos = startPlPos
                 overlayVisible = false
-                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, startPlPos)
+                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, subFlag, [], subtitleLangs, loopOn, startPlPos, 0.0, "", false, "", false, [], imageDurationSec)
                 event.accepted = true
             }
         } else {
@@ -122,8 +126,9 @@ FocusScope {
                 // Always save playlist state — skip completion detection
                 if (pos > 0 || plPos >= 0)
                     localFilesBackend.savePosition(filePath, pos, plPos)
-            } else {
-                // Single file: clear if near completion, save otherwise
+            } else if (!isImage(filePath)) {
+                // Single file: clear if near completion, save otherwise.
+                // Images carry no resume position, so they never write history.
                 if (dur > 0 && pos >= dur * 0.95)
                     localFilesBackend.clearPosition(filePath)
                 else if (pos > 5000)
@@ -141,6 +146,8 @@ FocusScope {
         var autoSubs  = appCore.get_setting(moduleRoot.moduleId, "auto_subtitles")
         subtitleMode  = (typeof autoSubs === "boolean") ? ((autoSubs === true) ? "on" : "forced") : (autoSubs || "forced")
         resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
+        var imgDur = parseFloat(appCore.get_setting(moduleRoot.moduleId, "image_duration"))
+        imageDurationSec = isNaN(imgDur) ? 5 : imgDur
 
         // Leaving this as an array since MPV - like most players - expects a *list* of languages
         // to progressively fall back to until a sub track is found. If we ever switch back to
@@ -158,12 +165,20 @@ FocusScope {
         // Shuffle wins: a shuffled playlist starts fresh & random; resume position
         // (a sequential item index) is meaningless once order is randomized.
         if (shuffleOn && isPlaylist(filePath)) {
-            mpvController.loadAndPlay(filePath, 0.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, -1, 0.0, "", false, "", true)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", true, [], imageDurationSec)
+            return
+        }
+
+        // A standalone image has no meaningful playback position, so it bypasses
+        // resume entirely (no saved-position lookup, no "RESUME PLAYBACK?" overlay).
+        // Images inside a playlist still resume via the playlist's item index below.
+        if (!isPlaylist(filePath) && isImage(filePath)) {
+            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec)
             return
         }
 
         if (resumeSetting === "no") {
-            mpvController.loadAndPlay(filePath, 0.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, -1)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec)
             return
         }
 
@@ -175,14 +190,14 @@ FocusScope {
             if (savedPos > 0 && savedPl >= 0)
                 resumedFromPlaylistPos = savedPl
             mpvController.loadAndPlay(filePath, savedPos > 0 ? savedPos / 1000.0 : 0.0,
-                                      0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1)
+                                      0, subFlag, [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1, 0.0, "", false, "", false, [], imageDurationSec)
         } else {
             if (savedPos > 0) {
                 savedPositionMs  = savedPos
                 savedPlaylistPos = savedPl
                 overlayVisible   = true
             } else {
-                mpvController.loadAndPlay(filePath, 0.0, 0, (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2), [], subtitleLangs, loopOn, -1)
+                mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec)
             }
         }
     }
@@ -267,6 +282,10 @@ FocusScope {
     function isPlaylist(path) {
         var lower = path.toLowerCase()
         return lower.endsWith(".m3u") || lower.endsWith(".m3u8")
+    }
+
+    function isImage(path) {
+        return localFilesBackend.isImage(path)
     }
 
     function formatTime(ms) {

--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -173,8 +173,7 @@ QVariantList LocalFilesBackend::getItems(const QString &path) {
     }
 
     for (const QString &name : dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name)) {
-        QString suffix = QFileInfo(name).suffix().toLower();
-        if (kPlaylistExts.contains(suffix)) {
+        if (isPlaylist(name)) {
             QString innerPath = dir.absoluteFilePath(name) + "/" + name;
             if (QFileInfo::exists(innerPath)) {
                 QVariantMap item;

--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -6,15 +6,19 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
-// Single source of truth for image types. kMediaExts (the browse filter) is built
-// from it, and QML asks isImage() rather than keeping its own copy of the list.
+// supported image types
 static const QStringList kImageExts = {
     "jpg", "jpeg", "png", "gif", "webp", "bmp", "tif", "tiff"
 };
+// supported playlist types
+static const QStringList kPlaylistExts = { 
+    "m3u", "m3u8" 
+};
+// full list of supported playback types (combo of video, image and playlist)
 static const QStringList kMediaExts =
     QStringList{ "mp4", "mkv", "avi", "mov", "m4v", "webm", "wmv", "flv", "f4v", "mpg", "mpeg", "vob" }
     + kImageExts
-    + QStringList{ "m3u", "m3u8" };
+    + kPlaylistExts;
 
 LocalFilesBackend::LocalFilesBackend(const QString &appRoot, const QString &dataRoot, QObject *parent)
     : QObject(parent), m_appRoot(appRoot), m_dataRoot(dataRoot), m_mediaRoot(dataRoot + "/media")
@@ -32,6 +36,10 @@ LocalFilesBackend::LocalFilesBackend(const QString &appRoot, const QString &data
 
 bool LocalFilesBackend::isImage(const QString &path) const {
     return kImageExts.contains(QFileInfo(path).suffix().toLower());
+}
+
+bool LocalFilesBackend::isPlaylist(const QString &path) const {
+    return kPlaylistExts.contains(QFileInfo(path).suffix().toLower());
 }
 
 QString LocalFilesBackend::historyFilePath() const {
@@ -164,7 +172,6 @@ QVariantList LocalFilesBackend::getItems(const QString &path) {
         return result;
     }
 
-    static const QStringList kPlaylistExts = { "m3u", "m3u8" };
     for (const QString &name : dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name)) {
         QString suffix = QFileInfo(name).suffix().toLower();
         if (kPlaylistExts.contains(suffix)) {

--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -1,13 +1,20 @@
 #include "LocalFilesBackend.h"
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QVariantMap>
 #include <QJsonDocument>
 #include <QJsonObject>
 
-static const QStringList kMediaExts = {
-    "mp4", "mkv", "avi", "mov", "m4v", "webm", "wmv", "flv", "f4v", "mpg", "mpeg", "vob", "m3u", "m3u8"
+// Single source of truth for image types. kMediaExts (the browse filter) is built
+// from it, and QML asks isImage() rather than keeping its own copy of the list.
+static const QStringList kImageExts = {
+    "jpg", "jpeg", "png", "gif", "webp", "bmp", "tif", "tiff"
 };
+static const QStringList kMediaExts =
+    QStringList{ "mp4", "mkv", "avi", "mov", "m4v", "webm", "wmv", "flv", "f4v", "mpg", "mpeg", "vob" }
+    + kImageExts
+    + QStringList{ "m3u", "m3u8" };
 
 LocalFilesBackend::LocalFilesBackend(const QString &appRoot, const QString &dataRoot, QObject *parent)
     : QObject(parent), m_appRoot(appRoot), m_dataRoot(dataRoot), m_mediaRoot(dataRoot + "/media")
@@ -21,6 +28,10 @@ LocalFilesBackend::LocalFilesBackend(const QString &appRoot, const QString &data
         if (!dir.isEmpty())
             setMediaRoot(dir);
     }
+}
+
+bool LocalFilesBackend::isImage(const QString &path) const {
+    return kImageExts.contains(QFileInfo(path).suffix().toLower());
 }
 
 QString LocalFilesBackend::historyFilePath() const {
@@ -85,6 +96,16 @@ void LocalFilesBackend::get_resume_playback_options() {
     QVariantMap no;  no["id"]  = "no";  no["label"]  = "Never";
     options << ask << yes << no;
     emit dynamicOptionsReady("resume_playback", options);
+}
+
+void LocalFilesBackend::get_image_duration_options() {
+    QVariantList options;
+    QVariantMap five;   five["id"]   = "5";  five["label"]   = "5 Seconds";
+    QVariantMap ten;    ten["id"]    = "10"; ten["label"]    = "10 Seconds";
+    QVariantMap thirty; thirty["id"] = "30"; thirty["label"] = "30 Seconds";
+    QVariantMap sixty;  sixty["id"]  = "60"; sixty["label"]  = "60 Seconds";
+    options << five << ten << thirty << sixty;
+    emit dynamicOptionsReady("image_duration", options);
 }
 
 void LocalFilesBackend::get_subtitle_languages() {

--- a/src/modules/local_files/LocalFilesBackend.h
+++ b/src/modules/local_files/LocalFilesBackend.h
@@ -10,6 +10,7 @@ public:
     explicit LocalFilesBackend(const QString &appRoot, const QString &dataRoot, QObject *parent = nullptr);
 
     Q_INVOKABLE QVariantList getItems(const QString &path);
+    Q_INVOKABLE bool         isImage(const QString &path) const;
     Q_INVOKABLE QString      mediaRoot() const;
     Q_INVOKABLE void         setMediaRoot(const QString &path);
 
@@ -19,6 +20,7 @@ public:
     Q_INVOKABLE void        get_resume_playback_options();
     Q_INVOKABLE void        get_auto_subtitles_options();
     Q_INVOKABLE void        get_subtitle_languages();
+    Q_INVOKABLE void        get_image_duration_options();
 
 signals:
     void dynamicOptionsReady(const QString &key, const QVariant &options);

--- a/src/modules/local_files/LocalFilesBackend.h
+++ b/src/modules/local_files/LocalFilesBackend.h
@@ -11,6 +11,7 @@ public:
 
     Q_INVOKABLE QVariantList getItems(const QString &path);
     Q_INVOKABLE bool         isImage(const QString &path) const;
+    Q_INVOKABLE bool         isPlaylist(const QString &path) const;
     Q_INVOKABLE QString      mediaRoot() const;
     Q_INVOKABLE void         setMediaRoot(const QString &path);
 

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -110,7 +110,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
                                  int playlistStart, float transcodeOffsetSec,
                                  const QString &plexToken, bool muteAudio,
                                  const QString &oscMode, bool shuffle,
-                                 const QStringList &subTitles) {
+                                 const QStringList &subTitles, float imageDurationSec) {
     if (m_process) {
         m_process->disconnect();
         if (m_process->state() != QProcess::NotRunning) {
@@ -241,6 +241,11 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         args << QStringLiteral("--loop-playlist=inf");
     if (shuffle)
         args << QStringLiteral("--shuffle");
+    // How long a still image is shown before mpv advances (or EOFs back to the
+    // menu). Global for the launch, so it covers every image in a mixed playlist;
+    // mpv ignores it for video and animated formats.
+    if (imageDurationSec > 0.0f)
+        args << QString("--image-display-duration=%1").arg(double(imageDurationSec), 0, 'f', 1);
     if (muteAudio)
         args << QStringLiteral("--no-audio");
     // yt-dlp hook intercepts HTTP media URLs and can break Plex/Jellyfin

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -49,7 +49,8 @@ public:
                                   bool muteAudio = false,
                                   const QString &oscMode = {},
                                   bool shuffle = false,
-                                  const QStringList &subTitles = {});
+                                  const QStringList &subTitles = {},
+                                  float imageDurationSec = 0.0f);
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);


### PR DESCRIPTION
## Summary

adds image playback support inspired by the comment from imark7777777 in https://github.com/anthonycaccese/240-MP/issues/50

images can be opened anywhere from within the local media directory 
they can be looped, shuffled and included in playlists (and even mixed with videos in a playlist which would handle the a kiosk type use case that imark7777777 was interested in using at their local theater)

this also adds a setting to local playback to define the image playback duration (defaults to 5 seconds)

## AI involvement

used to help plan the loadAndPlay approach to make sure that image duration did not cause regressions in other modules.  that said, now that we have a few more modules I am thinking it will be a good time in the near future to re-look at loadAndPlay parameters across all again to see if there are any benefits with some refactoring.  not necessary but could be helpful.

## Testing

I tested this on MacOS and RPi on both laptop screen and CRT
I ran through each duration to make sure they matched up and tested images as standalone items and in playlists (with videos).  Looping, shuffle all worked as planned.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
