### PR TITLE
feat(app core): screen saver for menu idle & playback pause

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(240mp
     src/modules/youtube/YouTubeBackend.cpp
     src/player/MpvController.cpp
     src/input/InputManager.cpp
+    src/input/IdleTracker.cpp
     $<$<BOOL:${APPLE}>:src/macos_utils.mm>
 )
 

--- a/Main.qml
+++ b/Main.qml
@@ -85,7 +85,17 @@ Window {
     Connections {
         target: appCore
         function onAppSettingChanged(key, value) {
-            if (key === "color_scheme") root.currentTheme = value
+            if (key === "color_scheme") {
+                root.currentTheme = value
+            } else if (key === "screensaver_timeout") {
+                if (value === "OFF") {
+                    idleTracker.enabled = false
+                    if (screenSaverActive) screenSaverActive = false
+                } else {
+                    idleTracker.enabled = true
+                    idleTracker.threshold = parseInt(value)
+                }
+            }
         }
     }
 
@@ -117,6 +127,17 @@ Window {
         }
         root.currentTheme = savedTheme
 
+        // Screensaver: apply saved setting (C++ default is enabled=OFF).
+        if (idleTracker) {
+            var ssVal = cfg.app && cfg.app.screensaver_timeout
+            if (ssVal && ssVal !== "OFF") {
+                idleTracker.enabled = true
+                idleTracker.threshold = parseInt(ssVal)
+            } else {
+                idleTracker.enabled = false
+            }
+        }
+
         // Break declarative bindings on macOS so the C++ NSWindow override
         // in forceWindowFullScreen() isn't immediately re-fought by QML.
         if (Qt.platform.os === "osx") {
@@ -143,10 +164,31 @@ Window {
     readonly property var hints: inputManager ? inputManager.hints : ({})
     readonly property string appVersion: appCore ? appCore.appVersion : ""
 
+    // --- SCREEN SAVER STATE ---
+    property bool screenSaverActive: false
+
     // --- APP-LEVEL NAV STACK ---
     property var appNavStack: []
     property var appCurrentParams: ({})
     property bool _startupNavigated: false
+
+    // --- MPV PLAYBACK TRACKING ---
+    // Block the screen saver while mpv is playing so it never flashes during or
+    // immediately after playback. The core guard is in IdleTracker (mpvActive
+    // property), which also resets the idle timer on transitions.
+    Connections {
+        target: mpvController
+        function onPositionChanged(ms) {
+            if (ms > 0 && mpvController.position > 0 && !idleTracker.mpvActive) {
+                idleTracker.mpvActive = true
+                idleTracker.resetActivity()
+            }
+        }
+        function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            idleTracker.mpvActive = false
+            idleTracker.resetActivity()
+        }
+    }
 
     // --- MODULE LOADER ---
     Loader {
@@ -194,6 +236,104 @@ Window {
                 moduleLoader.setSource(prev.source, { "navParams": prev.params, "navListState": prev.listState || {} })
             }
 
+        }
+    }
+
+    // --- SCREEN SAVER (Idle Tracker integration) ---
+    Connections {
+        target: idleTracker
+        function onActiveChanged() {
+            // Only show on active → true; never hide here — the overlay's
+            // key handler owns dismissal, preventing the C++ event filter's
+            // synchronous reset from stealing the key from QML.
+            if (idleTracker.active && idleTracker.enabled) {
+                if (!screenSaverActive) {
+                    var usableW = screenSaverOverlay.width - bounceLogo.width
+                    var usableH = screenSaverOverlay.height - bounceLogo.height
+                    bounceLogo.x = Math.random() * (usableW > 0 ? usableW : 1)
+                    bounceLogo.y = Math.random() * (usableH > 0 ? usableH : 1)
+                    bounceLogo.vx = (Math.random() > 0.5 ? 1 : -1) * (1 + Math.random() * 1.5)
+                    bounceLogo.vy = (Math.random() > 0.5 ? 1 : -1) * (1 + Math.random() * 1.5)
+                    screenSaverActive = true
+                    screenSaverOverlay.forceActiveFocus()
+                }
+            }
+        }
+    }
+
+    Item {
+        id: screenSaverOverlay
+        anchors.fill: parent
+        visible: screenSaverActive
+        z: 9999
+        focus: visible
+
+        // Solid black background — no transparency so it serves as a true
+        // CRT burn-in prevention black frame between the logo bounces.
+        Rectangle {
+            anchors.fill: parent
+            color: "#000000"
+        }
+
+        // Bouncing logo — classic DVD player screen saver
+        Image {
+            id: bounceLogo
+            source: "assets/images/logo.svg"
+            sourceSize.width: root.sw * 0.05
+            sourceSize.height: root.sw * 0.05
+            fillMode: Image.PreserveAspectFit
+            antialiasing: true
+
+            property real vx: 0
+            property real vy: 0
+            property color flashColor: root.accentColor
+
+            // Physics tick at ~60 fps while the overlay is visible
+            Timer {
+                interval: 16
+                repeat: true
+                running: screenSaverActive
+                onTriggered: {
+                    bounceLogo.x += bounceLogo.vx
+                    bounceLogo.y += bounceLogo.vy
+
+                    if (bounceLogo.x + bounceLogo.width > screenSaverOverlay.width) {
+                        bounceLogo.x = screenSaverOverlay.width - bounceLogo.width
+                        bounceLogo.vx = -Math.abs(bounceLogo.vx)
+                        bounceLogo.flashColor = root.accentColor
+                    } else if (bounceLogo.x < 0) {
+                        bounceLogo.x = 0
+                        bounceLogo.vx = Math.abs(bounceLogo.vx)
+                        bounceLogo.flashColor = root.accentColor
+                    }
+
+                    if (bounceLogo.y + bounceLogo.height > screenSaverOverlay.height) {
+                        bounceLogo.y = screenSaverOverlay.height - bounceLogo.height
+                        bounceLogo.vy = -Math.abs(bounceLogo.vy)
+                        bounceLogo.flashColor = root.accentColor
+                    } else if (bounceLogo.y < 0) {
+                        bounceLogo.y = 0
+                        bounceLogo.vy = Math.abs(bounceLogo.vy)
+                        bounceLogo.flashColor = root.accentColor
+                    }
+                }
+            }
+
+            // Subtle colour flash on each bounce
+            ColorAnimation on flashColor {
+                from: root.accentColor
+                to: root.primaryColor
+                duration: 300
+                running: screenSaverActive
+            }
+        }
+
+        // Capture any keypress to dismiss — consumes the event so the
+        // underlying view never sees it, preventing accidental navigation.
+        Keys.onPressed: (event) => {
+            event.accepted = true
+            screenSaverActive = false
+            moduleLoader.forceActiveFocus()
         }
     }
 }

