### PR TITLE
feat(youtube): add playlist support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ Note: 240-MP uses mpv as an external subprocess for video playback. It does not 
 brew install yt-dlp
 ```
 
-mpv's ytdl hook uses `yt-dlp` to resolve YouTube URLs at playback time. The YouTube module also expects a `youtube_subscriptions.txt` in the data directory (one channel ID per line, `#` comments allowed) — see [INSTALL.md](INSTALL.md) for details. Optionally, a `youtube_playlists.txt` in the same directory (one playlist URL or ID per line, optional `My Name | <url>` display-name prefix, `#` comments allowed) adds a Playlists menu; playlist contents are fetched by running `yt-dlp` directly.
+mpv's ytdl hook uses `yt-dlp` to resolve YouTube URLs at playback time. The YouTube module also expects at least one of two files in the data directory (`#` comments allowed in both; each file only gates its own menu entries): `youtube_subscriptions.txt` (one channel ID per line — enables Subscriptions/Channels; see [INSTALL.md](INSTALL.md)) and/or `youtube_playlists.txt` (one playlist URL or ID per line, optional `My Name | <url>` display-name prefix — enables Playlists; contents are fetched by running `yt-dlp` directly).
 
 **Install SDL2 (required, gamepad input):**
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ Note: 240-MP uses mpv as an external subprocess for video playback. It does not 
 brew install yt-dlp
 ```
 
-mpv's ytdl hook uses `yt-dlp` to resolve YouTube URLs at playback time. The YouTube module also expects a `youtube_subscriptions.txt` in the data directory (one channel ID per line, `#` comments allowed) — see [INSTALL.md](INSTALL.md) for details.
+mpv's ytdl hook uses `yt-dlp` to resolve YouTube URLs at playback time. The YouTube module also expects a `youtube_subscriptions.txt` in the data directory (one channel ID per line, `#` comments allowed) — see [INSTALL.md](INSTALL.md) for details. Optionally, a `youtube_playlists.txt` in the same directory (one playlist URL or ID per line, optional `My Name | <url>` display-name prefix, `#` comments allowed) adds a Playlists menu; playlist contents are fetched by running `yt-dlp` directly.
 
 **Install SDL2 (required, gamepad input):**
 

--- a/modules/youtube/views/Items.qml
+++ b/modules/youtube/views/Items.qml
@@ -32,6 +32,8 @@ FocusScope {
             return
         }
         var list = ["Subscriptions", "Channels"]
+        if (youtubeBackend.check_playlists().ok)
+            list.push("Playlists")
         if (youtubeBackend.getWatchLater().length > 0)
             list.push("Watch Later")
         if (youtubeBackend.getHistory().length > 0)
