### PR TITLE
fix: local files - repaint image playlists on RPi KMS

### DIFF
--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -21,6 +21,10 @@ FocusScope {
     property var    subtitleLangs:       []
     property int    imageDurationSec:    5
 
+    // True when playback is images (a standalone image, or a playlist that contains
+    // at least one image). Gates the slideshow-redraw mpv script — see MpvController.
+    property bool   imageContent:        false
+
     // mpv subtitle-track flag derived from subtitleMode: 0 = on, -1 = forced only, -2 = off.
     property int    subFlag:             (subtitleMode == "on") ? 0 : ((subtitleMode == "forced") ? -1 : -2)
 
@@ -55,7 +59,7 @@ FocusScope {
                 if (choiceIndex === 0 && startPlPos >= 0)
                     resumedFromPlaylistPos = startPlPos
                 overlayVisible = false
-                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, subFlag, [], subtitleLangs, loopOn, startPlPos, 0.0, "", false, "", false, [], imageDurationSec)
+                mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, subFlag, [], subtitleLangs, loopOn, startPlPos, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
                 event.accepted = true
             }
         } else {
@@ -149,6 +153,9 @@ FocusScope {
         var imgDur = parseFloat(appCore.get_setting(moduleRoot.moduleId, "image_duration"))
         imageDurationSec = isNaN(imgDur) ? 5 : imgDur
 
+        imageContent = isImage(filePath) ||
+                       (isPlaylist(filePath) && localFilesBackend.playlistContainsImages(filePath))
+
         // Leaving this as an array since MPV - like most players - expects a *list* of languages
         // to progressively fall back to until a sub track is found. If we ever switch back to
         // selecting a list in Settings, the change to support them all will be considerably simpler.
@@ -165,7 +172,7 @@ FocusScope {
         // Shuffle wins: a shuffled playlist starts fresh & random; resume position
         // (a sequential item index) is meaningless once order is randomized.
         if (shuffleOn && isPlaylist(filePath)) {
-            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", true, [], imageDurationSec)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", true, [], imageDurationSec, imageContent)
             return
         }
 
@@ -173,12 +180,12 @@ FocusScope {
         // resume entirely (no saved-position lookup, no "RESUME PLAYBACK?" overlay).
         // Images inside a playlist still resume via the playlist's item index below.
         if (!isPlaylist(filePath) && isImage(filePath)) {
-            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
             return
         }
 
         if (resumeSetting === "no") {
-            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec)
+            mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
             return
         }
 
@@ -190,14 +197,14 @@ FocusScope {
             if (savedPos > 0 && savedPl >= 0)
                 resumedFromPlaylistPos = savedPl
             mpvController.loadAndPlay(filePath, savedPos > 0 ? savedPos / 1000.0 : 0.0,
-                                      0, subFlag, [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1, 0.0, "", false, "", false, [], imageDurationSec)
+                                      0, subFlag, [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
         } else {
             if (savedPos > 0) {
                 savedPositionMs  = savedPos
                 savedPlaylistPos = savedPl
                 overlayVisible   = true
             } else {
-                mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec)
+                mpvController.loadAndPlay(filePath, 0.0, 0, subFlag, [], subtitleLangs, loopOn, -1, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
             }
         }
     }

--- a/scripts/slideshow-redraw.lua
+++ b/scripts/slideshow-redraw.lua
@@ -1,0 +1,17 @@
+-- vo=drm/gpu on KMS only repaints the primary plane when the video output
+-- reconfigures (a change in size or pixel format). A playlist of same-size still
+-- images therefore freezes on the first frame — the playlist clock advances but no
+-- KMS page-flip is issued for the next still, so the previous frame keeps scanning
+-- out. On each playlist advance, nudge a render-affecting but visually negligible
+-- property (video-zoom ~1.0007x, then back to 0) to wake the VO and force a flip.
+-- Loaded only for image content, so video playback is unaffected.
+local function kick()
+    local z = mp.get_property_number("video-zoom", 0) or 0
+    mp.set_property_number("video-zoom", (z ~= 0) and 0 or 0.001)
+end
+
+mp.observe_property("playlist-pos", "number", function(_, pos)
+    if pos == nil then return end
+    mp.add_timeout(0.10, kick)   -- two kicks: toggle to 0.001 then back to 0,
+    mp.add_timeout(0.25, kick)   -- ending clean with the new image shown at zoom 0
+end)

--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -42,6 +42,25 @@ bool LocalFilesBackend::isPlaylist(const QString &path) const {
     return kPlaylistExts.contains(QFileInfo(path).suffix().toLower());
 }
 
+// True if an .m3u/.m3u8 references at least one image entry. Used to decide whether
+// the slideshow-redraw mpv script is needed (see MpvController::loadAndPlay): mpv's
+// KMS output won't repaint consecutive same-size stills without it.
+bool LocalFilesBackend::playlistContainsImages(const QString &path) const {
+    if (!isPlaylist(path))
+        return false;
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+    while (!f.atEnd()) {
+        const QString line = QString::fromUtf8(f.readLine()).trimmed();
+        if (line.isEmpty() || line.startsWith('#'))
+            continue;
+        if (isImage(line))
+            return true;
+    }
+    return false;
+}
+
 QString LocalFilesBackend::historyFilePath() const {
     return m_dataRoot + "/local_files_history.json";
 }

--- a/src/modules/local_files/LocalFilesBackend.h
+++ b/src/modules/local_files/LocalFilesBackend.h
@@ -12,6 +12,7 @@ public:
     Q_INVOKABLE QVariantList getItems(const QString &path);
     Q_INVOKABLE bool         isImage(const QString &path) const;
     Q_INVOKABLE bool         isPlaylist(const QString &path) const;
+    Q_INVOKABLE bool         playlistContainsImages(const QString &path) const;
     Q_INVOKABLE QString      mediaRoot() const;
     Q_INVOKABLE void         setMediaRoot(const QString &path);
 

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -110,7 +110,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
                                  int playlistStart, float transcodeOffsetSec,
                                  const QString &plexToken, bool muteAudio,
                                  const QString &oscMode, bool shuffle,
-                                 const QStringList &subTitles, float imageDurationSec) {
+                                 const QStringList &subTitles, float imageDurationSec,
+                                 bool imageContent) {
     if (m_process) {
         m_process->disconnect();
         if (m_process->state() != QProcess::NotRunning) {
@@ -183,6 +184,17 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     const QString mediaKeysScript = m_appRoot + "/scripts/media-keys.lua";
     if (QFile::exists(mediaKeysScript))
         args << QString("--script=%1").arg(mediaKeysScript);
+
+    // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
+    // primary plane between two consecutive same-size/format stills, so a photo
+    // playlist freezes on the first frame while the clock advances. This script
+    // nudges a render-affecting property on each playlist advance to force a
+    // page-flip. Loaded only for image content, so video playback is untouched.
+    if (imageContent) {
+        const QString slideshowScript = m_appRoot + "/scripts/slideshow-redraw.lua";
+        if (QFile::exists(slideshowScript))
+            args << QString("--script=%1").arg(slideshowScript);
+    }
 
     if (playlistStart >= 0)
         args << QString("--playlist-start=%1").arg(playlistStart);

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -50,7 +50,8 @@ public:
                                   const QString &oscMode = {},
                                   bool shuffle = false,
                                   const QStringList &subTitles = {},
-                                  float imageDurationSec = 0.0f);
+                                  float imageDurationSec = 0.0f,
+                                  bool imageContent = false);
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);


### PR DESCRIPTION
## Summary

this is a fix for a bug I found testing photo playlists from local files on the RPi related to https://github.com/anthonycaccese/240-MP/pull/95

mpv's --vo=drm only repaints on a VO reconfig (size/pixel-format change), so same-size consecutive stills froze on the first frame while the playlist advanced. this injects a scripts/slideshow-redraw.lua (which contains a simple video-zoom nudge on each playlist advance) only for image content; the video path is untouched.

## AI involvement

Used to help debug outside of 240-MP to identify it was a repaint bug with same sized images in our EGLFS set up for the RPi, worked through the idea of a custom lua script approach to and to inject it only when a playlist contains an image reference.

## Testing

Tested on MacOS to confirm this has no adverse effects there
Tested on RPi for image only playlist, image+video mixed playlist, video playlist and confirmed transitions are working without performance issues or regression in local files
tested all other modules to confirm playback still working as intended

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