--- a/Main.qml
+++ b/Main.qml
@@ -88,12 +88,13 @@ Window {
             if (key === "color_scheme") {
                 root.currentTheme = value
             } else if (key === "screensaver_timeout") {
-                if (value === "OFF") {
+                var sec = parseInt(value)
+                if (sec > 0) {
+                    idleTracker.threshold = sec
+                    idleTracker.enabled = true
+                } else {  // "OFF"
                     idleTracker.enabled = false
                     if (screenSaverActive) screenSaverActive = false
-                } else {
-                    idleTracker.enabled = true
-                    idleTracker.threshold = parseInt(value)
                 }
             }
         }
@@ -127,15 +128,13 @@ Window {
         }
         root.currentTheme = savedTheme
 
-        // Screensaver: apply saved setting (C++ default is enabled=OFF).
-        if (idleTracker) {
-            var ssVal = cfg.app && cfg.app.screensaver_timeout
-            if (ssVal && ssVal !== "OFF") {
-                idleTracker.enabled = true
-                idleTracker.threshold = parseInt(ssVal)
-            } else {
-                idleTracker.enabled = false
-            }
+        // Screensaver: the tracker starts disabled; this is the single place the
+        // saved setting is applied (live changes land in onAppSettingChanged above,
+        // mirroring color_scheme). parseInt("OFF") is NaN, so OFF stays disabled.
+        var ssSec = parseInt(cfg.app && cfg.app.screensaver_timeout)
+        if (ssSec > 0) {
+            idleTracker.threshold = ssSec
+            idleTracker.enabled = true
         }
 
         // Break declarative bindings on macOS so the C++ NSWindow override
@@ -179,7 +178,7 @@ Window {
     Connections {
         target: mpvController
         function onPositionChanged(ms) {
-            if (ms > 0 && mpvController.position > 0 && !idleTracker.mpvActive) {
+            if (ms > 0 && !idleTracker.mpvActive) {
                 idleTracker.mpvActive = true
                 idleTracker.resetActivity()
             }
@@ -286,7 +285,6 @@ Window {
 
             property real vx: 0
             property real vy: 0
-            property color flashColor: root.accentColor
 
             // Physics tick at ~60 fps while the overlay is visible
             Timer {
@@ -300,38 +298,32 @@ Window {
                     if (bounceLogo.x + bounceLogo.width > screenSaverOverlay.width) {
                         bounceLogo.x = screenSaverOverlay.width - bounceLogo.width
                         bounceLogo.vx = -Math.abs(bounceLogo.vx)
-                        bounceLogo.flashColor = root.accentColor
                     } else if (bounceLogo.x < 0) {
                         bounceLogo.x = 0
                         bounceLogo.vx = Math.abs(bounceLogo.vx)
-                        bounceLogo.flashColor = root.accentColor
                     }
 
                     if (bounceLogo.y + bounceLogo.height > screenSaverOverlay.height) {
                         bounceLogo.y = screenSaverOverlay.height - bounceLogo.height
                         bounceLogo.vy = -Math.abs(bounceLogo.vy)
-                        bounceLogo.flashColor = root.accentColor
                     } else if (bounceLogo.y < 0) {
                         bounceLogo.y = 0
                         bounceLogo.vy = Math.abs(bounceLogo.vy)
-                        bounceLogo.flashColor = root.accentColor
                     }
                 }
-            }
-
-            // Subtle colour flash on each bounce
-            ColorAnimation on flashColor {
-                from: root.accentColor
-                to: root.primaryColor
-                duration: 300
-                running: screenSaverActive
             }
         }
 
         // Capture any keypress to dismiss — consumes the event so the
         // underlying view never sees it, preventing accidental navigation.
+        // Ctrl+Q still quits (moduleLoader's handler is a sibling, so it
+        // can't see keys focused here — handle the chord directly).
         Keys.onPressed: (event) => {
             event.accepted = true
+            if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_Q) {
+                Qt.quit()
+                return
+            }
             screenSaverActive = false
             moduleLoader.forceActiveFocus()
         }

--- a/scripts/screensaver.lua
+++ b/scripts/screensaver.lua
@@ -1,4 +1,4 @@
--- Screen saver for 240-MP: bounces "240-MP" text across a solid black
+-- Screen saver for 240-MP: bounces the 240-MP logo across a solid black
 -- background when the video has been paused longer than the configured timeout.
 --
 -- Loaded by --script= only when screensaver_timeout != "OFF".
@@ -13,14 +13,47 @@ local assdraw = require("mp.assdraw")
 local timeout_sec = tonumber(mp.get_opt("screensaver_timeout") or "60") or 60
 local SPEED = 2
 
+-- ─── logo ─────────────────────────────────────────────────────────────────────
+-- Vector copy of assets/images/logo.svg (44x24 units, straight segments only,
+-- filled white) so the mpv screen saver bounces the same mark as the QML one.
+-- Subpath windings alternate, so the mask cutout and the shape inside it render
+-- as hole / fill under both the even-odd and nonzero fill rules.
+local LOGO_UNITS_W, LOGO_UNITS_H = 44, 24
+local LOGO_SUBPATHS = {
+    { 44,0, 44,24, 0,24, 0,0 },
+    { 8,15.5, 8,17.5, 10,17.5, 10,19.5, 34,19.5, 34,17.5, 36,17.5, 36,15.5,
+      38,15.5, 38,8.5, 36,8.5, 36,6.5, 34,6.5, 34,4.5, 28,4.5, 28,6.5,
+      26,6.5, 26,8.5, 24,8.5, 24,15.5, 26,15.5, 26,17.5, 18,17.5, 18,15.5,
+      20,15.5, 20,8.5, 18,8.5, 18,6.5, 16,6.5, 16,4.5, 10,4.5, 10,6.5,
+      8,6.5, 8,8.5, 6,8.5, 6,15.5 },
+    { 27,13.535, 26,13.535, 26,10.035, 27,10.035, 27,9.035, 28,9.035,
+      28,8.035, 29,8.035, 29,7.035, 33,7.035, 33,8.035, 34,8.035,
+      34,9.035, 35,9.035, 35,10.035, 36,10.035, 36,13.535, 35,13.535,
+      35,14.536, 34,14.536, 34,15.535, 33,15.535, 33,16.535, 29,16.535,
+      29,15.535, 28,15.535, 28,14.536, 27,14.536 },
+}
+
+-- Build the ASS drawing string at a pixel scale, origin 0,0 (\pos moves it)
+local function logo_drawing(scale)
+    local parts = {}
+    for _, sp in ipairs(LOGO_SUBPATHS) do
+        for i = 1, #sp, 2 do
+            parts[#parts + 1] = string.format("%s%.1f %.1f",
+                i == 1 and "m " or "l ", sp[i] * scale, sp[i + 1] * scale)
+        end
+    end
+    return table.concat(parts, " ")
+end
+
 -- ─── state ───────────────────────────────────────────────────────────────────
 local ss_active   = false
 local paused_sec  = 0
 local x, y   = 20, 20
 local vx, vy = SPEED, SPEED
--- Bounce box for "240-MP" at \fs108 (overlay units == OSD pixels)
-local TEXT_W  = 400
-local TEXT_H  = 120
+-- Set at activation: logo sized to 5% of OSD width (matching the QML overlay's
+-- sourceSize of root.sw * 0.05), drawing pre-scaled to pixels.
+local logo_w, logo_h = 0, 0
+local logo_path = ""
 
 -- ─── forward declarations ─────────────────────────────────────────────────────
 local activate, dismiss, anim_timer
@@ -38,11 +71,11 @@ local function draw_frame(w, h, tx, ty)
         "{\\bord0\\shad0\\1c&H000000&\\1a&H00&\\p1}m 0 0 l %d 0 l %d %d l 0 %d{\\p0}",
         w, w, h, h
     ))
-    -- Bouncing text on top
+    -- Bouncing logo on top
     a:new_event()
     a:append(string.format(
-        "{\\an7\\pos(%d,%d)\\fs108\\b1\\c&HFFFFFF&}240-MP{\\b0}",
-        math.floor(tx), math.floor(ty)
+        "{\\an7\\pos(%d,%d)\\bord0\\shad0\\1c&HFFFFFF&\\p1}%s{\\p0}",
+        math.floor(tx), math.floor(ty), logo_path
     ))
     overlay.res_x = w
     overlay.res_y = h
@@ -66,8 +99,13 @@ activate = function()
     if ww == 0 then ww = 640 end
     if wh == 0 then wh = 480 end
 
-    x = math.floor(math.random() * math.max(1, math.floor(ww / 2)))
-    y = math.floor(math.random() * math.max(1, math.floor(wh / 2)))
+    local scale = (ww * 0.1) / LOGO_UNITS_W
+    logo_w = LOGO_UNITS_W * scale
+    logo_h = LOGO_UNITS_H * scale
+    logo_path = logo_drawing(scale)
+
+    x = math.floor(math.random() * math.max(1, ww - logo_w))
+    y = math.floor(math.random() * math.max(1, wh - logo_h))
     vx = SPEED
     vy = SPEED
 
@@ -116,16 +154,16 @@ anim_timer = mp.add_periodic_timer(0.016, function()
     x = x + vx
     y = y + vy
 
-    if x + TEXT_W > ww then
-        x = ww - TEXT_W
+    if x + logo_w > ww then
+        x = ww - logo_w
         vx = -math.abs(vx)
     elseif x < 0 then
         x = 0
         vx = math.abs(vx)
     end
 
-    if y + TEXT_H > wh then
-        y = wh - TEXT_H
+    if y + logo_h > wh then
+        y = wh - logo_h
         vy = -math.abs(vy)
     elseif y < 0 then
         y = 0

--- a/scripts/screensaver.lua
+++ b/scripts/screensaver.lua
@@ -3,25 +3,24 @@
 --
 -- Loaded by --script= only when screensaver_timeout != "OFF".
 -- Uses the same ASS-overlay technique as media-keys.lua's volume bar.
--- On any key the overlay is dismissed AND the key falls through to its default
--- handler, so a single SPACE press both dismisses the screen saver AND unpauses.
+-- Dismiss keys are consumed, matching the app-shell overlay: the first press
+-- only wakes the screen saver, the next press acts normally.
 
-local options = require("mp.options")
-local assdraw  = require("mp.assdraw")
-local o = {
-    timeout = 60,
-    speed   = 2,
-}
-options.read_options(o, "screensaver")
+local assdraw = require("mp.assdraw")
+
+-- Raw script-opts key (same convention as mpv-osc.lua's transcode-offset);
+-- mp.options.read_options would instead expect a "screensaver-" prefix.
+local timeout_sec = tonumber(mp.get_opt("screensaver_timeout") or "60") or 60
+local SPEED = 2
 
 -- ─── state ───────────────────────────────────────────────────────────────────
 local ss_active   = false
 local paused_sec  = 0
-local timeout_sec = o.timeout
 local x, y   = 20, 20
-local vx, vy = o.speed, o.speed
-local TEXT_W  = 148
-local TEXT_H  = 38
+local vx, vy = SPEED, SPEED
+-- Bounce box for "240-MP" at \fs108 (overlay units == OSD pixels)
+local TEXT_W  = 400
+local TEXT_H  = 120
 
 -- ─── forward declarations ─────────────────────────────────────────────────────
 local activate, dismiss, anim_timer
@@ -54,7 +53,7 @@ end
 -- ─── key bindings ─────────────────────────────────────────────────────────────
 local DISMISS_KEYS = {
     "SPACE", "ENTER", "KP_ENTER", "ESC",
-    "LEFT", "RIGHT", "UP", "DOWN", "PGUP",
+    "LEFT", "RIGHT", "UP", "DOWN", "PGUP", "PGDWN",
     "HOME", "END",
     "MBTN_LEFT", "MBTN_RIGHT",
 }
@@ -69,8 +68,8 @@ activate = function()
 
     x = math.floor(math.random() * math.max(1, math.floor(ww / 2)))
     y = math.floor(math.random() * math.max(1, math.floor(wh / 2)))
-    vx = o.speed
-    vy = o.speed
+    vx = SPEED
+    vy = SPEED
 
     for _, k in ipairs(DISMISS_KEYS) do
         mp.add_forced_key_binding(k, "ss-dismiss-" .. k, dismiss)

--- a/scripts/screensaver.lua
+++ b/scripts/screensaver.lua
@@ -1,0 +1,138 @@
+-- Screen saver for 240-MP: bounces "240-MP" text across a solid black
+-- background when the video has been paused longer than the configured timeout.
+--
+-- Loaded by --script= only when screensaver_timeout != "OFF".
+-- Uses the same ASS-overlay technique as media-keys.lua's volume bar.
+-- On any key the overlay is dismissed AND the key falls through to its default
+-- handler, so a single SPACE press both dismisses the screen saver AND unpauses.
+
+local options = require("mp.options")
+local assdraw  = require("mp.assdraw")
+local o = {
+    timeout = 60,
+    speed   = 2,
+}
+options.read_options(o, "screensaver")
+
+-- ─── state ───────────────────────────────────────────────────────────────────
+local ss_active   = false
+local paused_sec  = 0
+local timeout_sec = o.timeout
+local x, y   = 20, 20
+local vx, vy = o.speed, o.speed
+local TEXT_W  = 148
+local TEXT_H  = 38
+
+-- ─── forward declarations ─────────────────────────────────────────────────────
+local activate, dismiss, anim_timer
+
+-- ─── ASS overlay ──────────────────────────────────────────────────────────────
+local overlay = mp.create_osd_overlay("ass-events")
+
+-- ─── draw full frame ─────────────────────────────────────────────────────────
+local function draw_frame(w, h, tx, ty)
+    local a = assdraw.ass_new()
+    -- Solid black background covering the entire OSD area
+    a:new_event()
+    a:pos(0, 0)
+    a:append(string.format(
+        "{\\bord0\\shad0\\1c&H000000&\\1a&H00&\\p1}m 0 0 l %d 0 l %d %d l 0 %d{\\p0}",
+        w, w, h, h
+    ))
+    -- Bouncing text on top
+    a:new_event()
+    a:append(string.format(
+        "{\\an7\\pos(%d,%d)\\fs108\\b1\\c&HFFFFFF&}240-MP{\\b0}",
+        math.floor(tx), math.floor(ty)
+    ))
+    overlay.res_x = w
+    overlay.res_y = h
+    overlay.data  = a.text
+    overlay:update()
+end
+
+-- ─── key bindings ─────────────────────────────────────────────────────────────
+local DISMISS_KEYS = {
+    "SPACE", "ENTER", "KP_ENTER", "ESC",
+    "LEFT", "RIGHT", "UP", "DOWN", "PGUP",
+    "HOME", "END",
+    "MBTN_LEFT", "MBTN_RIGHT",
+}
+
+activate = function()
+    if ss_active then return end
+    ss_active = true
+
+    local ww, wh = mp.get_osd_size()
+    if ww == 0 then ww = 640 end
+    if wh == 0 then wh = 480 end
+
+    x = math.floor(math.random() * math.max(1, math.floor(ww / 2)))
+    y = math.floor(math.random() * math.max(1, math.floor(wh / 2)))
+    vx = o.speed
+    vy = o.speed
+
+    for _, k in ipairs(DISMISS_KEYS) do
+        mp.add_forced_key_binding(k, "ss-dismiss-" .. k, dismiss)
+    end
+
+    draw_frame(ww, wh, x, y)
+    anim_timer:resume()
+end
+
+dismiss = function()
+    if not ss_active then return end
+    ss_active = false
+    paused_sec = 0
+
+    overlay:remove()
+    anim_timer:kill()
+
+    for _, k in ipairs(DISMISS_KEYS) do
+        pcall(mp.remove_key_binding, "ss-dismiss-" .. k)
+    end
+end
+
+-- ─── 1-second tick: count up while paused ────────────────────────────────────
+local pause_monitor = mp.add_periodic_timer(1.0, function()
+    if ss_active then return end
+    local is_paused = mp.get_property_native("pause")
+    if is_paused then
+        paused_sec = paused_sec + 1
+        if paused_sec >= timeout_sec then
+            activate()
+        end
+    else
+        paused_sec = 0
+    end
+end)
+
+-- ─── ~60 fps animation ───────────────────────────────────────────────────────
+anim_timer = mp.add_periodic_timer(0.016, function()
+    if not ss_active then return end
+
+    local ww, wh = mp.get_osd_size()
+    if ww == 0 or wh == 0 then return end
+
+    x = x + vx
+    y = y + vy
+
+    if x + TEXT_W > ww then
+        x = ww - TEXT_W
+        vx = -math.abs(vx)
+    elseif x < 0 then
+        x = 0
+        vx = math.abs(vx)
+    end
+
+    if y + TEXT_H > wh then
+        y = wh - TEXT_H
+        vy = -math.abs(vy)
+    elseif y < 0 then
+        y = 0
+        vy = math.abs(vy)
+    end
+
+    draw_frame(ww, wh, x, y)
+end)
+anim_timer:kill()

--- a/src/input/IdleTracker.cpp
+++ b/src/input/IdleTracker.cpp
@@ -1,0 +1,95 @@
+#include "IdleTracker.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QKeyEvent>
+
+IdleTracker::IdleTracker(int thresholdSec, QObject *parent)
+    : QObject(parent)
+    , m_threshold(thresholdSec)
+{
+    m_timer.setInterval(1000);
+    connect(&m_timer, &QTimer::timeout, this, &IdleTracker::tick);
+
+    // App-wide event filter catches all keyboard and gamepad-synthesised key
+    // events before they reach QML, so we reset the idle counter on any input.
+    QCoreApplication::instance()->installEventFilter(this);
+
+    m_timer.start();
+}
+
+void IdleTracker::setThreshold(int seconds)
+{
+    if (m_threshold == seconds)
+        return;
+    m_threshold = seconds;
+    emit thresholdChanged();
+}
+
+void IdleTracker::setEnabled(bool on)
+{
+    if (m_enabled == on)
+        return;
+    m_enabled = on;
+    emit enabledChanged();
+
+    if (!m_enabled && m_active) {
+        m_active = false;
+        emit activeChanged();
+    }
+}
+
+void IdleTracker::setMpvActive(bool active)
+{
+    if (m_mpvActive == active)
+        return;
+    m_mpvActive = active;
+    emit mpvActiveChanged();
+
+    // If activation was blocked by mpv and mpv just ended, deactive immediately
+    // so the screen saver doesn't flash on the menu after playback.
+    if (!m_mpvActive && m_active) {
+        m_active = false;
+        emit activeChanged();
+    }
+}
+
+void IdleTracker::resetActivity()
+{
+    const bool wasActive = m_active;
+    m_idleSeconds = 0;
+    m_active = false;
+
+    emit idleSecondsChanged();
+    if (wasActive)
+        emit activeChanged();
+    emit activityDetected();
+}
+
+bool IdleTracker::eventFilter(QObject *obj, QEvent *event)
+{
+    Q_UNUSED(obj)
+    if (event->type() == QEvent::KeyPress) {
+        auto *ke = static_cast<QKeyEvent *>(event);
+        // Ignore auto-repeat events — holding a key shouldn't keep resetting
+        // the idle timer forever (the first press resets, held repeats don't).
+        if (!ke->isAutoRepeat())
+            resetActivity();
+    }
+    // Never consume the event — let it reach QML normally.
+    return false;
+}
+
+void IdleTracker::tick()
+{
+    if (m_active || !m_enabled || m_mpvActive)
+        return;
+
+    ++m_idleSeconds;
+    emit idleSecondsChanged();
+
+    if (m_idleSeconds >= m_threshold) {
+        m_active = true;
+        emit activeChanged();
+    }
+}

--- a/src/input/IdleTracker.cpp
+++ b/src/input/IdleTracker.cpp
@@ -46,7 +46,7 @@ void IdleTracker::setMpvActive(bool active)
     m_mpvActive = active;
     emit mpvActiveChanged();
 
-    // If activation was blocked by mpv and mpv just ended, deactive immediately
+    // If activation was blocked by mpv and mpv just ended, deactivate immediately
     // so the screen saver doesn't flash on the menu after playback.
     if (!m_mpvActive && m_active) {
         m_active = false;

--- a/src/input/IdleTracker.h
+++ b/src/input/IdleTracker.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <QObject>
+#include <QTimer>
+#include <QElapsedTimer>
+
+// Tracks global input inactivity and emits signals when idle for a configurable
+// number of seconds. Used by the screen saver overlay in Main.qml.
+//
+// Installs a global QEventFilter that resets on any KeyPress (real keyboard
+// and gamepad-synthesized events both reach it). A 1-second tick timer
+// increments m_idleSeconds while no activity is detected.
+//
+// Exposed to QML as a context property "idleTracker".
+class IdleTracker : public QObject {
+    Q_OBJECT
+    // True when idle time has exceeded the threshold.
+    Q_PROPERTY(bool active READ isActive NOTIFY activeChanged)
+    // Current consecutive idle seconds since last activity.
+    Q_PROPERTY(int idleSeconds READ idleSeconds NOTIFY idleSecondsChanged)
+    // Idle threshold in seconds before active becomes true.
+    Q_PROPERTY(int threshold READ threshold WRITE setThreshold NOTIFY thresholdChanged)
+    // Master switch — when false the timer never fires active.
+    Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY enabledChanged)
+    // Blocks activation while a media session is active (mpv playing).
+    // Prevents the screen saver from showing on top of playback.
+    Q_PROPERTY(bool mpvActive READ isMpvActive WRITE setMpvActive NOTIFY mpvActiveChanged)
+
+public:
+    explicit IdleTracker(int thresholdSec = 60, QObject *parent = nullptr);
+
+    bool isActive()      const { return m_active;       }
+    int  idleSeconds()   const { return m_idleSeconds;  }
+    int  threshold()     const { return m_threshold;    }
+    bool isEnabled()     const { return m_enabled;      }
+    bool isMpvActive()   const { return m_mpvActive;    }
+
+    void setThreshold(int seconds);
+    void setEnabled(bool on);
+    void setMpvActive(bool active);
+
+    // Called from C++ or QML to mark input activity — resets the idle counter
+    // and deactivates the idle state if it was active.
+    Q_INVOKABLE void resetActivity();
+
+signals:
+    void activeChanged();
+    void idleSecondsChanged();
+    void thresholdChanged();
+    void enabledChanged();
+    void mpvActiveChanged();
+    // Emitted on every call to resetActivity (including from the event filter).
+    void activityDetected();
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+private slots:
+    void tick();
+
+private:
+    QTimer m_timer;
+    int    m_threshold;
+    int    m_idleSeconds = 0;
+    bool   m_active      = false;
+    bool   m_enabled     = true;
+    bool   m_mpvActive   = false;
+};

--- a/src/input/IdleTracker.h
+++ b/src/input/IdleTracker.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <QObject>
 #include <QTimer>
-#include <QElapsedTimer>
 
 // Tracks global input inactivity and emits signals when idle for a configurable
 // number of seconds. Used by the screen saver overlay in Main.qml.
@@ -62,6 +61,6 @@ private:
     int    m_threshold;
     int    m_idleSeconds = 0;
     bool   m_active      = false;
-    bool   m_enabled     = true;
+    bool   m_enabled     = false;   // off until Main.qml applies the saved setting
     bool   m_mpvActive   = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "modules/youtube/YouTubeBackend.h"
 #include "player/MpvController.h"
 #include "input/InputManager.h"
+#include "input/IdleTracker.h"
 #ifdef Q_OS_MAC
 #include "macos_utils.h"
 #endif
@@ -85,6 +86,23 @@ int main(int argc, char *argv[]) {
     YouTubeBackend      youtubeBackend(appRoot, dataRoot);
     MpvController       mpvController(appRoot, &appCore);
     InputManager        inputManager(dataRoot);
+    IdleTracker         idleTracker(60);   // default threshold, disabled until user opts in
+
+    // Read saved screensaver setting ("OFF" or a number). Defaults to OFF on fresh install.
+    {
+        const QVariant saved = appCore.get_setting("", "screensaver_timeout");
+        const QString val = saved.toString();
+        if (val == QLatin1String("OFF") || val.isEmpty()) {
+            idleTracker.setEnabled(false);
+        } else {
+            bool ok = false;
+            int n = val.toInt(&ok);
+            if (ok && n >= 10) {
+                idleTracker.setEnabled(true);
+                idleTracker.setThreshold(n);
+            }
+        }
+    }
 
     // When the Qt window is inactive (fullscreen mpv has OS focus on macOS),
     // gamepad actions bypass QML and drive mpv directly over IPC.
@@ -101,6 +119,7 @@ int main(int argc, char *argv[]) {
     appCore.registerModule("com.240mp.ambient_mode", "ambientModeBackend", &ambientMode, ctx);
     appCore.registerModule("com.240mp.youtube",      "youtubeBackend",     &youtubeBackend, ctx);
 
+    ctx->setContextProperty("idleTracker",   &idleTracker);
     ctx->setContextProperty("appCore",       &appCore);
     ctx->setContextProperty("mpvController", &mpvController);
     ctx->setContextProperty("inputManager",  &inputManager);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,23 +86,7 @@ int main(int argc, char *argv[]) {
     YouTubeBackend      youtubeBackend(appRoot, dataRoot);
     MpvController       mpvController(appRoot, &appCore);
     InputManager        inputManager(dataRoot);
-    IdleTracker         idleTracker(60);   // default threshold, disabled until user opts in
-
-    // Read saved screensaver setting ("OFF" or a number). Defaults to OFF on fresh install.
-    {
-        const QVariant saved = appCore.get_setting("", "screensaver_timeout");
-        const QString val = saved.toString();
-        if (val == QLatin1String("OFF") || val.isEmpty()) {
-            idleTracker.setEnabled(false);
-        } else {
-            bool ok = false;
-            int n = val.toInt(&ok);
-            if (ok && n >= 10) {
-                idleTracker.setEnabled(true);
-                idleTracker.setThreshold(n);
-            }
-        }
-    }
+    IdleTracker         idleTracker(60);   // disabled until Main.qml applies the saved setting
 
     // When the Qt window is inactive (fullscreen mpv has OS focus on macOS),
     // gamepad actions bypass QML and drive mpv directly over IPC.

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -186,24 +186,15 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         args << QString("--script=%1").arg(mediaKeysScript);
 
     // Screen saver Lua script — only loaded when the user has opted in via the
-    // screensaver_timeout setting (any value other than "OFF").
-    // Script-opt is appended to scriptOpts below where it is declared.
-    bool screensaverEnabled = false;
-    int  screensaverTimeout  = 60;
+    // screensaver_timeout setting (a positive number of seconds; "OFF" parses
+    // to 0 and disables). The timeout reaches the script via scriptOpts below.
+    int screensaverTimeout = 0;
     if (m_appCore) {
-        const QVariant ssVal = m_appCore->get_setting(QString(), "screensaver_timeout");
-        const QString ssStr = ssVal.toString();
-        if (ssStr != QLatin1String("OFF") && !ssStr.isEmpty()) {
-            const QString ssScript = m_appRoot + "/scripts/screensaver.lua";
-            if (QFile::exists(ssScript)) {
-                args << QString("--script=%1").arg(ssScript);
-                bool ok = false;
-                int n = ssStr.toInt(&ok);
-                if (ok && n >= 10) {
-                    screensaverEnabled = true;
-                    screensaverTimeout = n;
-                }
-            }
+        const int n = m_appCore->get_setting(QString(), "screensaver_timeout").toString().toInt();
+        const QString ssScript = m_appRoot + "/scripts/screensaver.lua";
+        if (n > 0 && QFile::exists(ssScript)) {
+            screensaverTimeout = n;
+            args << QString("--script=%1").arg(ssScript);
         }
     }
 
@@ -248,7 +239,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     QStringList scriptOpts;
     if (transcodeOffsetSec > 0.5f)
         scriptOpts << QString("transcode-offset=%1").arg(double(transcodeOffsetSec), 0, 'f', 3);
-    if (screensaverEnabled)
+    if (screensaverTimeout > 0)
         scriptOpts << QString("screensaver_timeout=%1").arg(screensaverTimeout);
 
     // Hand the OSC a map of external sub-file URL -> friendly track name so it can show

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -185,6 +185,28 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     if (QFile::exists(mediaKeysScript))
         args << QString("--script=%1").arg(mediaKeysScript);
 
+    // Screen saver Lua script — only loaded when the user has opted in via the
+    // screensaver_timeout setting (any value other than "OFF").
+    // Script-opt is appended to scriptOpts below where it is declared.
+    bool screensaverEnabled = false;
+    int  screensaverTimeout  = 60;
+    if (m_appCore) {
+        const QVariant ssVal = m_appCore->get_setting(QString(), "screensaver_timeout");
+        const QString ssStr = ssVal.toString();
+        if (ssStr != QLatin1String("OFF") && !ssStr.isEmpty()) {
+            const QString ssScript = m_appRoot + "/scripts/screensaver.lua";
+            if (QFile::exists(ssScript)) {
+                args << QString("--script=%1").arg(ssScript);
+                bool ok = false;
+                int n = ssStr.toInt(&ok);
+                if (ok && n >= 10) {
+                    screensaverEnabled = true;
+                    screensaverTimeout = n;
+                }
+            }
+        }
+    }
+
     // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
     // primary plane between two consecutive same-size/format stills, so a photo
     // playlist freezes on the first frame while the clock advances. This script
@@ -226,6 +248,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     QStringList scriptOpts;
     if (transcodeOffsetSec > 0.5f)
         scriptOpts << QString("transcode-offset=%1").arg(double(transcodeOffsetSec), 0, 'f', 3);
+    if (screensaverEnabled)
+        scriptOpts << QString("screensaver_timeout=%1").arg(screensaverTimeout);
 
     // Hand the OSC a map of external sub-file URL -> friendly track name so it can show
     // the real subtitle name. mpv otherwise titles an external sub from its URL basename,

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -75,6 +75,7 @@ MpvController::MpvController(const QString &appRoot, AppCore *appCore, QObject *
         sendCommand({"observe_property", 1, "time-pos"});
         sendCommand({"observe_property", 2, "duration"});
         sendCommand({"observe_property", 3, "playlist-pos"});
+        sendCommand({"observe_property", 4, "pause"});
     });
     connect(m_ipc, &QLocalSocket::readyRead, this, &MpvController::onIpcReadyRead);
 
@@ -84,10 +85,14 @@ MpvController::MpvController(const QString &appRoot, AppCore *appCore, QObject *
 
     // Watchdog: fires every 10 s; logs a warning if no IPC time-pos event has
     // arrived for 30 s while connected — strong indicator of a playback freeze.
+    // Exempt while paused: time-pos is legitimately silent then (a long pause is
+    // a normal state now that the screen saver runs over it), and the unpause
+    // property-change event refreshes m_lastIpcEventMs so the 30 s window
+    // restarts fresh on resume.
     m_watchdogTimer = new QTimer(this);
     m_watchdogTimer->setInterval(10000);
     connect(m_watchdogTimer, &QTimer::timeout, this, [this] {
-        if (m_ipc->state() != QLocalSocket::ConnectedState) return;
+        if (m_ipc->state() != QLocalSocket::ConnectedState || m_paused) return;
         qint64 silenceMs = QDateTime::currentMSecsSinceEpoch() - m_lastIpcEventMs;
         if (silenceMs > 30000) {
             qWarning("[MpvController] WATCHDOG: no IPC time-pos event for %lld s — possible freeze",
@@ -127,6 +132,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     m_position    = 0;
     m_duration    = 0;
     m_playlistPos = -1;
+    m_paused      = false;
     m_lastEndFileReason.clear();
 
 #ifdef Q_OS_MACOS
@@ -462,6 +468,10 @@ void MpvController::onIpcReadyRead() {
         const QString     name = obj["name"].toString();
         const QJsonValue  data = obj["data"];
         if (data.isNull() || data.isUndefined()) continue; // property unavailable during shutdown
+        if (name == "pause") {
+            m_paused = data.toBool();
+            continue;
+        }
         const double val = data.toDouble();
         if (name == "time-pos") {
             m_position = int(val * 1000.0);

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -116,6 +116,7 @@ private:
     QTimer       *m_connectTimer   = nullptr;
     QTimer       *m_watchdogTimer  = nullptr;
     qint64        m_lastIpcEventMs = 0;
+    bool          m_paused         = false;  // mirrors mpv's pause property (watchdog exemption)
     QString       m_appRoot;
     QString       m_socketPath;
     QString       m_inputConfPath;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -112,6 +112,20 @@ FocusScope {
             moduleId: ""
         })
 
+        // SCREEN SAVER section — single control: OFF disables, a number sets the
+        // timeout for both menu idle and playback pause (handled inside mpv).
+        items.push({ type: "section", label: "Screen Saver" })
+
+        items.push({
+            type: "list_single",
+            key: "screensaver_timeout",
+            label: "Screen Saver",
+            options: ["OFF", "30", "60", "120"],
+            value: appSettings["screensaver_timeout"] || "OFF",
+            description: "Prevent CRT burn-in after seconds of inactivity or pause",
+            moduleId: ""
+        })
+
         // MODULES section — only show modules with has_settings
         var hasModuleSettings = false
         for (var i = 0; i < installedModules.length; i++) {

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -114,8 +114,6 @@ FocusScope {
 
         // SCREEN SAVER section — single control: OFF disables, a number sets the
         // timeout for both menu idle and playback pause (handled inside mpv).
-        items.push({ type: "section", label: "Screen Saver" })
-
         items.push({
             type: "list_single",
             key: "screensaver_timeout",


### PR DESCRIPTION
## Summary

Adds a screen saver to prevent CRT burn-in, controlled by a single app-level "Screen Saver" setting (OFF/30/60/120 seconds). Closes #109.

Two independent triggers share one timeout:

- **Menu idle**: new `IdleTracker` C++ class monitors global input via an app-wide event filter. After the configured timeout with no keypresses, a full-black QML overlay appears with a bouncing 240-MP logo. During mpv playback activation is blocked by the `mpvActive` property, and the timer resets on playback start/end transitions.

- **Playback pause**: `scripts/screensaver.lua` runs inside mpv via `--script=`. When the video is paused longer than the timeout, a solid black full-frame overlay with white bouncing "240-MP" text appears. The SVG logo would need conversion to raw RGBA pixels on disk (convert logo.svg -resize 144x144 logo.rgba) as a build-time step.

## AI involvement

The code was written using OpenCode Go assistance (deepseek-v4-flash and other open models). The Lua script went through several rounds of fixes with ordering, ASS overlay coordinate space (`res_x`/`res_y`), and key binding portability. All changes were reviewed and tested manually before submitting.

## Testing

- Platform(s) tested: Arch Linux (X11), Pi 5 test pending #102
- Display / output tested: 1920×1080 monitor, mpv via gpu-next VO


## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)