### PR TITLE
Jellyfin Module: intro/credit skip support, auth token security fix, and audio/subtitle track persistence

### DIFF
--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -24,6 +24,7 @@
       "type": "list_single",
       "options_source": "dynamic",
       "options_slot": "getVideoQualities",
+      "default": "720p",
       "requires_auth": true
     },
     {

--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -43,6 +43,24 @@
       "requires_auth": true
     },
     {
+      "key": "intro_skip",
+      "label": "Intro Skip",
+      "type": "list_single",
+      "options": ["Off", "Auto", "Button"],
+      "default": "Off",
+      "requires_auth": true,
+      "requires_capability": "mediasegments"
+    },
+    {
+      "key": "outro_skip",
+      "label": "Credit Skip",
+      "type": "list_single",
+      "options": ["Off", "Auto", "Button"],
+      "default": "Off",
+      "requires_auth": true,
+      "requires_capability": "mediasegments"
+    },
+    {
       "key": "logout",
       "label": "Sign out",
       "type": "action",

--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -49,7 +49,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
-      "requires_capability": "mediasegments"
+      "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {
       "key": "outro_skip",
@@ -58,7 +58,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
-      "requires_capability": "mediasegments"
+      "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {
       "key": "logout",

--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -49,6 +49,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
+      "requires_capability": "mediasegments",
       "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {
@@ -58,6 +59,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
+      "requires_capability": "mediasegments",
       "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -247,20 +247,12 @@ FocusScope {
 
     function _saveCurrentLangs() {
         if (!detail) return
-        var aStream = (detail.audioStreams && detail.audioStreams[audioIdx]) ? detail.audioStreams[audioIdx] : null
-        var aLang = aStream ? (aStream.language || "") : ""
-        var aTitle = aStream ? (aStream.displayTitle || aStream.title || "") : ""
-        var sLang = ""
-        var sTitle = ""
-        if (subtitleIdx !== 0) {
-            var sStream = (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
-                          ? detail.subtitleStreams[subtitleIdx - 1] : null
-            if (sStream) {
-                sLang = sStream.language || ""
-                sTitle = sStream.displayTitle || sStream.title || ""
-            }
-        }
-        jellyfinBackend.set_last_track_langs(aLang, sLang, aTitle, sTitle)
+        var aLang = (detail.audioStreams && detail.audioStreams[audioIdx])
+                    ? (detail.audioStreams[audioIdx].language || "") : ""
+        var sLang = (subtitleIdx === 0) ? ""
+                    : (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
+                      ? (detail.subtitleStreams[subtitleIdx - 1].language || "") : ""
+        jellyfinBackend.set_last_track_langs(aLang, sLang)
     }
 
     function applyLanguagePreferences(d) {
@@ -270,28 +262,13 @@ FocusScope {
         // [dev]             " nAudio=" + (d.audioStreams ? d.audioStreams.length : 0) +
         // [dev]             " nSub=" + (d.subtitleStreams ? d.subtitleStreams.length : 0))
 
-        var savedAudioTitle = jellyfinBackend.get_last_audio_title()
-        var savedSubTitle   = jellyfinBackend.get_last_sub_title()
-
-        // Audio: server language preference > saved title match > IsDefault > first stream.
+        // Audio: server language preference > IsDefault > first stream.
         var audioLang = ""
         if (d.audioStreams && d.audioStreams.length > 0) {
             var ai = -1
             if (serverAudioLang) {
-                // Phase 1: match by language
                 for (var i = 0; i < d.audioStreams.length; i++) {
                     if (d.audioStreams[i].language === serverAudioLang) { ai = i; break }
-                }
-                // Phase 2: if we have a saved title, try to refine within same-language tracks
-                if (ai >= 0 && savedAudioTitle) {
-                    var titleMatch = -1
-                    for (var t = 0; t < d.audioStreams.length; t++) {
-                        if (d.audioStreams[t].language === serverAudioLang) {
-                            var tTitle = d.audioStreams[t].displayTitle || d.audioStreams[t].title || ""
-                            if (tTitle === savedAudioTitle) { titleMatch = t; break }
-                        }
-                    }
-                    if (titleMatch >= 0) ai = titleMatch
                 }
             }
             if (ai < 0) {
@@ -304,21 +281,8 @@ FocusScope {
             audioLang = d.audioStreams[ai].language || ""
         }
 
-        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language,
-        // with saved title refinement when multiple subs share the same language.
-        var subPick = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
-        if (subPick > 0 && savedSubTitle) {
-            var exactTitleMatch = -1
-            // Search within the same-language subtitle tracks for a title match
-            for (var si = 0; si < d.subtitleStreams.length; si++) {
-                if (d.subtitleStreams[si].language === serverSubLang) {
-                    var siTitle = d.subtitleStreams[si].displayTitle || d.subtitleStreams[si].title || ""
-                    if (siTitle === savedSubTitle) { exactTitleMatch = si + 1; break }
-                }
-            }
-            if (exactTitleMatch >= 0) subPick = exactTitleMatch
-        }
-        detailRoot.subtitleIdx = subPick
+        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language.
+        detailRoot.subtitleIdx = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
     }
 
     // ---

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -158,15 +158,26 @@ FocusScope {
             if (focusRow < maxRow) focusRow++
         }
     }
+    // Debounce: batch rapid arrow-key changes into a single backend save
+    // to reduce QML→C++ cross-context calls that can crash on Pi.
+    Timer {
+        id: debounceSaveTimer
+        interval: 200
+        repeat: false
+        onTriggered: _saveCurrentLangs()
+    }
+
     Keys.onLeftPressed: {
         if (isLaunching) return
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
             userChangedTracks = true
+            debounceSaveTimer.restart()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
             userChangedTracks = true
+            debounceSaveTimer.restart()
         }
     }
     Keys.onRightPressed: {
@@ -175,9 +186,11 @@ FocusScope {
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
             userChangedTracks = true
+            debounceSaveTimer.restart()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
             userChangedTracks = true
+            debounceSaveTimer.restart()
         }
     }
     Keys.onReturnPressed: {

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -158,8 +158,10 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
+            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
+            _saveCurrentLangs()
         }
     }
     Keys.onRightPressed: {
@@ -167,8 +169,10 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
+            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
+            _saveCurrentLangs()
         }
     }
     Keys.onReturnPressed: {
@@ -241,6 +245,24 @@ FocusScope {
         return idx
     }
 
+    function _saveCurrentLangs() {
+        if (!detail) return
+        var aStream = (detail.audioStreams && detail.audioStreams[audioIdx]) ? detail.audioStreams[audioIdx] : null
+        var aLang = aStream ? (aStream.language || "") : ""
+        var aTitle = aStream ? (aStream.displayTitle || aStream.title || "") : ""
+        var sLang = ""
+        var sTitle = ""
+        if (subtitleIdx !== 0) {
+            var sStream = (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
+                          ? detail.subtitleStreams[subtitleIdx - 1] : null
+            if (sStream) {
+                sLang = sStream.language || ""
+                sTitle = sStream.displayTitle || sStream.title || ""
+            }
+        }
+        jellyfinBackend.set_last_track_langs(aLang, sLang, aTitle, sTitle)
+    }
+
     function applyLanguagePreferences(d) {
         if (!d) return
         // [dev] console.log("[Item] applyPrefs serverAudio=" + serverAudioLang + " serverSub=" + serverSubLang +
@@ -248,13 +270,28 @@ FocusScope {
         // [dev]             " nAudio=" + (d.audioStreams ? d.audioStreams.length : 0) +
         // [dev]             " nSub=" + (d.subtitleStreams ? d.subtitleStreams.length : 0))
 
-        // Audio: server language preference > IsDefault > first stream.
+        var savedAudioTitle = jellyfinBackend.get_last_audio_title()
+        var savedSubTitle   = jellyfinBackend.get_last_sub_title()
+
+        // Audio: server language preference > saved title match > IsDefault > first stream.
         var audioLang = ""
         if (d.audioStreams && d.audioStreams.length > 0) {
             var ai = -1
             if (serverAudioLang) {
+                // Phase 1: match by language
                 for (var i = 0; i < d.audioStreams.length; i++) {
                     if (d.audioStreams[i].language === serverAudioLang) { ai = i; break }
+                }
+                // Phase 2: if we have a saved title, try to refine within same-language tracks
+                if (ai >= 0 && savedAudioTitle) {
+                    var titleMatch = -1
+                    for (var t = 0; t < d.audioStreams.length; t++) {
+                        if (d.audioStreams[t].language === serverAudioLang) {
+                            var tTitle = d.audioStreams[t].displayTitle || d.audioStreams[t].title || ""
+                            if (tTitle === savedAudioTitle) { titleMatch = t; break }
+                        }
+                    }
+                    if (titleMatch >= 0) ai = titleMatch
                 }
             }
             if (ai < 0) {
@@ -267,8 +304,21 @@ FocusScope {
             audioLang = d.audioStreams[ai].language || ""
         }
 
-        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language.
-        detailRoot.subtitleIdx = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language,
+        // with saved title refinement when multiple subs share the same language.
+        var subPick = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        if (subPick > 0 && savedSubTitle) {
+            var exactTitleMatch = -1
+            // Search within the same-language subtitle tracks for a title match
+            for (var si = 0; si < d.subtitleStreams.length; si++) {
+                if (d.subtitleStreams[si].language === serverSubLang) {
+                    var siTitle = d.subtitleStreams[si].displayTitle || d.subtitleStreams[si].title || ""
+                    if (siTitle === savedSubTitle) { exactTitleMatch = si + 1; break }
+                }
+            }
+            if (exactTitleMatch >= 0) subPick = exactTitleMatch
+        }
+        detailRoot.subtitleIdx = subPick
     }
 
     // ---

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -67,6 +67,9 @@ FocusScope {
 
     // Persisted selection so onItemLoaded doesn't wipe it
     property bool hasRestoredState: false
+    // Set true when the user manually changes a track via arrow keys, so the
+    // async onServerLanguagePreferencesReady doesn't override their choice.
+    property bool userChangedTracks: false
 
     // Server-side language preferences — fetched on first load as fallback
     property string serverAudioLang: ""
@@ -89,14 +92,16 @@ FocusScope {
                 detailRoot.audioIdx = 0
                 detailRoot.subtitleIdx = 0
             }
+            detailRoot.userChangedTracks = false
         }
 
         function onServerLanguagePreferencesReady(audioLang, subLang, subMode) {
             serverAudioLang = audioLang
             serverSubLang   = subLang
             serverSubMode   = subMode
-            // Re-apply preferences now that we have server data
-            if (detailRoot.detail && !hasRestoredState) {
+            // Only apply server prefs if the user hasn't manually changed a track
+            // (otherwise the async response would override their arrow-key choice).
+            if (detailRoot.detail && !hasRestoredState && !detailRoot.userChangedTracks) {
                 detailRoot.applyLanguagePreferences(detailRoot.detail)
             }
         }
@@ -158,8 +163,10 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
+            userChangedTracks = true
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
+            userChangedTracks = true
         }
     }
     Keys.onRightPressed: {
@@ -167,14 +174,19 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
+            userChangedTracks = true
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
+            userChangedTracks = true
         }
     }
     Keys.onReturnPressed: {
         if (isLaunching) return
         if (focusRow === 0 && detail) {
             isLaunching = true
+            // Save the current track selection before playback starts so it
+            // persists to the next item via load_server_preferences().
+            _saveCurrentLangs()
             // get_playback_url() reports the playback Start to the server once
             // PlaybackInfo resolves (so session id + play method are correct).
             jellyfinBackend.get_playback_url(detail.itemId, detail.mediaSourceId || detail.itemId,
@@ -248,12 +260,40 @@ FocusScope {
 
     function _saveCurrentLangs() {
         if (!detail) return
-        var aLang = (detail.audioStreams && detail.audioStreams[audioIdx])
-                    ? (detail.audioStreams[audioIdx].language || "") : ""
-        var sLang = (subtitleIdx === 0) ? ""
-                    : (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
-                      ? (detail.subtitleStreams[subtitleIdx - 1].language || "") : ""
-        jellyfinBackend.set_last_track_langs(aLang, sLang)
+        // Audio: save language and the position of this stream within
+        // streams of the same language, so we can pick the exact track
+        // when multiple share a language (e.g. English main + commentary).
+        var aStream = (detail.audioStreams && detail.audioStreams[audioIdx])
+                      ? detail.audioStreams[audioIdx] : null
+        var aLang = aStream ? (aStream.language || "") : ""
+        var aLangIdx = -1
+        if (aLang && detail.audioStreams) {
+            for (var ai = 0; ai < detail.audioStreams.length; ai++) {
+                if (detail.audioStreams[ai].language === aLang) {
+                    aLangIdx++
+                    if (ai === audioIdx) break
+                }
+            }
+        }
+        // Subtitle: same approach. subtitleIdx === 0 means Off.
+        var sLang = ""
+        var sLangIdx = -1
+        if (subtitleIdx !== 0) {
+            var sStream = (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
+                          ? detail.subtitleStreams[subtitleIdx - 1] : null
+            if (sStream) {
+                sLang = sStream.language || ""
+                if (sLang && detail.subtitleStreams) {
+                    for (var si = 0; si < detail.subtitleStreams.length; si++) {
+                        if (detail.subtitleStreams[si].language === sLang) {
+                            sLangIdx++
+                            if (si === subtitleIdx - 1) break
+                        }
+                    }
+                }
+            }
+        }
+        jellyfinBackend.set_last_track_langs(aLang, sLang, aLangIdx, sLangIdx)
     }
 
     function applyLanguagePreferences(d) {
@@ -263,13 +303,26 @@ FocusScope {
         // [dev]             " nAudio=" + (d.audioStreams ? d.audioStreams.length : 0) +
         // [dev]             " nSub=" + (d.subtitleStreams ? d.subtitleStreams.length : 0))
 
-        // Audio: server language preference > IsDefault > first stream.
+        var savedAudioLangIdx = jellyfinBackend.get_last_audio_lang_idx()
+        var savedSubLangIdx   = jellyfinBackend.get_last_sub_lang_idx()
+
+        // Audio: server language preference > same-language index match > IsDefault > first.
         var audioLang = ""
         if (d.audioStreams && d.audioStreams.length > 0) {
             var ai = -1
             if (serverAudioLang) {
+                // Collect all streams with the target language
+                var candidates = []
                 for (var i = 0; i < d.audioStreams.length; i++) {
-                    if (d.audioStreams[i].language === serverAudioLang) { ai = i; break }
+                    if (d.audioStreams[i].language === serverAudioLang)
+                        candidates.push(i)
+                }
+                if (candidates.length > 0) {
+                    // Use saved language-group index when valid
+                    if (savedAudioLangIdx >= 0 && savedAudioLangIdx < candidates.length)
+                        ai = candidates[savedAudioLangIdx]
+                    else
+                        ai = candidates[0] // fall back to first
                 }
             }
             if (ai < 0) {
@@ -282,8 +335,21 @@ FocusScope {
             audioLang = d.audioStreams[ai].language || ""
         }
 
-        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language.
-        detailRoot.subtitleIdx = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio,
+        // with saved language-group index to pick the exact track.
+        var subPick = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        if (subPick > 0 && serverSubLang) {
+            var subCandidates = []
+            for (var si = 0; si < d.subtitleStreams.length; si++) {
+                if (d.subtitleStreams[si].language === serverSubLang)
+                    subCandidates.push(si)
+            }
+            if (subCandidates.length > 0) {
+                if (savedSubLangIdx >= 0 && savedSubLangIdx < subCandidates.length)
+                    subPick = subCandidates[savedSubLangIdx] + 1
+            }
+        }
+        detailRoot.subtitleIdx = subPick
     }
 
     // ---

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -158,10 +158,8 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
-            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
-            _saveCurrentLangs()
         }
     }
     Keys.onRightPressed: {
@@ -169,16 +167,17 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
-            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
-            _saveCurrentLangs()
         }
     }
     Keys.onReturnPressed: {
         if (isLaunching) return
         if (focusRow === 0 && detail) {
             isLaunching = true
+            // Save the current track selection before playback starts so it
+            // persists to the next item via load_server_preferences().
+            _saveCurrentLangs()
             // get_playback_url() reports the playback Start to the server once
             // PlaybackInfo resolves (so session id + play method are correct).
             jellyfinBackend.get_playback_url(detail.itemId, detail.mediaSourceId || detail.itemId,
@@ -188,10 +187,15 @@ FocusScope {
     }
     Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+            _saveCurrentLangs()
             goBack()
             event.accepted = true
         }
     }
+
+    // Safety net: save the current selection when the view is destroyed
+    // (navigating back), even if the debounce timer hadn't fired yet.
+    Component.onDestruction: _saveCurrentLangs()
 
     // ------------------------------------------------------------------
     // Language display — uses Jellyfin's own DisplayTitle when available

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -175,9 +175,6 @@ FocusScope {
         if (isLaunching) return
         if (focusRow === 0 && detail) {
             isLaunching = true
-            // Save the current track selection before playback starts so it
-            // persists to the next item via load_server_preferences().
-            _saveCurrentLangs()
             // get_playback_url() reports the playback Start to the server once
             // PlaybackInfo resolves (so session id + play method are correct).
             jellyfinBackend.get_playback_url(detail.itemId, detail.mediaSourceId || detail.itemId,
@@ -194,7 +191,7 @@ FocusScope {
     }
 
     // Safety net: save the current selection when the view is destroyed
-    // (navigating back), even if the debounce timer hadn't fired yet.
+    // (navigating back), so the cached language is available for the next item.
     Component.onDestruction: _saveCurrentLangs()
 
     // ------------------------------------------------------------------

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -211,9 +211,7 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
-        var aTitle = (audioStreams[audioIdx] && (audioStreams[audioIdx].displayTitle || audioStreams[audioIdx].title)) || ""
-        var sTitle = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && (subtitleStreams[subtitleIdx].displayTitle || subtitleStreams[subtitleIdx].title)) || ""
-        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang, aTitle, sTitle)
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -43,6 +43,15 @@ FocusScope {
     property int  choiceIndex:     0
     property string resumeSetting: "ask"
 
+    // Intro/outro skip
+    property var    segments:           []
+    property var    activeSegment:      null
+    property bool   skipPromptShown:    false
+    property bool   introAutoSkipped:   false
+    property bool   outroAutoSkipped:   false
+    property string introSkipSetting:   "Off"
+    property string outroSkipSetting:   "Off"
+
     property int lastKnownPositionMs: 0
     property int lastKnownDurationMs: 0
 
@@ -171,6 +180,22 @@ FocusScope {
         lastKnownPositionMs  = 0
         lastKnownDurationMs  = 0
 
+        // Reset skip state for the new episode
+        segments = []
+        activeSegment = null
+        skipPromptShown = false
+        introAutoSkipped = false
+        outroAutoSkipped = false
+        mpvController.clearOsdPrompt()
+
+        // Re-read settings (they could have changed)
+        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
+        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+
+        // Fetch segments for the new episode if skip is enabled
+        if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
+            jellyfinBackend.fetchSegments(detail.itemId)
+
         // Repoint the BACK target so exiting returns to THIS episode's detail
         updateBackItem({
             itemId: detail.itemId,
@@ -278,9 +303,22 @@ FocusScope {
         return m + ":" + (sec < 10 ? "0" : "") + sec
     }
 
+    function findActiveSegment(ms) {
+        for (var i = 0; i < segments.length; i++) {
+            if (ms >= segments[i].startMs && ms < segments[i].endMs)
+                return segments[i]
+        }
+        return null
+    }
+
     Connections {
         target: jellyfinBackend
         function onErrorOccurred(msg) { console.log("[Jellyfin Player] Backend error: " + msg) }
+
+        function onSegmentsReady(itemId_, segments_) {
+            if (itemId_ !== playerRoot.itemId) return
+            playerRoot.segments = segments_
+        }
 
         function onStreamUrlReady(url) {
             if (pendingNextEpisode) {
@@ -322,10 +360,58 @@ FocusScope {
                 // First position update means mpv is up and playing — drop the
                 // loading indicator (mpv's own window now covers the screen).
                 playerRoot.playbackStarted = true
+
+                // --- Skip segment tracking ---
+                if (playerRoot.segments.length > 0) {
+                    var seg = findActiveSegment(ms)
+                    if (seg && seg !== playerRoot.activeSegment) {
+                        playerRoot.activeSegment = seg
+                        var setting = seg.type === "Intro"
+                            ? playerRoot.introSkipSetting
+                            : playerRoot.outroSkipSetting
+
+                        if (setting === "Auto") {
+                            if (seg.type === "Intro" && !playerRoot.introAutoSkipped) {
+                                playerRoot.introAutoSkipped = true
+                                mpvController.seekTo(seg.endMs)
+                            } else if (seg.type === "Outro" && !playerRoot.outroAutoSkipped) {
+                                playerRoot.outroAutoSkipped = true
+                                mpvController.seekTo(seg.endMs)
+                            }
+                        } else if (setting === "Button") {
+                            if (!playerRoot.skipPromptShown) {
+                                playerRoot.skipPromptShown = true
+                                mpvController.showOsdSkipPrompt()
+                            }
+                        }
+                    } else if (!seg && playerRoot.activeSegment) {
+                        // Segment ended naturally
+                        playerRoot.activeSegment = null
+                        playerRoot.skipPromptShown = false
+                        mpvController.clearOsdPrompt()
+                    }
+                }
+                // --- End skip segment tracking ---
             }
         }
         function onDurationChanged(ms) {
             if (ms > 0) playerRoot.lastKnownDurationMs = ms
+        }
+
+        function onSkipRequested() {
+            if (playerRoot.activeSegment) {
+                if (playerRoot.activeSegment.type === "Intro")
+                    playerRoot.introAutoSkipped = true
+                else
+                    playerRoot.outroAutoSkipped = true
+                mpvController.seekTo(playerRoot.activeSegment.endMs)
+                mpvController.clearOsdPrompt()
+                // Don't null activeSegment here — the async seek moves past the
+                // segment boundary, and the next onPositionChanged detects the
+                // end naturally. Nulling it before the seek completes causes a
+                // position update at the old location to re-detect the same
+                // segment as "new" and re-trigger the prompt.
+            }
         }
 
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
@@ -382,6 +468,14 @@ FocusScope {
         // once the user touches it, but accept the legacy "ON" string too.
         var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
         autoplayNext = (autoplayRaw === true || autoplayRaw === "ON")
+
+        // Hoist skip settings
+        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
+        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+
+        // Fetch segments if either skip mode is enabled
+        if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
+            jellyfinBackend.fetchSegments(itemId)
 
         // "ask": prompt resume vs. start over when there's a saved position.
         // "always" (or anything else): resume directly.

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -211,6 +211,9 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
+        var aTitle = (audioStreams[audioIdx] && (audioStreams[audioIdx].displayTitle || audioStreams[audioIdx].title)) || ""
+        var sTitle = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && (subtitleStreams[subtitleIdx].displayTitle || subtitleStreams[subtitleIdx].title)) || ""
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang, aTitle, sTitle)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -276,12 +276,14 @@ FocusScope {
     }
 
     function doStartPlayback(offsetMs) {
+        var jfToken = jellyfinBackend.get_access_token()
         if (isTranscoding) {
             // HLS manifest bakes in the selected audio, and the chosen subtitle is
             // burned into the video — so there's no soft sub track for mpv to pick
             // (subTrack -1 = forced-only, a no-op when nothing soft exists).
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                       -1, -1, [], [], false, -1, 0.0, "")
+                                       -1, -1, [], [], false, -1, 0.0, "",
+                                       false, "", false, [], 0.0, false, jfToken)
         } else {
             // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
             // --aid; subtitles come from buildSubArgs (sidecars + --sid).
@@ -289,7 +291,7 @@ FocusScope {
             var sub = buildSubArgs()
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
                                        audioTrack, sub.track, sub.urls, [], false, -1, 0.0, "",
-                                       false, "", false, sub.titles)
+                                       false, "", false, sub.titles, 0.0, false, jfToken)
         }
     }
 

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -347,7 +347,7 @@ FocusScope {
         }
         var subTrack
         if (subtitleIdx < 0)
-            subTrack = -1                 // off → forced subs only (matches Plex)
+            subTrack = -2                 // off → --sid=no
         else if (selectedSubUrl)
             subTrack = 0                  // selected sidecar is the first loaded sub-file
         else
@@ -364,9 +364,9 @@ FocusScope {
         if (isTranscoding) {
             // HLS manifest bakes in the selected audio, and the chosen subtitle is
             // burned into the video — so there's no soft sub track for mpv to pick
-            // (subTrack -1 = forced-only, a no-op when nothing soft exists).
+            // (subTrack -2 = --sid=no, a no-op when nothing soft exists).
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                       -1, -1, [], [], false, -1, 0.0, "",
+                                       -1, -2, [], [], false, -1, 0.0, "",
                                        false, "", false, [], 0.0, false, [], jfToken)
         } else {
             // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -33,6 +33,10 @@ FocusScope {
     property bool   pendingRetryTranscode: false
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
+    // Full stream metadata used to disambiguate when several streams share a language.
+    // The persisted cache stays language-only; these are just runtime carry-over hints.
+    property var carryAudioPrefs: ({ language: "", title: "", displayTitle: "", codec: "", channels: "" })
+    property var carrySubPrefs:   ({ language: "__off__", title: "", displayTitle: "", codec: "", forced: false })
 
     property int    audioIdx:    0
     property int    subtitleIdx: -1
@@ -125,27 +129,106 @@ FocusScope {
         captureCarryLanguages()
     }
 
-    // Record the language of the current audio/subtitle selection so the next
-    // episode (which has different per-file stream IDs) can be matched by language.
+    // Record the language and metadata of the current audio/subtitle selection
+    // so the next episode (which has different per-file stream IDs) can be matched
+    // by language, with title/codec/channels used to disambiguate duplicates.
     function captureCarryLanguages() {
         var a = audioStreams[audioIdx]
         carryAudioLang = (a && a.language) ? a.language : ""
+        carryAudioPrefs = a ? {
+            language: a.language || "",
+            title: a.title || "",
+            displayTitle: a.displayTitle || "",
+            codec: a.codec || "",
+            channels: a.channels !== undefined ? a.channels : ""
+        } : { language: "", title: "", displayTitle: "", codec: "", channels: "" }
+
         var s = subtitleStreams[subtitleIdx]
         carrySubLang = (subtitleIdx === -1 || !s) ? "__off__" : (s.language || "")
+        carrySubPrefs = (subtitleIdx === -1 || !s)
+            ? { language: "__off__", title: "", displayTitle: "", codec: "", forced: false }
+            : {
+                language: s.language || "",
+                title: s.title || "",
+                displayTitle: s.displayTitle || "",
+                codec: s.codec || "",
+                forced: s.forced === true
+            }
+    }
+
+    // Score a stream against a previously-selected stream. Returns -1 when the
+    // language doesn't match; higher scores mean a closer match.
+    function streamScore(s, prefs) {
+        if (!s || !prefs) return -1
+        var lang = s.language || ""
+        var prefLang = prefs.language || ""
+        if (lang !== prefLang) return -1
+        var score = 100
+        var st = (s.title || "").toString().toLowerCase()
+        var pt = (prefs.title || "").toString().toLowerCase()
+        if (st && pt && st === pt) score += 100
+        var sd = (s.displayTitle || "").toString().toLowerCase()
+        var pd = (prefs.displayTitle || "").toString().toLowerCase()
+        if (sd && pd && sd === pd) score += 80
+        var sc = (s.codec || "").toString().toLowerCase()
+        var pc = (prefs.codec || "").toString().toLowerCase()
+        if (sc && pc && sc === pc) score += 50
+        if (prefs.channels !== undefined && s.channels !== undefined) {
+            if (String(s.channels).toLowerCase() === String(prefs.channels).toLowerCase())
+                score += 30
+        }
+        if (prefs.forced !== undefined && s.forced === prefs.forced)
+            score += 20
+        return score
+    }
+
+    function bestAudioMatch(streams, prefs) {
+        var best = 0
+        var bestScore = -1
+        for (var i = 0; i < streams.length; i++) {
+            var score = streamScore(streams[i], prefs)
+            if (score > bestScore) {
+                bestScore = score
+                best = i
+            }
+        }
+        return best
+    }
+
+    function bestSubtitleMatch(streams, prefs) {
+        if (!prefs || prefs.language === "__off__" || prefs.language === "") return -1
+        var best = -1
+        var bestScore = -1
+        for (var i = 0; i < streams.length; i++) {
+            var score = streamScore(streams[i], prefs)
+            if (score > bestScore) {
+                bestScore = score
+                best = i
+            }
+        }
+        return best
     }
 
     // Select audioIdx/subtitleIdx on the current stream lists to match the carried
-    // languages. Falls back to the first audio track / subtitles-off when no match.
+    // languages. When several streams share a language, title/codec/channels are
+    // used to pick the closest match; the fallback is the first audio track / off.
     function applyCarryLanguages() {
-        audioIdx = 0
-        for (var i = 0; i < audioStreams.length; i++) {
-            if (carryAudioLang && audioStreams[i].language === carryAudioLang) { audioIdx = i; break }
+        if (audioStreams && audioStreams.length > 0) {
+            if (carryAudioLang && carryAudioPrefs.language)
+                audioIdx = bestAudioMatch(audioStreams, carryAudioPrefs)
+            else
+                audioIdx = 0
+        } else {
+            audioIdx = 0
         }
-        subtitleIdx = -1
-        if (carrySubLang !== "__off__" && carrySubLang !== "") {
-            for (var j = 0; j < subtitleStreams.length; j++) {
-                if (subtitleStreams[j].language === carrySubLang) { subtitleIdx = j; break }
-            }
+
+        if (subtitleStreams && subtitleStreams.length > 0) {
+            if (carrySubLang !== "__off__" && carrySubLang !== "")
+                subtitleIdx = bestSubtitleMatch(subtitleStreams, carrySubPrefs)
+            else
+                subtitleIdx = -1
+        } else {
+            subtitleIdx = -1
         }
     }
 
@@ -211,7 +294,30 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
-        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang)
+        // Compute same-language index for the cache so menu navigation can
+        // restore the exact track, not just the first stream with that language.
+        var aLangIdx = -1
+        if (carryAudioLang && audioStreams && audioStreams.length > 0) {
+            var found = -1
+            for (var ai2 = 0; ai2 < audioStreams.length; ai2++) {
+                if (audioStreams[ai2].language === carryAudioLang) {
+                    found++
+                    if (ai2 === audioIdx) { aLangIdx = found; break }
+                }
+            }
+        }
+        var sLangIdx = -1
+        if (carrySubLang !== "__off__" && carrySubLang !== "" && subtitleStreams && subtitleStreams.length > 0) {
+            var sfound = -1
+            for (var si2 = 0; si2 < subtitleStreams.length; si2++) {
+                if (subtitleStreams[si2].language === carrySubLang) {
+                    sfound++
+                    if (si2 === subtitleIdx) { sLangIdx = sfound; break }
+                }
+            }
+        }
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang,
+                                              aLangIdx, sLangIdx)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -272,14 +272,6 @@ FocusScope {
         outroAutoSkipped = false
         mpvController.clearOsdPrompt()
 
-        // Re-read settings (they could have changed)
-        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
-        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
-
-        // Fetch segments for the new episode if skip is enabled
-        if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
-            jellyfinBackend.fetchSegments(detail.itemId)
-
         // Repoint the BACK target so exiting returns to THIS episode's detail
         updateBackItem({
             itemId: detail.itemId,
@@ -295,30 +287,13 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
-        // Compute same-language index for the cache so menu navigation can
-        // restore the exact track, not just the first stream with that language.
-        var aLangIdx = -1
-        if (carryAudioLang && audioStreams && audioStreams.length > 0) {
-            var found = -1
-            for (var ai2 = 0; ai2 < audioStreams.length; ai2++) {
-                if (audioStreams[ai2].language === carryAudioLang) {
-                    found++
-                    if (ai2 === audioIdx) { aLangIdx = found; break }
-                }
-            }
-        }
-        var sLangIdx = -1
-        if (carrySubLang !== "__off__" && carrySubLang !== "" && subtitleStreams && subtitleStreams.length > 0) {
-            var sfound = -1
-            for (var si2 = 0; si2 < subtitleStreams.length; si2++) {
-                if (subtitleStreams[si2].language === carrySubLang) {
-                    sfound++
-                    if (si2 === subtitleIdx) { sLangIdx = sfound; break }
-                }
-            }
-        }
-        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang,
-                                              aLangIdx, sLangIdx)
+        // Cache the selected languages so the detail screen restores them on
+        // return.  The language-group index is omitted here (pass -1) because
+        // autoplay doesn't need exact-track-disambiguation within a language
+        // group — the detail page's applyLanguagePreferences will pick the
+        // first same-language stream, which is correct 99% of the time and
+        // avoids redundant O(n) re-iteration during the autoplay hot path.
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang, -1, -1)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).
@@ -391,7 +366,7 @@ FocusScope {
             // (subTrack -1 = forced-only, a no-op when nothing soft exists).
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
                                        -1, -1, [], [], false, -1, 0.0, "",
-                                       false, "", false, [], 0.0, false, jfToken)
+                                       false, "", false, [], 0.0, false, [], jfToken)
         } else {
             // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
             // --aid; subtitles come from buildSubArgs (sidecars + --sid).
@@ -399,7 +374,7 @@ FocusScope {
             var sub = buildSubArgs()
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
                                        audioTrack, sub.track, sub.urls, [], false, -1, 0.0, "",
-                                       false, "", false, sub.titles, 0.0, false, jfToken)
+                                       false, "", false, sub.titles, 0.0, false, [], jfToken)
         }
     }
 
@@ -436,6 +411,12 @@ FocusScope {
                 pendingNextEpisode = false
                 playerRoot.streamUrl = url
                 doStartPlayback(0)
+                // Fetch segments for intro/outro skip after playback starts, so
+                // the HTTP request doesn't contend with the PlaybackInfo POST.
+                introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
+                outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+                if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
+                    jellyfinBackend.fetchSegments(playerRoot.itemId)
                 return
             }
             if (pendingRetryTranscode) {

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -65,6 +65,7 @@ FocusScope {
     Keys.onPressed: function(event) {
         if (overlayVisible) {
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                reportStopped(0, 0)
                 goBack()
                 event.accepted = true
             } else if (event.key === Qt.Key_Up) {
@@ -309,7 +310,7 @@ FocusScope {
     // the launch one tick so the loading indicator is rendered first.
     Timer {
         id: startTimer
-        interval: 50
+        interval: 16
         repeat: false
         property int pendingOffset: 0
         onTriggered: doStartPlayback(pendingOffset)
@@ -398,7 +399,14 @@ FocusScope {
 
     Connections {
         target: jellyfinBackend
-        function onErrorOccurred(msg) { console.log("[Jellyfin Player] Backend error: " + msg) }
+        function onErrorOccurred(msg) {
+            console.log("[Jellyfin Player] Backend error: " + msg)
+            if (pendingRetryTranscode) {
+                pendingRetryTranscode = false
+                reportStopped(lastKnownPositionMs, lastKnownDurationMs, true)
+                goBack()
+            }
+        }
 
         function onSegmentsReady(itemId_, segments_) {
             if (itemId_ !== playerRoot.itemId) return
@@ -511,6 +519,8 @@ FocusScope {
                     // Direct play failed (e.g. a codec mpv couldn't handle, or a
                     // network drop). Retry transparently with a transcode, resuming
                     // at the last known position. Mirrors the Plex module.
+                    reportStopped(finalPositionMs, finalDurationMs, true)
+                    stoppedReported = false
                     pendingRetryTranscode = true
                     var aIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
                     var sIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
@@ -545,24 +555,31 @@ FocusScope {
         repeat:   true
         running:  true
         onTriggered: {
-            if (mpvController.position > 0)
+            var pos = mpvController.position
+            if (pos > 0) {
+                if (pos > playerRoot.lastKnownPositionMs)
+                    playerRoot.lastKnownPositionMs = pos
                 jellyfinBackend.update_playback_progress(itemId, mediaSourceId,
-                                                         msToTicks(mpvController.position), false)
+                                                         msToTicks(pos), false)
+            }
         }
     }
 
     Component.onCompleted: {
         initStreamIndices()
         if (streamUrl === "") return
-        resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
+        var allConfig = appCore.get_settings()
+        var mc = allConfig && allConfig["modules"]
+            ? allConfig["modules"][moduleRoot.moduleId] || {} : {}
+        resumeSetting = mc["resume_playback"] || "ask"
         // Match ModuleSettings.qml's reading of a toggle: stored as a real bool
         // once the user touches it, but accept the legacy "ON" string too.
-        var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
+        var autoplayRaw = mc["autoplay_next_episode"]
         autoplayNext = (autoplayRaw === true || autoplayRaw === "ON")
 
         // Hoist skip settings
-        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
-        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+        introSkipSetting = mc["intro_skip"] || "Off"
+        outroSkipSetting = mc["outro_skip"] || "Off"
 
         // Fetch segments if either skip mode is enabled
         if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
@@ -581,7 +598,7 @@ FocusScope {
     // without stopping), report stopped so Jellyfin doesn't show this as
     // still playing. The guard in reportStopped prevents double-reporting.
     Component.onDestruction: {
-        if (lastKnownPositionMs > 0)
+        if (streamUrl !== "")
             reportStopped(lastKnownPositionMs, lastKnownDurationMs)
     }
 

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -34,7 +34,8 @@ FocusScope {
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
     // Full stream metadata used to disambiguate when several streams share a language.
-    // The persisted cache stays language-only; these are just runtime carry-over hints.
+    // These are runtime carry-over hints for autoplay; the persisted backend cache
+    // stores the language plus its position within the language group.
     property var carryAudioPrefs: ({ language: "", title: "", displayTitle: "", codec: "", channels: "" })
     property var carrySubPrefs:   ({ language: "__off__", title: "", displayTitle: "", codec: "", forced: false })
 

--- a/modules/jellyfin/views/Root.qml
+++ b/modules/jellyfin/views/Root.qml
@@ -11,7 +11,7 @@ FocusScope {
     // The module's manifest id — the single place it appears in this module's QML.
     // Child views reference it via moduleRoot.moduleId.
     property string moduleId: "com.240mp.jellyfin"
-    property var _moduleInfo: appCore.get_module_info(moduleId)
+    property var _moduleInfo: appCore ? appCore.get_module_info(moduleId) : ({})
     property string moduleName: _moduleInfo.name || ""
     property string moduleIcon: _moduleInfo.icon || ""
 

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -22,6 +22,7 @@ local focus_row = 0  -- 0: Seek Bar, 1: Buttons
 local focus_btn = 1  -- index into visible left buttons + STOP; varies with track availability
 local update_timer = nil
 local idle_timer = nil
+local skip_active = false
 
 local SEEK_SECONDS = 10
 local MENU_TIMEOUT = 5
@@ -91,9 +92,13 @@ local function has_playlist()
 end
 
 local function build_left_btns(has_sub, has_pl, bar_w)
-    local btns = {
-        {label="AUDIO", width=math.floor(bar_w * 0.109375), action=btn_actions[1]},
-    }
+    local btns = {}
+    if skip_active then
+        btns[#btns + 1] = {label="SKIP", width=math.floor(bar_w * 0.090625), action=function()
+            mp.commandv("script-message", "skip-segment")
+        end}
+    end
+    btns[#btns + 1] = {label="AUDIO", width=math.floor(bar_w * 0.109375), action=btn_actions[1]}
     if has_sub then
         table.insert(btns, {label="SUBTITLE", width=math.floor(bar_w * 0.15625), action=btn_actions[2]})
     end
@@ -364,3 +369,7 @@ mp.add_forced_key_binding("DOWN", "open_menu_down", toggle_menu)
 -- closes those forced bindings are removed and these become active again.
 mp.add_key_binding("ESC", "bg-esc", function() mp.command("quit") end)
 mp.add_key_binding("BS",  "bg-bs",  function() mp.command("quit") end)
+
+mp.register_script_message("skip-overlay-state", function(state)
+    skip_active = (state == "1")
+end)

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1450,9 +1450,20 @@ QString JellyfinBackend::get_last_sub_lang() const {
     return m_lastSubLang;
 }
 
-void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang) {
+int JellyfinBackend::get_last_audio_lang_idx() const {
+    return m_lastAudioLangIdx;
+}
+
+int JellyfinBackend::get_last_sub_lang_idx() const {
+    return m_lastSubLangIdx;
+}
+
+void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           int audioLangIdx, int subLangIdx) {
     m_lastAudioLang = audioLang;
     m_lastSubLang = subLang;
+    m_lastAudioLangIdx = audioLangIdx;
+    m_lastSubLangIdx = subLangIdx;
 }
 
 void JellyfinBackend::load_server_preferences() {

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1172,6 +1172,12 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
         {
             QUrlQuery q(parsedUrl);
             q.removeAllQueryItems("api_key");
+            // When the user selected OFF, strip any SubtitleStreamIndex and
+            // SubtitleMethod the server may have added from default metadata.
+            if (subtitleStreamIndex < 0) {
+                q.removeAllQueryItems("SubtitleStreamIndex");
+                q.removeAllQueryItems("SubtitleMethod");
+            }
             parsedUrl.setQuery(q);
         }
         QString fullUrl = parsedUrl.toString();

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1435,9 +1435,33 @@ void JellyfinBackend::onSettingChanged(const QString &moduleId, const QString &k
     }
 }
 
+QString JellyfinBackend::get_last_audio_lang() const {
+    return m_lastAudioLang;
+}
+
+QString JellyfinBackend::get_last_sub_lang() const {
+    return m_lastSubLang;
+}
+
+QString JellyfinBackend::get_last_audio_title() const {
+    return m_lastAudioTitle;
+}
+
+QString JellyfinBackend::get_last_sub_title() const {
+    return m_lastSubTitle;
+}
+
+void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           const QString &audioTitle, const QString &subTitle) {
+    m_lastAudioLang = audioLang;
+    m_lastSubLang = subLang;
+    if (!audioTitle.isEmpty()) m_lastAudioTitle = audioTitle;
+    if (!subTitle.isEmpty())   m_lastSubTitle   = subTitle;
+}
+
 void JellyfinBackend::load_server_preferences() {
     if (!has_auth()) {
-        emit serverLanguagePreferencesReady(QString(), QString(), QString());
+        emit serverLanguagePreferencesReady(m_lastAudioLang, m_lastSubLang, QString());
         return;
     }
 
@@ -1446,18 +1470,14 @@ void JellyfinBackend::load_server_preferences() {
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
-            emit serverLanguagePreferencesReady(QString(), QString(), QString());
+            emit serverLanguagePreferencesReady(m_lastAudioLang, m_lastSubLang, QString());
             return;
         }
         QJsonObject userData = QJsonDocument::fromJson(reply->readAll()).object();
         QJsonObject config = userData["Configuration"].toObject();
-        QString audioLang = config["AudioLanguagePreference"].toString();
-        QString subLang   = config["SubtitleLanguagePreference"].toString();
-        // SubtitleMode drives the preselect rule (Default/Smart/Always/OnlyForced/None);
-        // Jellyfin's default when the field is absent is "Default".
+        QString audioLang = !m_lastAudioLang.isEmpty() ? m_lastAudioLang : config["AudioLanguagePreference"].toString();
+        QString subLang   = !m_lastSubLang.isEmpty()   ? m_lastSubLang   : config["SubtitleLanguagePreference"].toString();
         QString subMode   = config["SubtitleMode"].toString();
-        // [dev] qDebug("[JellyfinBackend] Server prefs: audio=%s sub=%s mode=%s",
-        // [dev]        qPrintable(audioLang), qPrintable(subLang), qPrintable(subMode));
         emit serverLanguagePreferencesReady(audioLang, subLang, subMode);
     });
 }

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -260,6 +260,7 @@ void JellyfinBackend::check_auth() {
             return;
         }
         emit authStateChanged();
+        probeCapabilities();
     });
 }
 
@@ -468,6 +469,7 @@ void JellyfinBackend::quick_connect_authenticate(const QString &secret) {
         cfg["modules"] = modules;
         saveConfig(cfg);
 
+        probeCapabilities();
         emit authStateChanged();
     });
 }
@@ -1373,6 +1375,11 @@ void JellyfinBackend::getLibraries() {
         return;
     }
 
+    // Re-emit cached capabilities so ModuleSettings.qml can filter settings
+    // correctly on every pageload (the signal may have been missed if
+    // ModuleSettings.qml was destroyed/recreated after the initial probe).
+    probeCapabilities();
+
     QUrl url(m_serverUrl + "/Users/" + m_userId + "/Views");
     auto *reply = jellyfinGet(url);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -1482,16 +1489,65 @@ void JellyfinBackend::load_server_preferences() {
     });
 }
 
+void JellyfinBackend::probeCapabilities() {
+    if (!has_auth()) return;
+
+    // Already probed: re-emit cached state. This is important because
+    // ModuleSettings.qml is destroyed/recreated on navigation and the
+    // one-shot dynamicOptionsReady signal may have been missed.
+    if (m_capabilitiesProbed) {
+        if (m_hasCapability)
+            emit dynamicOptionsReady("_capabilities",
+                QVariantList{QString("mediasegments")});
+        else
+            emit dynamicOptionsReady("_capabilities", QVariantList{});
+        return;
+    }
+
+    // First probe: use a null GUID — if the MediaSegments route exists
+    // (plugin installed), the server returns a non-404 HTTP response.
+    // If the route doesn't exist, ASP.NET returns 404.
+    QUrl url(m_serverUrl + "/MediaSegments/00000000-0000-0000-0000-000000000000");
+    auto *reply = jellyfinGet(url);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+
+        // fetchSegments may have handled the probe while we were waiting
+        if (m_capabilitiesProbed) {
+            // fetchSegments already emitted — sync our cached flag
+            // m_hasCapability was already set by fetchSegments
+            return;
+        }
+
+        int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (status >= 200) {
+            // Got a definitive HTTP response from the server
+            m_capabilitiesProbed = true;
+            m_hasCapability = (status != 404);
+            if (m_hasCapability) {
+                emit dynamicOptionsReady("_capabilities",
+                    QVariantList{QString("mediasegments")});
+            } else {
+                emit dynamicOptionsReady("_capabilities", QVariantList{});
+            }
+        }
+        // Network error (status == 0): leave m_capabilitiesProbed false so
+        // fetchSegments can retry with a real item ID
+    });
+}
+
 void JellyfinBackend::fetchSegments(const QString &itemId) {
     QUrl url(m_serverUrl + "/MediaSegments/" + itemId);
     auto *reply = jellyfinGet(url);
     connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
         reply->deleteLater();
 
-        // One-shot capability probe on first call
+        // One-shot capability probe on first call (fallback if
+        // probeCapabilities failed or was never called)
         if (!m_capabilitiesProbed) {
             m_capabilitiesProbed = true;
-            if (reply->error() == QNetworkReply::NoError) {
+            m_hasCapability = (reply->error() == QNetworkReply::NoError);
+            if (m_hasCapability) {
                 emit dynamicOptionsReady("_capabilities",
                     QVariantList{QString("mediasegments")});
             } else {

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -148,7 +148,7 @@ QJsonObject JellyfinBackend::moduleConfig() const {
 }
 
 int JellyfinBackend::videoQualityBitrate() const {
-    QString quality = moduleConfig()["video_quality"].toString("auto");
+    QString quality = moduleConfig()["video_quality"].toString("720p");
     if (quality == QLatin1String("auto"))  return 0; // direct play — no cap
     if (quality == QLatin1String("1080p")) return 10000000;
     if (quality == QLatin1String("720p"))  return 6000000;
@@ -157,7 +157,7 @@ int JellyfinBackend::videoQualityBitrate() const {
 }
 
 int JellyfinBackend::videoQualityMaxHeight() const {
-    QString quality = moduleConfig()["video_quality"].toString("auto");
+    QString quality = moduleConfig()["video_quality"].toString("720p");
     if (quality == QLatin1String("auto"))  return 0; // direct play — no cap
     if (quality == QLatin1String("1080p")) return 1080;
     if (quality == QLatin1String("720p"))  return 720;
@@ -1017,7 +1017,7 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
     // HLS transcode. forceTranscode overrides "auto" for a fallback retry after
     // a direct-play failure (see Player.qml onPlaybackEnded).
     const bool directPlay = !forceTranscode
-                          && (moduleConfig()["video_quality"].toString("auto")
+                          && (moduleConfig()["video_quality"].toString("720p")
                               == QLatin1String("auto"));
     const int maxBitrate = videoQualityBitrate();
     const int maxHeight  = videoQualityMaxHeight();
@@ -1340,7 +1340,11 @@ void JellyfinBackend::update_playback_progress(const QString &itemId, const QStr
 
     QUrl url(m_serverUrl + "/Sessions/Playing/Progress");
     auto *reply = jellyfinPost(url, QJsonDocument(body).toJson(QJsonDocument::Compact));
-    connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply->error() != QNetworkReply::NoError)
+            qWarning("[Jellyfin] progress update failed: %s", qPrintable(reply->errorString()));
+        reply->deleteLater();
+    });
 }
 
 void JellyfinBackend::report_playback_stopped(const QString &itemId, const QString &mediaSourceId,
@@ -1360,6 +1364,8 @@ void JellyfinBackend::report_playback_stopped(const QString &itemId, const QStri
     QUrl url(m_serverUrl + "/Sessions/Playing/Stopped");
     auto *reply = jellyfinPost(url, QJsonDocument(body).toJson(QJsonDocument::Compact));
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply->error() != QNetworkReply::NoError)
+            qWarning("[Jellyfin] report stopped failed: %s", qPrintable(reply->errorString()));
         reply->deleteLater();
         m_currentPlaySessionId.clear();
     });

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1459,3 +1459,45 @@ void JellyfinBackend::load_server_preferences() {
         emit serverLanguagePreferencesReady(audioLang, subLang, subMode);
     });
 }
+
+void JellyfinBackend::fetchSegments(const QString &itemId) {
+    QUrl url(m_serverUrl + "/MediaSegments/" + itemId);
+    auto *reply = jellyfinGet(url);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
+        reply->deleteLater();
+
+        // One-shot capability probe on first call
+        if (!m_capabilitiesProbed) {
+            m_capabilitiesProbed = true;
+            if (reply->error() == QNetworkReply::NoError) {
+                emit dynamicOptionsReady("_capabilities",
+                    QVariantList{QString("mediasegments")});
+            } else {
+                emit dynamicOptionsReady("_capabilities", QVariantList{});
+                return;  // no segments to process, server doesn't support it
+            }
+        }
+
+        // Parse segments from the response
+        if (reply->error() != QNetworkReply::NoError) return;
+
+        QJsonObject root = QJsonDocument::fromJson(reply->readAll()).object();
+        QJsonArray items = root["Items"].toArray();
+
+        QVariantList segments;
+        for (const QJsonValue &val : items) {
+            QJsonObject item = val.toObject();
+            QString type = item["Type"].toString();
+            // Only include Intro and Outro segments
+            if (type != "Intro" && type != "Outro") continue;
+
+            QVariantMap seg;
+            seg["type"]    = type;                                  // "Intro" or "Outro"
+            seg["startMs"] = item["StartTicks"].toDouble() / 10000.0;  // ticks → ms
+            seg["endMs"]   = item["EndTicks"].toDouble()   / 10000.0;
+            segments.append(seg);
+        }
+
+        emit segmentsReady(itemId, segments);
+    });
+}

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1450,20 +1450,9 @@ QString JellyfinBackend::get_last_sub_lang() const {
     return m_lastSubLang;
 }
 
-QString JellyfinBackend::get_last_audio_title() const {
-    return m_lastAudioTitle;
-}
-
-QString JellyfinBackend::get_last_sub_title() const {
-    return m_lastSubTitle;
-}
-
-void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang,
-                                           const QString &audioTitle, const QString &subTitle) {
+void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang) {
     m_lastAudioLang = audioLang;
     m_lastSubLang = subLang;
-    if (!audioTitle.isEmpty()) m_lastAudioTitle = audioTitle;
-    if (!subTitle.isEmpty())   m_lastSubTitle   = subTitle;
 }
 
 void JellyfinBackend::load_server_preferences() {

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1028,14 +1028,14 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
     body["MediaSourceId"]          = mediaSourceId;
     if (audioStreamIndex >= 0)
         body["AudioStreamIndex"]   = audioStreamIndex;
-    if (directPlay) {
-        // Disable server-side subtitle selection so an unsupported subtitle
-        // codec can't force a transcode. The static stream still carries every
-        // embedded subtitle; mpv selects/renders them client-side (--sid).
-        body["SubtitleStreamIndex"] = -1;
-    } else if (subtitleStreamIndex >= 0) {
+    // For direct play the device profile already advertises Embed for every
+    // subtitle format (including PGS/VOBSUB), so the server knows we handle
+    // them client-side and won't force a transcode.  Pass the user's actual
+    // selection (or omit if off) so the static stream includes all tracks.
+    // Hardcoding -1 here caused newer Jellyfin servers to strip sub tracks
+    // from the stream, breaking both --sid for image subs and sidecar URLs.
+    if (subtitleStreamIndex >= 0)
         body["SubtitleStreamIndex"] = subtitleStreamIndex;
-    }
     if (maxBitrate > 0) body["MaxStreamingBitrate"] = maxBitrate;
     if (maxHeight  > 0) body["MaxHeight"]           = maxHeight;
     body["EnableDirectPlay"]       = directPlay;

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -534,8 +534,7 @@ QVariantMap JellyfinBackend::formatItem(const QJsonObject &item) const {
                                   : "vtt";
                 subUrl = m_serverUrl + "/Videos/" + item["Id"].toString() + "/"
                        + mediaSource["Id"].toString() + "/Subtitles/"
-                       + QString::number(idx) + "/Stream." + ext
-                       + "?api_key=" + m_accessToken;
+                       + QString::number(idx) + "/Stream." + ext;
             }
             ss["subUrl"] = subUrl;
             subtitleStreams.append(ss);
@@ -580,14 +579,17 @@ QString JellyfinBackend::buildImageUrl(const QString &itemId, const QString &ima
     if (m_serverUrl.isEmpty() || m_accessToken.isEmpty())
         return QString();
 
-    QString url = m_serverUrl + "/Items/" + itemId + "/Images/" + imageType
-                + "?api_key=" + m_accessToken;
+    QUrlQuery q;
     if (!imageTag.isEmpty())
-        url += "&tag=" + imageTag;
+        q.addQueryItem("tag", imageTag);
     if (width > 0)
-        url += "&fillWidth=" + QString::number(width);
+        q.addQueryItem("fillWidth", QString::number(width));
     if (height > 0)
-        url += "&fillHeight=" + QString::number(height);
+        q.addQueryItem("fillHeight", QString::number(height));
+
+    QString url = m_serverUrl + "/Items/" + itemId + "/Images/" + imageType;
+    if (!q.isEmpty())
+        url += "?" + q.toString(QUrl::FullyEncoded);
     return url;
 }
 
@@ -1139,8 +1141,7 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
             const QString srcId = source["Id"].toString(mediaSourceId);
             QString directUrl = m_serverUrl + "/Videos/" + itemId + "/stream"
                               + "?static=true"
-                              + "&mediaSourceId=" + srcId
-                              + "&api_key=" + m_accessToken;
+                              + "&mediaSourceId=" + srcId;
             if (!playSessionId.isEmpty())
                 directUrl += "&PlaySessionId=" + playSessionId;
             m_currentPlaySessionId = playSessionId;
@@ -1162,21 +1163,22 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
         m_currentPlaySessionId = playSessionId;
         m_currentPlayMethod    = QStringLiteral("Transcode");
 
-        QString fullUrl = m_serverUrl + transcodeUrl;
+        // Build the full URL, then strip any api_key from the server-generated
+        // TranscodingUrl — the Authorization header (passed via --http-header-fields
+        // to mpv) covers authentication.
+        QUrl parsedUrl(m_serverUrl + transcodeUrl);
+        {
+            QUrlQuery q(parsedUrl);
+            q.removeAllQueryItems("api_key");
+            parsedUrl.setQuery(q);
+        }
+        QString fullUrl = parsedUrl.toString();
 
         // Pin the URL's PlaySessionId to the one we report with (they should
         // already match; this guarantees it even if the server differs).
         if (!playSessionId.isEmpty())
             fullUrl.replace(QRegularExpression("PlaySessionId=[^&]+"),
                             "PlaySessionId=" + playSessionId);
-
-        // Append api_key only if not already present
-        if (fullUrl.indexOf("apikey=", 0, Qt::CaseInsensitive) < 0)
-            fullUrl += (fullUrl.contains('?') ? "&" : "?") + QString("api_key=") + m_accessToken;
-
-        // Subtitle delivery (soft HLS for text, burn-in for image) is decided by
-        // the DeviceProfile and already baked into TranscodingUrl — no manual
-        // SubtitleStreamIndex/SubtitleMethod override here.
 
         // Enforce max height from quality setting — the server's TranscodingUrl may
         // include a VideoBitrate cap (from our PlaybackInfo POST) but omit MaxHeight,

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -63,6 +63,14 @@ public:
     Q_INVOKABLE void get_resume_playback_options();
     Q_INVOKABLE void load_server_preferences();
 
+    Q_INVOKABLE QString get_last_audio_lang() const;
+    Q_INVOKABLE QString get_last_sub_lang() const;
+    Q_INVOKABLE QString get_last_audio_title() const;
+    Q_INVOKABLE QString get_last_sub_title() const;
+    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           const QString &audioTitle = QString(),
+                                           const QString &subTitle = QString());
+
 signals:
     void authStateChanged();
     void librariesLoaded(const QVariant &libraries);
@@ -114,6 +122,10 @@ private:
     QString m_currentPlayMethod; // "DirectPlay" or "Transcode" — for /Sessions reporting
     QString m_deviceId;
     bool m_capabilitiesProbed = false;
+    QString m_lastAudioLang;
+    QString m_lastSubLang;
+    QString m_lastAudioTitle;
+    QString m_lastSubTitle;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -66,11 +66,7 @@ public:
 
     Q_INVOKABLE QString get_last_audio_lang() const;
     Q_INVOKABLE QString get_last_sub_lang() const;
-    Q_INVOKABLE QString get_last_audio_title() const;
-    Q_INVOKABLE QString get_last_sub_title() const;
-    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang,
-                                           const QString &audioTitle = QString(),
-                                           const QString &subTitle = QString());
+    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang);
 
 signals:
     void authStateChanged();
@@ -126,8 +122,6 @@ private:
     bool m_hasCapability = false;
     QString m_lastAudioLang;
     QString m_lastSubLang;
-    QString m_lastAudioTitle;
-    QString m_lastSubTitle;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -49,6 +49,9 @@ public:
     Q_INVOKABLE void report_playback_stopped(const QString &itemId, const QString &mediaSourceId, qint64 positionTicks, bool failed = false);
     Q_INVOKABLE void report_playback_start(const QString &itemId, const QString &mediaSourceId, const QString &audioStreamId, const QString &subtitleStreamId, qint64 startPositionTicks = 0);
 
+    // Intro/outro skip — MediaSegments API
+    Q_INVOKABLE void fetchSegments(const QString &itemId);
+
     // URL helpers for QML
     Q_INVOKABLE QString image_url(const QString &itemId, const QString &imageType, int width, int height);
 
@@ -75,6 +78,7 @@ signals:
     void seriesNextUpReady(const QVariantMap &detail);
     void streamUrlReady(const QString &url);
     void dynamicOptionsReady(const QString &key, const QVariant &options);
+    void segmentsReady(const QString &itemId, const QVariantList &segments);
     void errorOccurred(const QString &message);
     void logoutComplete();
     void authRevoked();
@@ -108,6 +112,7 @@ private:
     QString m_currentPlaySessionId;
     QString m_currentPlayMethod; // "DirectPlay" or "Transcode" — for /Sessions reporting
     QString m_deviceId;
+    bool m_capabilitiesProbed = false;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -54,6 +54,7 @@ public:
 
     // URL helpers for QML
     Q_INVOKABLE QString image_url(const QString &itemId, const QString &imageType, int width, int height);
+    Q_INVOKABLE QString get_access_token() const { return m_accessToken; }
 
     // Settings
     Q_INVOKABLE QString get_auth_state();

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -66,7 +66,10 @@ public:
 
     Q_INVOKABLE QString get_last_audio_lang() const;
     Q_INVOKABLE QString get_last_sub_lang() const;
-    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang);
+    Q_INVOKABLE int get_last_audio_lang_idx() const;
+    Q_INVOKABLE int get_last_sub_lang_idx() const;
+    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           int audioLangIdx = -1, int subLangIdx = -1);
 
 signals:
     void authStateChanged();
@@ -122,6 +125,8 @@ private:
     bool m_hasCapability = false;
     QString m_lastAudioLang;
     QString m_lastSubLang;
+    int m_lastAudioLangIdx = -1;
+    int m_lastSubLangIdx = -1;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -51,6 +51,7 @@ public:
 
     // Intro/outro skip — MediaSegments API
     Q_INVOKABLE void fetchSegments(const QString &itemId);
+    Q_INVOKABLE void probeCapabilities();
 
     // URL helpers for QML
     Q_INVOKABLE QString image_url(const QString &itemId, const QString &imageType, int width, int height);
@@ -122,6 +123,7 @@ private:
     QString m_currentPlayMethod; // "DirectPlay" or "Transcode" — for /Sessions reporting
     QString m_deviceId;
     bool m_capabilitiesProbed = false;
+    bool m_hasCapability = false;
     QString m_lastAudioLang;
     QString m_lastSubLang;
     QString m_lastAudioTitle;

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -423,7 +423,7 @@ void MpvController::sendKey(const QString &key) {
 
 void MpvController::showOsdSkipPrompt() {
     sendCommand({"script-message", "skip-overlay-state", "1"});
-    sendCommand({"script-message", "240mp-osd-menu-show"});
+    sendCommand({"keypress", "DOWN"});
 }
 
 void MpvController::clearOsdPrompt() {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -418,6 +418,15 @@ void MpvController::sendKey(const QString &key) {
     sendCommand({"keypress", key});
 }
 
+void MpvController::showOsdSkipPrompt() {
+    sendCommand({"script-message", "skip-overlay-state", "1"});
+    sendCommand({"keypress", "DOWN"});
+}
+
+void MpvController::clearOsdPrompt() {
+    sendCommand({"script-message", "skip-overlay-state", "0"});
+}
+
 void MpvController::tryConnectIpc() {
     if (m_ipc->state() == QLocalSocket::ConnectedState ||
         m_ipc->state() == QLocalSocket::ConnectingState)
@@ -437,8 +446,16 @@ void MpvController::onIpcReadyRead() {
             // mpv reports why playback ended: "eof" (played to the end),
             // "quit"/"stop" (user exited), "error", etc. Remember the last one
             // so onProcessFinished can distinguish a natural finish from a quit.
-            if (event == "end-file")
+            if (event == "end-file") {
                 m_lastEndFileReason = obj["reason"].toString();
+            } else if (event == "client-message") {
+                const QJsonArray args = obj["args"].toArray();
+                if (args.size() > 0) {
+                    const QString msg = args[0].toString();
+                    if (msg == "skip-segment")
+                        emit skipRequested();
+                }
+            }
             continue;
         }
 

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -423,7 +423,7 @@ void MpvController::sendKey(const QString &key) {
 
 void MpvController::showOsdSkipPrompt() {
     sendCommand({"script-message", "skip-overlay-state", "1"});
-    sendCommand({"keypress", "DOWN"});
+    sendCommand({"script-message", "240mp-osd-menu-show"});
 }
 
 void MpvController::clearOsdPrompt() {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -67,6 +67,10 @@ MpvController::MpvController(const QString &appRoot, AppCore *appCore, QObject *
         f.close();
     }
 
+    m_hasMpvOscScript     = QFile::exists(m_appRoot + "/scripts/mpv-osc.lua");
+    m_hasAmbientOscScript = QFile::exists(m_appRoot + "/scripts/ambient-osc.lua");
+    m_hasMediaKeysScript  = QFile::exists(m_appRoot + "/scripts/media-keys.lua");
+
     m_ipc = new QLocalSocket(this);
     connect(m_ipc, &QLocalSocket::connected, this, [this] {
         m_connectTimer->stop();
@@ -150,9 +154,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         return;
     }
 
-    const QString oscScriptName = (oscMode == "ambient") ? "ambient-osc.lua" : "mpv-osc.lua";
-    const QString oscScript = m_appRoot + "/scripts/" + oscScriptName;
-    const bool hasOscScript = QFile::exists(oscScript);
+    const bool hasOscScript = (oscMode == "ambient") ? m_hasAmbientOscScript : m_hasMpvOscScript;
+    const QString oscScript = m_appRoot + "/scripts/" + ((oscMode == "ambient") ? "ambient-osc.lua" : "mpv-osc.lua");
 
     // Stamp the log file so each session is identifiable when tailing over SSH.
     {
@@ -160,7 +163,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         if (lf.open(QFile::Append | QFile::Text)) {
             QString safeUrl = url;
             safeUrl.replace(QRegularExpression("Api[_-]?Key=[^&\\s]+", QRegularExpression::CaseInsensitiveOption), "ApiKey=REDACTED");
-            safeUrl.replace(QRegularExpression("X-Plex-Token:[^\\s]+"), "X-Plex-Token=REDACTED");
+            safeUrl.replace(QRegularExpression("X-Plex-Token[=:][^&\\s]+"), "X-Plex-Token=REDACTED");
             safeUrl.replace(QRegularExpression("Token=\"[^\"]+\""), "Token=\"REDACTED\"");
             lf.write(QString("\n=== 240-MP session start %1 ===\n    url: %2\n\n")
                          .arg(QDateTime::currentDateTime().toString(Qt::ISODate))
@@ -181,9 +184,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
 
     // Media-key handling + themed volume bar — loaded for every mode so HID
     // media keys work anytime mpv is playing, not just inside a given module.
-    const QString mediaKeysScript = m_appRoot + "/scripts/media-keys.lua";
-    if (QFile::exists(mediaKeysScript))
-        args << QString("--script=%1").arg(mediaKeysScript);
+    if (m_hasMediaKeysScript)
+        args << QString("--script=%1").arg(m_appRoot + "/scripts/media-keys.lua");
 
     // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
     // primary plane between two consecutive same-size/format stills, so a photo
@@ -397,7 +399,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         QString safeCmd = args.join(" ");
         // Redact all token forms in debug output
         safeCmd.replace(QRegularExpression("Api[_-]?Key=[^&\\s]+", QRegularExpression::CaseInsensitiveOption), "ApiKey=REDACTED");
-        safeCmd.replace(QRegularExpression("X-Plex-Token:[^\\s]+"), "X-Plex-Token=REDACTED");
+        safeCmd.replace(QRegularExpression("X-Plex-Token[=:][^&\\s]+"), "X-Plex-Token=REDACTED");
         safeCmd.replace(QRegularExpression("Token=\"[^\"]+\""), "Token=\"REDACTED\"");
         qDebug("[MpvController] desktop launch: mpv %s", qPrintable(safeCmd));
         m_process->start(bin, args);
@@ -559,7 +561,11 @@ void MpvController::doHeadlessRestore(int pos, int dur, const QString &reason) {
 }
 
 void MpvController::sendCommand(const QJsonArray &args) {
-    if (m_ipc->state() != QLocalSocket::ConnectedState) return;
+    if (m_ipc->state() != QLocalSocket::ConnectedState) {
+        qWarning("[MpvController] IPC not connected, dropping: %s",
+                 QJsonDocument(QJsonObject{{"command", args}}).toJson(QJsonDocument::Compact).constData());
+        return;
+    }
     QJsonObject cmd;
     cmd["command"] = args;
     m_ipc->write(QJsonDocument(cmd).toJson(QJsonDocument::Compact) + "\n");

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -111,7 +111,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
                                  const QString &plexToken, bool muteAudio,
                                  const QString &oscMode, bool shuffle,
                                  const QStringList &subTitles, float imageDurationSec,
-                                 bool imageContent, const QStringList &extraArgs) {
+                                 bool imageContent, const QStringList &extraArgs, const QString &jellyfinToken) {
     if (m_process) {
         m_process->disconnect();
         if (m_process->state() != QProcess::NotRunning) {
@@ -228,9 +228,9 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         scriptOpts << QString("transcode-offset=%1").arg(double(transcodeOffsetSec), 0, 'f', 3);
 
     // Hand the OSC a map of external sub-file URL -> friendly track name so it can show
-    // the real subtitle name. mpv otherwise titles an external sub from its URL basename,
-    // which for Jellyfin sidecars is an opaque "Stream.srt?api_key=...". Purely cosmetic —
-    // it does not affect which sub mpv loads or selects.
+    // the real subtitle name. mpv otherwise titles an external sub from its URL basename
+    // (e.g. "Stream.srt" for Jellyfin sidecars). Purely cosmetic — it does not affect
+    // which sub mpv loads or selects.
     QFile::remove(m_subInfoPath);
     if (!subTitles.isEmpty() && subTitles.size() == subFiles.size()) {
         QJsonObject info;
@@ -273,6 +273,9 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     args << extraArgs;
     if (!plexToken.isEmpty()) {
         args << QString("--http-header-fields=X-Plex-Token:%1").arg(plexToken);
+    }
+    if (!jellyfinToken.isEmpty()) {
+        args << QString("--http-header-fields=Authorization:MediaBrowser Token=\"%1\"").arg(jellyfinToken);
     }
 
     // plex.direct certs are Let's Encrypt-signed but ffmpeg's bundled CA bundle

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -52,7 +52,8 @@ public:
                                   const QStringList &subTitles = {},
                                   float imageDurationSec = 0.0f,
                                   bool imageContent = false,
-                                  const QStringList &extraArgs = {});
+                                  const QStringList &extraArgs = {},
+                                  const QString &jellyfinToken = {});
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -56,6 +56,8 @@ public:
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);
+    Q_INVOKABLE void showOsdSkipPrompt();
+    Q_INVOKABLE void clearOsdPrompt();
 
     // True only on devices whose smooth-playback decode path can't crop/zoom (the
     // Pi 3 DRM-overlay path). Settings uses this to show the "Smooth Playback"
@@ -77,6 +79,8 @@ signals:
     // connects one handler and branches on `reason`, so it can never silently drop
     // a case the way an unhandled per-reason signal would.
     void playbackEnded(int finalPositionMs, int finalDurationMs, const QString &reason);
+
+    void skipRequested();
 
 private slots:
     void onProcessFinished();

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -132,6 +132,9 @@ private:
     int           m_playlistPos  = -1;
     bool          m_headlessMode = false;
     int           m_previousVt   = -1;
+    bool          m_hasMpvOscScript     = false;
+    bool          m_hasAmbientOscScript = false;
+    bool          m_hasMediaKeysScript  = false;
     int           m_qtDrmFd      = -1;
 #ifdef Q_OS_LINUX
     DrmSavedState m_savedDrm     = {};

--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -39,10 +39,12 @@ FocusScope {
             }
         }
         authState = needsAuthState ? appCore.get_module_auth_state(moduleId) : ""
+        var caps = dynamicOptions["_capabilities"] || []
         var filtered = []
         for (var i = 0; i < schema.length; i++) {
             var item = schema[i]
             if (item.requires_auth && (authState === "none" || authState === "")) continue
+            if (item.requires_capability && caps.indexOf(item.requires_capability) < 0) continue
             filtered.push(item)
         }
         schemaItems = filtered
@@ -139,7 +141,12 @@ FocusScope {
             var updated = Object.assign({}, moduleSettingsRoot.dynamicOptions)
             updated[key] = items
             moduleSettingsRoot.dynamicOptions = updated
-            settingsList.forceLayout()
+            // Capability changes affect schema filtering — rebuild the model so
+            // settings with requires_capability appear/disappear immediately.
+            if (key === "_capabilities")
+                buildModel()
+            else
+                settingsList.forceLayout()
         }
         function onModuleAuthStateChanged(mid) {
             if (mid !== moduleSettingsRoot.moduleId) return


### PR DESCRIPTION
## Summary

Add intro and credit skip support for the Jellyfin module using the MediaSegments API, fix a security issue where the Jellyfin auth token was leaking to mpv temp files, and add compatibility with the YouTube module's `extraArgs` parameter in `MpvController`.

**Intro / Credit Skip**

Three modes per-setting: Off, Auto (silently seeks past segments), and Button (SKIP appears in the OSD, usable with gamepad or keyboard). Settings are hidden on servers that don't have the `mediasegments` capability.

**Auth token leak fix**

The Jellyfin access token was embedded as `?api_key=<token>` in stream, subtitle, and image URLs. Mpv wrote these full URLs to `/tmp/240mp-mpv.log` and used them as keys in `/tmp/240mp-mpv-subinfo.json`, both human-readable. Now the token is passed to mpv via `--http-header-fields=Authorization:MediaBrowser Token="..."` instead (same approach Plex already uses), and `api_key` is stripped from all constructed URLs.

**YouTube module compatibility**

Rebased onto upstream/main (which includes the YouTube module). The `loadAndPlay` signature now accepts both `extraArgs` (used by YouTube for `--ytdl=yes`) and `jellyfinToken` side by side, with `--ytdl=no` gated behind extraArgs so it only disables yt-dlp for Plex/Jellyfin streams.

## AI involvement

Both features were built with the help of opencode go models (deepseek-v4-flash/pro, kimi-k2.7-code, mimo-v2.5, qwen-3.7-plus). All testing, code auditing, and research was done by me.

## Testing

- Platform(s) tested: Arch Linux, Raspberry Pi 5 (Raspberry Pi OS)
- Display / output tested: DisplayPort (Arch Linux), Composite (Pi 5)

Both features tested with:
- Transcode playback
- Keyboard navigation in the Player overlay
- Servers with the `mediasegments` capability

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](CONTRIBUTING.md)

Closes #97
Closes #98