@@ -124,6 +126,8 @@ FocusScope {
                 navigateTo("Subscriptions.qml", { mode: "feed" }, state)
             else if (selected === "Channels")
                 navigateTo("Channels.qml", {}, state)
+            else if (selected === "Playlists")
+                navigateTo("Playlists.qml", {}, state)
             else if (selected === "Watch Later")
                 navigateTo("Subscriptions.qml", { mode: "watchlater" }, state)
             else if (selected === "History")

--- a/modules/youtube/views/Items.qml
+++ b/modules/youtube/views/Items.qml
@@ -22,17 +22,32 @@ FocusScope {
     property bool isLoading: false
     property string errorMessage: ""
 
-    // The subscriptions file and the watch-later/history files are local reads,
-    // so this menu builds synchronously — isLoading exists only for pattern
-    // parity with the other modules.
+    // The subscriptions/playlists files and the watch-later/history files are
+    // local reads, so this menu builds synchronously — isLoading exists only
+    // for pattern parity with the other modules.
+    //
+    // The module loads when either youtube_subscriptions.txt or
+    // youtube_playlists.txt is usable; each file only gates its own entries.
     Component.onCompleted: {
-        var status = youtubeBackend.check_subscriptions()
-        if (!status.ok) {
-            errorMessage = status.error
+        var subsStatus = youtubeBackend.check_subscriptions()
+        var plStatus = youtubeBackend.check_playlists()
+        if (!subsStatus.ok && !plStatus.ok) {
+            // A file that exists but failed its check has the more actionable
+            // error; with no files at all, point at both options.
+            if (subsStatus.fileExists)
+                errorMessage = subsStatus.error
+            else if (plStatus.fileExists)
+                errorMessage = plStatus.error
+            else
+                errorMessage = "REQUIRED FILES NOT FOUND\n\n"
+                             + "ADD YOUTUBE_SUBSCRIPTIONS.TXT OR YOUTUBE_PLAYLISTS.TXT\n\n"
+                             + "PLEASE SEE THE WIKI FOR DETAILS"
             return
         }
-        var list = ["Subscriptions", "Channels"]
-        if (youtubeBackend.check_playlists().ok)
+        var list = []
+        if (subsStatus.ok)
+            list.push("Subscriptions", "Channels")
+        if (plStatus.ok)
             list.push("Playlists")
         if (youtubeBackend.getWatchLater().length > 0)
             list.push("Watch Later")
@@ -69,7 +84,7 @@ FocusScope {
     Text {
         visible: !isLoading && errorMessage !== ""
         text: errorMessage
-        color: root.tertiaryColor
+        color: root.secondaryColor
         font.family: root.globalFont
         anchors.centerIn: parent
         width: root.sw * 0.76875 //492 — long guidance lines wrap instead of clipping offscreen

--- a/modules/youtube/views/Playlists.qml
+++ b/modules/youtube/views/Playlists.qml
@@ -1,0 +1,188 @@
+import QtQuick
+import Components
+
+// Playlist list from youtube_playlists.txt, in file order (the user's own
+// curation is the sort — no letter-nav panel, unlike Channels).
+FocusScope {
+    id: playlistsRoot
+
+    property var navParams: ({})
+    property var navListState: navParams.navListState || ({})
+
+    signal navigateTo(string path, var params, var listState)
+    signal goBack()
+
+    property var items: []
+    property bool isLoading: false
+    property string errorMessage: ""
+
+    Component.onCompleted: {
+        isLoading = true
+        errorMessage = ""
+        youtubeBackend.load_playlists()
+    }
+
+    Connections {
+        target: youtubeBackend
+
+        function onPlaylistsLoaded(playlists) {
+            playlistsRoot.isLoading = false
+            playlistsRoot.items = playlists
+            if (playlists.length > 0) {
+                var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
+                itemList.currentIndex = Math.min(restore, playlists.length - 1)
+                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+            }
+        }
+
+        function onErrorOccurred(msg) {
+            playlistsRoot.isLoading = false
+            playlistsRoot.errorMessage = msg
+        }
+    }
+
+    focus: true
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+            goBack()
+            event.accepted = true
+        }
+    }
+
+    // ---
+    // UI
+    // ---
+
+    AppBar {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125 //60
+        anchors.leftMargin: root.sw * 0.125 //80
+        iconSource: moduleRoot.moduleIcon
+        title: moduleRoot.moduleName
+        subtitle: "Playlists"
+    }
+
+    // Loading / empty / error states
+    Text {
+        visible: isLoading
+        text: "LOADING..."
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.centerIn: parent
+        font.pixelSize: root.sh * 0.05 //24
+    }
+    Text {
+        visible: !isLoading && errorMessage !== ""
+        text: errorMessage
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.centerIn: parent
+        width: root.sw * 0.76875 //492 — long guidance lines wrap instead of clipping offscreen
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        font.pixelSize: root.sh * 0.05 //24
+    }
+    Text {
+        visible: !isLoading && errorMessage === "" && items.length === 0
+        text: "NO PLAYLISTS FOUND"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.centerIn: parent
+        font.pixelSize: root.sh * 0.05 //24
+    }
+
+    // Playlist list
+    ListView {
+        id: itemList
+        model: items
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.25 //120
+        anchors.leftMargin: root.sw * 0.115625 //74
+        width: root.sw * 0.76875 //492
+        height: root.sh * 0.525 //252
+        clip: true
+        focus: true
+
+        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
+        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onReturnPressed: {
+            var item = items[itemList.currentIndex]
+            if (!item)
+                return
+            playlistsRoot.navigateTo("Subscriptions.qml", {
+                mode: "playlist",
+                playlistId: item.playlistId,
+                playlistName: item.title
+            }, { currentIndex: itemList.currentIndex })
+        }
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                playlistsRoot.goBack()
+                event.accepted = true
+            }
+        }
+
+        delegate: Item {
+            width: itemList.width
+            height: root.sh * 0.0583333 //28
+
+            Item {
+                id: textClip
+                width: Math.min(rowText.implicitWidth, itemList.width)
+                height: parent.height
+                clip: true
+
+                Rectangle {
+                    color: root.accentColor
+                    anchors.fill: rowText
+                    visible: itemList.currentIndex === index
+                }
+
+                Text {
+                    id: rowText
+                    text: modelData.title || ""
+                    color: itemList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    anchors.verticalCenter: parent.verticalCenter
+                    x: 0
+                    topPadding: root.sh * 0.0041667 //2
+                    leftPadding: root.sw * 0.009375 //6
+                    rightPadding: root.sw * 0.009375 //6
+                    bottomPadding: root.sh * 0.00625 //3
+                    font.pixelSize: root.sh * 0.05 //24
+                }
+
+                SequentialAnimation {
+                    running: (itemList.currentIndex === index) &&
+                             (rowText.implicitWidth > textClip.width)
+                    loops: Animation.Infinite
+                    onRunningChanged: if (!running) rowText.x = 0
+                    PauseAnimation { duration: 1500 }
+                    NumberAnimation {
+                        target: rowText; property: "x"
+                        to: textClip.width - rowText.implicitWidth
+                        duration: Math.abs(to) * 20
+                    }
+                    PauseAnimation { duration: 2000 }
+                    PropertyAction { target: rowText; property: "x"; value: 0 }
+                }
+            }
+        }
+    }
+
+    // Footer
+    Text {
+        id: footer
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":SELECT"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667 //50
+        anchors.leftMargin: root.sw * 0.125 //80
+        font.pixelSize: root.sh * 0.0333333 //16
+    }
+}

--- a/modules/youtube/views/Subscriptions.qml
+++ b/modules/youtube/views/Subscriptions.qml
@@ -2,9 +2,9 @@ import QtQuick
 import Components
 
 // Video list — serves the aggregated Subscriptions feed (mode "feed"), a single
-// channel's videos (mode "channel"), the saved Watch Later list ("watchlater")
-// and the recently-watched History list ("history"). Right on any row opens the
-// save/remove watch-later overlay.
+// channel's videos (mode "channel"), a user playlist ("playlist"), the saved
+// Watch Later list ("watchlater") and the recently-watched History list
+// ("history"). Right on any row opens the save/remove watch-later overlay.
 FocusScope {
     id: itemsRoot
 
@@ -17,6 +17,8 @@ FocusScope {
     property string mode: navParams.mode || "feed"
     property string channelId: navParams.channelId || ""
     property string channelName: navParams.channelName || ""
+    property string playlistId: navParams.playlistId || ""
+    property string playlistName: navParams.playlistName || ""
 
     property var items: []
     property bool isLoading: false
@@ -92,6 +94,8 @@ FocusScope {
             errorMessage = ""
             if (mode === "feed")
                 youtubeBackend.load_subscriptions_feed()
+            else if (mode === "playlist")
+                youtubeBackend.load_playlist_videos(playlistId)
             else
                 youtubeBackend.load_channel_videos(channelId)
         }
@@ -116,8 +120,16 @@ FocusScope {
             itemsRoot.restoreListIndex()
         }
 
+        function onPlaylistVideosLoaded(loadedPlaylistId, videos) {
+            if (itemsRoot.mode !== "playlist" || loadedPlaylistId !== itemsRoot.playlistId)
+                return
+            itemsRoot.isLoading = false
+            itemsRoot.items = itemsRoot.filterShorts(videos)
+            itemsRoot.restoreListIndex()
+        }
+
         function onErrorOccurred(msg) {
-            if (itemsRoot.mode !== "feed" && itemsRoot.mode !== "channel")
+            if (itemsRoot.mode !== "feed" && itemsRoot.mode !== "channel" && itemsRoot.mode !== "playlist")
                 return
             itemsRoot.isLoading = false
             itemsRoot.errorMessage = msg
@@ -138,6 +150,7 @@ FocusScope {
         subtitle: itemsRoot.mode === "feed" ? "Subscriptions"
                 : itemsRoot.mode === "watchlater" ? "Watch Later"
                 : itemsRoot.mode === "history" ? "History"
+                : itemsRoot.mode === "playlist" ? itemsRoot.playlistName
                 : itemsRoot.channelName
     }
 

--- a/src/modules/youtube/YouTubeBackend.cpp
+++ b/src/modules/youtube/YouTubeBackend.cpp
@@ -74,6 +74,7 @@ QVariantMap YouTubeBackend::check_subscriptions() {
     QVariantMap result;
     result["ok"]           = error.isEmpty();
     result["error"]        = error;
+    result["fileExists"]   = QFile::exists(m_dataRoot + "/" + kSubscriptionsFileName);
     result["channelCount"] = ids.size();
     return result;
 }
@@ -357,6 +358,7 @@ QVariantMap YouTubeBackend::check_playlists() {
     QVariantMap result;
     result["ok"]            = error.isEmpty();
     result["error"]         = error;
+    result["fileExists"]    = QFile::exists(m_dataRoot + "/" + kPlaylistsFileName);
     result["playlistCount"] = refs.size();
     return result;
 }

--- a/src/modules/youtube/YouTubeBackend.cpp
+++ b/src/modules/youtube/YouTubeBackend.cpp
@@ -7,13 +7,17 @@
 #include <QJsonObject>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QProcess>
 #include <QRegularExpression>
+#include <QStandardPaths>
+#include <QTimer>
 #include <QUrl>
 #include <QXmlStreamReader>
 
 #include <algorithm>
 
 static const char *kSubscriptionsFileName = "youtube_subscriptions.txt";
+static const char *kPlaylistsFileName     = "youtube_playlists.txt";
 
 static QString watchUrlFor(const QString &videoId) {
     return QStringLiteral("https://www.youtube.com/watch?v=") + videoId;
@@ -283,6 +287,284 @@ QVariantList YouTubeBackend::buildChannelList() const {
                                 Qt::CaseInsensitive) < 0;
     });
     return channels;
+}
+
+// ---------------------------------------------------------------------------
+// Playlists file (youtube_playlists.txt)
+// Line format: [My Display Name | ] <playlist URL or bare playlist ID>
+// ---------------------------------------------------------------------------
+
+// "list=" query param when present, bare token otherwise. A URL without a
+// list= param isn't a playlist link — rejected so it can't be fed to yt-dlp
+// as something else entirely.
+static QString playlistIdFromToken(QString token) {
+    const int listPos = token.indexOf(QLatin1String("list="));
+    if (listPos >= 0) {
+        token = token.mid(listPos + 5);
+        const int end = token.indexOf(QRegularExpression(QStringLiteral("[&#?/]")));
+        if (end >= 0)
+            token = token.left(end);
+        return token;
+    }
+    if (token.contains(QLatin1String("://")))
+        return {};
+    return token;
+}
+
+QList<YouTubeBackend::PlaylistFileRef> YouTubeBackend::readPlaylistEntries(QString *error) const {
+    const QString path = m_dataRoot + "/" + kPlaylistsFileName;
+    if (!QFile::exists(path)) {
+        if (error)
+            *error = QStringLiteral("NO PLAYLISTS FILE FOUND\n"
+                                    "CREATE YOUTUBE_PLAYLISTS.TXT IN THE DATA DIRECTORY\n"
+                                    "WITH ONE PLAYLIST URL PER LINE");
+        return {};
+    }
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        if (error)
+            *error = QStringLiteral("COULD NOT READ YOUTUBE_PLAYLISTS.TXT");
+        return {};
+    }
+    QList<PlaylistFileRef> refs;
+    QStringList seen;
+    while (!f.atEnd()) {
+        const QString line = QString::fromUtf8(f.readLine()).trimmed();
+        if (line.isEmpty() || line.startsWith('#'))
+            continue;
+        // Split the optional display-name prefix at the last '|' (URLs never
+        // contain one, display names conceivably could).
+        QString name, token = line;
+        const int bar = line.lastIndexOf('|');
+        if (bar >= 0) {
+            name  = line.left(bar).trimmed();
+            token = line.mid(bar + 1).trimmed();
+        }
+        const QString id = playlistIdFromToken(token);
+        if (id.isEmpty() || seen.contains(id))
+            continue;
+        seen << id;
+        refs.append({id, name});
+    }
+    if (refs.isEmpty() && error)
+        *error = QStringLiteral("NO PLAYLISTS FOUND IN YOUTUBE_PLAYLISTS.TXT");
+    return refs;
+}
+
+QVariantMap YouTubeBackend::check_playlists() {
+    QString error;
+    const QList<PlaylistFileRef> refs = readPlaylistEntries(&error);
+    QVariantMap result;
+    result["ok"]            = error.isEmpty();
+    result["error"]         = error;
+    result["playlistCount"] = refs.size();
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Playlist loaders — yt-dlp --flat-playlist subprocesses feeding the same
+// cache/queue shape as the RSS channel path. yt-dlp is used (rather than the
+// playlist RSS feed) because the feed stops at 15 entries.
+// ---------------------------------------------------------------------------
+
+void YouTubeBackend::load_playlists(bool forceRefresh) {
+    m_emitPlaylistsWhenDone = true;
+    ensurePlaylistsFresh(forceRefresh);
+}
+
+void YouTubeBackend::load_playlist_videos(const QString &playlistId, bool forceRefresh) {
+    m_emitPlaylistVideosWhenDone = playlistId;
+    ensurePlaylistsFresh(forceRefresh);
+}
+
+// mpv resolves yt-dlp itself at playback time; this is for the app's own
+// browse-time subprocesses.
+static QString ytDlpExecutable() {
+#ifdef Q_OS_MACOS
+    // .app bundles launched via double-click get a minimal PATH that excludes
+    // Homebrew. Prepend known install locations so findExecutable works.
+    const QStringList extraPaths = { "/opt/homebrew/bin", "/usr/local/bin" };
+    const QStringList currentPath = qEnvironmentVariable("PATH").split(":");
+    for (const QString &p : extraPaths) {
+        if (!currentPath.contains(p))
+            qputenv("PATH", (p + ":" + qEnvironmentVariable("PATH")).toUtf8());
+    }
+#endif
+    return QStandardPaths::findExecutable(QStringLiteral("yt-dlp"));
+}
+
+void YouTubeBackend::ensurePlaylistsFresh(bool forceRefresh) {
+    if (m_pendingPlaylists > 0)
+        return; // refresh already in flight — the emit flags queue on it
+
+    QString error;
+    const QList<PlaylistFileRef> refs = readPlaylistEntries(&error);
+    if (refs.isEmpty()) {
+        m_emitPlaylistsWhenDone = false;
+        m_emitPlaylistVideosWhenDone.clear();
+        emit errorOccurred(error);
+        return;
+    }
+    m_playlistOrder.clear();
+    for (const PlaylistFileRef &ref : refs) {
+        m_playlistOrder << ref.id;
+        PlaylistEntry &entry = m_playlists[ref.id];
+        entry.playlistId = ref.id;
+        entry.fileName   = ref.name; // re-read every refresh so file edits apply
+    }
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    QStringList stale;
+    for (const QString &id : m_playlistOrder) {
+        const PlaylistEntry &entry = m_playlists.value(id);
+        if (forceRefresh || !entry.fetchOk || now - entry.fetchedMs > kCacheTtlMs)
+            stale << id;
+    }
+
+    if (stale.isEmpty()) {
+        finishPlaylistAggregate(); // everything fresh — serve from cache
+        return;
+    }
+    if (ytDlpExecutable().isEmpty()) {
+        // Nothing can be fetched; report against whatever the cache holds.
+        finishPlaylistAggregate();
+        return;
+    }
+    m_pendingPlaylists   = stale.size();
+    m_playlistFetchQueue = stale;
+    spawnNextPlaylistFetch();
+}
+
+void YouTubeBackend::spawnNextPlaylistFetch() {
+    const QString bin = ytDlpExecutable();
+    while (m_activePlaylistFetches < kMaxConcurrentPlaylistFetches
+           && !m_playlistFetchQueue.isEmpty()) {
+        const QString playlistId = m_playlistFetchQueue.takeFirst();
+        ++m_activePlaylistFetches;
+
+        auto *proc = new QProcess(this);
+        const QStringList args{
+            QStringLiteral("--flat-playlist"),
+            QStringLiteral("-I"), QStringLiteral("1:%1").arg(kMaxPlaylistItems),
+            QStringLiteral("--no-warnings"),
+            // One JSON object per entry — robust against '|' etc. in titles
+            QStringLiteral("--print"),
+            QStringLiteral("%(.{id,title,channel,uploader,playlist_title})j"),
+            QStringLiteral("--"),
+            QStringLiteral("https://www.youtube.com/playlist?list=") + playlistId,
+        };
+
+        auto finish = [this, proc, playlistId]() {
+            proc->deleteLater();
+            QString      title;
+            QVariantList videos;
+            const QList<QByteArray> lines = proc->readAllStandardOutput().split('\n');
+            for (const QByteArray &line : lines) {
+                const QJsonObject obj = QJsonDocument::fromJson(line.trimmed()).object();
+                if (obj.isEmpty())
+                    continue;
+                if (title.isEmpty())
+                    title = obj.value(QLatin1String("playlist_title")).toString();
+                const QString videoId    = obj.value(QLatin1String("id")).toString();
+                const QString videoTitle = obj.value(QLatin1String("title")).toString();
+                if (videoId.isEmpty())
+                    continue;
+                // Tombstones YouTube leaves in place of removed entries
+                if (videoTitle == QLatin1String("[Private video]")
+                    || videoTitle == QLatin1String("[Deleted video]"))
+                    continue;
+                QString channel = obj.value(QLatin1String("channel")).toString();
+                if (channel.isEmpty())
+                    channel = obj.value(QLatin1String("uploader")).toString();
+                QVariantMap v;
+                v["videoId"]     = videoId;
+                v["title"]       = videoTitle;
+                v["channelId"]   = QString();
+                v["channelName"] = channel;
+                // Flat entries carry no publish date; playlist order stands in
+                v["publishedAt"] = QString();
+                v["publishedMs"] = qint64(0);
+                v["url"]         = watchUrlFor(videoId);
+                v["isShort"]     = false; // not detectable from flat entries
+                videos.append(v);
+            }
+            // Non-zero exit with parsed entries still counts (partial page
+            // failures on huge lists) — same "partial parses kept" stance as RSS.
+            const bool ok = proc->exitStatus() == QProcess::NormalExit
+                            && (proc->exitCode() == 0 || !videos.isEmpty());
+            if (ok) {
+                PlaylistEntry &entry = m_playlists[playlistId];
+                entry.fetchedTitle = title;
+                entry.videos       = videos;
+                entry.fetchOk      = true;
+                entry.fetchedMs    = QDateTime::currentMSecsSinceEpoch();
+            }
+            // On failure: keep any previously cached videos (stale beats empty)
+
+            --m_activePlaylistFetches;
+            if (--m_pendingPlaylists <= 0) {
+                m_pendingPlaylists      = 0;
+                m_activePlaylistFetches = 0;
+                m_playlistFetchQueue.clear();
+                finishPlaylistAggregate();
+            } else {
+                spawnNextPlaylistFetch();
+            }
+        };
+        connect(proc, &QProcess::finished, this, finish);
+        // finished() is never emitted when the binary fails to launch
+        connect(proc, &QProcess::errorOccurred, this,
+                [finish](QProcess::ProcessError processError) {
+                    if (processError == QProcess::FailedToStart)
+                        finish();
+                });
+        QTimer::singleShot(kPlaylistFetchTimeoutMs, proc, [proc]() { proc->kill(); });
+        proc->start(bin, args);
+    }
+}
+
+void YouTubeBackend::finishPlaylistAggregate() {
+    const bool    listWanted   = m_emitPlaylistsWhenDone;
+    const QString videosWanted = m_emitPlaylistVideosWhenDone;
+    m_emitPlaylistsWhenDone = false;
+    m_emitPlaylistVideosWhenDone.clear();
+
+    bool anyOk = false;
+    for (const QString &id : m_playlistOrder)
+        anyOk = anyOk || m_playlists.value(id).fetchOk;
+    if (!anyOk) {
+        emit errorOccurred(QStringLiteral("COULD NOT LOAD PLAYLISTS\n"
+                                          "CHECK YOUR NETWORK CONNECTION AND THAT\n"
+                                          "YT-DLP IS INSTALLED AND UP TO DATE"));
+        return;
+    }
+
+    if (listWanted)
+        emit playlistsLoaded(buildPlaylistList());
+    if (!videosWanted.isEmpty()) {
+        const PlaylistEntry entry = m_playlists.value(videosWanted);
+        if (entry.fetchOk)
+            emit playlistVideosLoaded(videosWanted, entry.videos);
+        else
+            emit errorOccurred(QStringLiteral("COULD NOT LOAD PLAYLIST"));
+    }
+}
+
+QVariantList YouTubeBackend::buildPlaylistList() const {
+    QVariantList playlists;
+    for (const QString &id : m_playlistOrder) {
+        const PlaylistEntry entry = m_playlists.value(id);
+        QVariantMap p;
+        p["playlistId"] = id;
+        // File-name override wins; fall back to the raw ID so a playlist whose
+        // fetch failed is still visible (same choice as buildChannelList)
+        p["title"]      = !entry.fileName.isEmpty()     ? entry.fileName
+                        : !entry.fetchedTitle.isEmpty() ? entry.fetchedTitle
+                                                        : id;
+        p["videoCount"] = entry.videos.size();
+        playlists << p;
+    }
+    return playlists; // file order — the user's own curation is the sort
 }
 
 // ---------------------------------------------------------------------------

--- a/src/modules/youtube/YouTubeBackend.h
+++ b/src/modules/youtube/YouTubeBackend.h
@@ -17,7 +17,12 @@
 // cached in memory per channel for the session (kCacheTtlMs TTL), so the first
 // entry into Subscriptions or Channels fills the cache for every other view.
 //
-// Two user files besides subscriptions:
+// Playlists come from <dataRoot>/youtube_playlists.txt (one playlist URL or ID
+// per line, optional "My Name | <url>" display-name prefix). RSS feeds for
+// playlists stop at 15 entries, so playlist contents are fetched by spawning
+// yt-dlp --flat-playlist instead (async QProcess, same session cache TTL).
+//
+// Two user files besides subscriptions/playlists:
 //   youtube_history.json     — watch history + resume positions, keyed by videoId
 //   youtube_watch_later.json — ordered saved-video list (newest first)
 class YouTubeBackend : public QObject {
@@ -33,6 +38,13 @@ public:
     Q_INVOKABLE void load_subscriptions_feed(bool forceRefresh = false);
     Q_INVOKABLE void load_channels(bool forceRefresh = false);
     Q_INVOKABLE void load_channel_videos(const QString &channelId, bool forceRefresh = false);
+
+    // Synchronous playlists-file check, mirroring check_subscriptions():
+    // { ok: bool, error: QString, playlistCount: int }
+    Q_INVOKABLE QVariantMap check_playlists();
+
+    Q_INVOKABLE void load_playlists(bool forceRefresh = false);
+    Q_INVOKABLE void load_playlist_videos(const QString &playlistId, bool forceRefresh = false);
 
     // Maps the playback_resolution setting ("480p"/"720p"/"1080p", unknown → 480p)
     // to a yt-dlp format string. H.264 is preferred first for RPi hardware decode.
@@ -59,6 +71,8 @@ signals:
     void subscriptionsFeedLoaded(const QVariant &videos);
     void channelsLoaded(const QVariant &channels);
     void channelVideosLoaded(const QString &channelId, const QVariant &videos);
+    void playlistsLoaded(const QVariant &playlists);
+    void playlistVideosLoaded(const QString &playlistId, const QVariant &videos);
     void errorOccurred(const QString &message);
 
 private:
@@ -68,6 +82,20 @@ private:
         QVariantList videos;           // newest first
         qint64       fetchedMs = 0;    // 0 = never fetched successfully
         bool         feedOk    = false;
+    };
+
+    struct PlaylistEntry {
+        QString      playlistId;
+        QString      fileName;         // optional "Name |" override from the file
+        QString      fetchedTitle;     // playlist_title reported by yt-dlp
+        QVariantList videos;           // playlist order
+        qint64       fetchedMs = 0;
+        bool         fetchOk   = false;
+    };
+
+    struct PlaylistFileRef {
+        QString id;
+        QString name;                  // empty when the line had no "Name |" prefix
     };
 
     QString      historyFilePath() const;
@@ -85,6 +113,12 @@ private:
     QVariantList buildChannelList() const;
     QNetworkRequest makeRequest(const QUrl &url) const;
 
+    QList<PlaylistFileRef> readPlaylistEntries(QString *error = nullptr) const;
+    void         ensurePlaylistsFresh(bool forceRefresh);
+    void         spawnNextPlaylistFetch();
+    void         finishPlaylistAggregate();
+    QVariantList buildPlaylistList() const;
+
     QString m_appRoot;
     QString m_dataRoot;
     QNetworkAccessManager m_nam;
@@ -99,7 +133,21 @@ private:
     bool    m_emitChannelsWhenDone = false;
     QString m_emitChannelVideosWhenDone;      // channelId, or empty
 
+    // Playlist mirror of the channel cache/refresh state, fed by yt-dlp
+    // subprocesses instead of RSS requests.
+    QHash<QString, PlaylistEntry> m_playlists;
+    QStringList m_playlistOrder;              // playlist IDs in file order (deduped)
+    QStringList m_playlistFetchQueue;         // stale IDs waiting for a process slot
+    int m_pendingPlaylists       = 0;
+    int m_activePlaylistFetches  = 0;
+
+    bool    m_emitPlaylistsWhenDone = false;
+    QString m_emitPlaylistVideosWhenDone;     // playlistId, or empty
+
     static constexpr qint64 kCacheTtlMs      = 15 * 60 * 1000;
     static constexpr int    kMaxFeedItems    = 100;
     static constexpr int    kMaxHistoryItems = 100;
+    static constexpr int    kMaxPlaylistItems = 500;             // caps infinite Mix/Radio lists
+    static constexpr int    kMaxConcurrentPlaylistFetches = 2;   // yt-dlp is heavy on the Pi
+    static constexpr int    kPlaylistFetchTimeoutMs = 60000;
 };

--- a/src/modules/youtube/YouTubeBackend.h
+++ b/src/modules/youtube/YouTubeBackend.h
@@ -32,7 +32,7 @@ public:
                             QObject *parent = nullptr);
 
     // Synchronous subscriptions-file check for the menu view:
-    // { ok: bool, error: QString, channelCount: int }
+    // { ok: bool, error: QString, fileExists: bool, channelCount: int }
     Q_INVOKABLE QVariantMap check_subscriptions();
 
     Q_INVOKABLE void load_subscriptions_feed(bool forceRefresh = false);
@@ -40,7 +40,7 @@ public:
     Q_INVOKABLE void load_channel_videos(const QString &channelId, bool forceRefresh = false);
 
     // Synchronous playlists-file check, mirroring check_subscriptions():
-    // { ok: bool, error: QString, playlistCount: int }
+    // { ok: bool, error: QString, fileExists: bool, playlistCount: int }
     Q_INVOKABLE QVariantMap check_playlists();
 
     Q_INVOKABLE void load_playlists(bool forceRefresh = false);


### PR DESCRIPTION
## Summary

Closes https://github.com/anthonycaccese/240-MP/issues/106

Notes:
- This leverages yt-dlp's `--flat-playlist` option to poll for playlist metadata which enables the return of "more items" (see notes below) than the traditional RSS cap of 15 that exists on YouTubes RSS feeds for playlists
- That said it has some limitations to keep in mind
    - Because its a poll it can take a bit more time than parsing an already existing RSS feed.  This basically means that when you open the playlist menu just expect to sit for a bit longer while the playlists you've listed are parsed.  There is a cache in place for 15 mins so it won't occur on every open
    - Regarding the "more items" and why that doesn't say "all items"... I had to put a cap of 500 in place to prevent crashing for things like infinite auto generated playlists.  in practice my guess is that limit should be more than enough but if its not... its just what we'll need to accept for this implementation.  We're running YouTube on a CRT without auth so this is pretty awesome already =)
- the module is also updated to look for either a subscriptions or a playlist file now so you can have one or the other or both and it will work
- the new youtube_playlists.txt file accepts one playlist per line and the playlist entry can be its full URL or just its ID. It also allows for an optional title to be added if you'd prefer to give the playlist a custom title when it displays in 240-MP (otherwise it falls back to the title of the playlist on YouTube)
- For a playlist to display it needs to be either public or unlisted (private playlists are not supported as they require auth)   

## AI involvement

Used to structure the approach for using yt-dlp for parsing and displaying playlists in the interface

## Testing

Validated on both MacOS and RPi.  I tested on a RPi 4 and while there was latency pulling in the playlist items it loaded fairly quickly (I tested with 2 100 item playlists)

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)