### PR TITLE
Feat: jellyfin intro skip

### DIFF
--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -43,6 +43,24 @@
       "requires_auth": true
     },
     {
+      "key": "intro_skip",
+      "label": "Intro Skip",
+      "type": "list_single",
+      "options": ["Off", "Auto", "Button"],
+      "default": "Off",
+      "requires_auth": true,
+      "requires_capability": "mediasegments"
+    },
+    {
+      "key": "outro_skip",
+      "label": "Credit Skip",
+      "type": "list_single",
+      "options": ["Off", "Auto", "Button"],
+      "default": "Off",
+      "requires_auth": true,
+      "requires_capability": "mediasegments"
+    },
+    {
       "key": "logout",
       "label": "Sign out",
       "type": "action",

--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -49,7 +49,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
-      "requires_capability": "mediasegments"
+      "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {
       "key": "outro_skip",
@@ -58,7 +58,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
-      "requires_capability": "mediasegments"
+      "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {
       "key": "logout",

--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -49,6 +49,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
+      "requires_capability": "mediasegments",
       "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {
@@ -58,6 +59,7 @@
       "options": ["Off", "Auto", "Button"],
       "default": "Off",
       "requires_auth": true,
+      "requires_capability": "mediasegments",
       "description": "Requires the Jellyfin Intro Skipper plugin on your server"
     },
     {

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -43,6 +43,15 @@ FocusScope {
     property int  choiceIndex:     0
     property string resumeSetting: "ask"
 
+    // Intro/outro skip
+    property var    segments:           []
+    property var    activeSegment:      null
+    property bool   skipPromptShown:    false
+    property bool   introAutoSkipped:   false
+    property bool   outroAutoSkipped:   false
+    property string introSkipSetting:   "Off"
+    property string outroSkipSetting:   "Off"
+
     property int lastKnownPositionMs: 0
     property int lastKnownDurationMs: 0
 
@@ -171,6 +180,22 @@ FocusScope {
         lastKnownPositionMs  = 0
         lastKnownDurationMs  = 0
 
+        // Reset skip state for the new episode
+        segments = []
+        activeSegment = null
+        skipPromptShown = false
+        introAutoSkipped = false
+        outroAutoSkipped = false
+        mpvController.clearOsdPrompt()
+
+        // Re-read settings (they could have changed)
+        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
+        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+
+        // Fetch segments for the new episode if skip is enabled
+        if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
+            jellyfinBackend.fetchSegments(detail.itemId)
+
         // Repoint the BACK target so exiting returns to THIS episode's detail
         updateBackItem({
             itemId: detail.itemId,
@@ -278,9 +303,22 @@ FocusScope {
         return m + ":" + (sec < 10 ? "0" : "") + sec
     }
 
+    function findActiveSegment(ms) {
+        for (var i = 0; i < segments.length; i++) {
+            if (ms >= segments[i].startMs && ms < segments[i].endMs)
+                return segments[i]
+        }
+        return null
+    }
+
     Connections {
         target: jellyfinBackend
         function onErrorOccurred(msg) { console.log("[Jellyfin Player] Backend error: " + msg) }
+
+        function onSegmentsReady(itemId_, segments_) {
+            if (itemId_ !== playerRoot.itemId) return
+            playerRoot.segments = segments_
+        }
 
         function onStreamUrlReady(url) {
             if (pendingNextEpisode) {
@@ -322,10 +360,58 @@ FocusScope {
                 // First position update means mpv is up and playing — drop the
                 // loading indicator (mpv's own window now covers the screen).
                 playerRoot.playbackStarted = true
+
+                // --- Skip segment tracking ---
+                if (playerRoot.segments.length > 0) {
+                    var seg = findActiveSegment(ms)
+                    if (seg && seg !== playerRoot.activeSegment) {
+                        playerRoot.activeSegment = seg
+                        var setting = seg.type === "Intro"
+                            ? playerRoot.introSkipSetting
+                            : playerRoot.outroSkipSetting
+
+                        if (setting === "Auto") {
+                            if (seg.type === "Intro" && !playerRoot.introAutoSkipped) {
+                                playerRoot.introAutoSkipped = true
+                                mpvController.seekTo(seg.endMs)
+                            } else if (seg.type === "Outro" && !playerRoot.outroAutoSkipped) {
+                                playerRoot.outroAutoSkipped = true
+                                mpvController.seekTo(seg.endMs)
+                            }
+                        } else if (setting === "Button") {
+                            if (!playerRoot.skipPromptShown) {
+                                playerRoot.skipPromptShown = true
+                                mpvController.showOsdSkipPrompt()
+                            }
+                        }
+                    } else if (!seg && playerRoot.activeSegment) {
+                        // Segment ended naturally
+                        playerRoot.activeSegment = null
+                        playerRoot.skipPromptShown = false
+                        mpvController.clearOsdPrompt()
+                    }
+                }
+                // --- End skip segment tracking ---
             }
         }
         function onDurationChanged(ms) {
             if (ms > 0) playerRoot.lastKnownDurationMs = ms
+        }
+
+        function onSkipRequested() {
+            if (playerRoot.activeSegment) {
+                if (playerRoot.activeSegment.type === "Intro")
+                    playerRoot.introAutoSkipped = true
+                else
+                    playerRoot.outroAutoSkipped = true
+                mpvController.seekTo(playerRoot.activeSegment.endMs)
+                mpvController.clearOsdPrompt()
+                // Don't null activeSegment here — the async seek moves past the
+                // segment boundary, and the next onPositionChanged detects the
+                // end naturally. Nulling it before the seek completes causes a
+                // position update at the old location to re-detect the same
+                // segment as "new" and re-trigger the prompt.
+            }
         }
 
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
@@ -382,6 +468,14 @@ FocusScope {
         // once the user touches it, but accept the legacy "ON" string too.
         var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
         autoplayNext = (autoplayRaw === true || autoplayRaw === "ON")
+
+        // Hoist skip settings
+        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
+        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+
+        // Fetch segments if either skip mode is enabled
+        if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
+            jellyfinBackend.fetchSegments(itemId)
 
         // "ask": prompt resume vs. start over when there's a saved position.
         // "always" (or anything else): resume directly.

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -188,14 +188,6 @@ FocusScope {
         outroAutoSkipped = false
         mpvController.clearOsdPrompt()
 
-        // Re-read settings (they could have changed)
-        introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
-        outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
-
-        // Fetch segments for the new episode if skip is enabled
-        if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
-            jellyfinBackend.fetchSegments(detail.itemId)
-
         // Repoint the BACK target so exiting returns to THIS episode's detail
         updateBackItem({
             itemId: detail.itemId,
@@ -326,6 +318,12 @@ FocusScope {
                 pendingNextEpisode = false
                 playerRoot.streamUrl = url
                 doStartPlayback(0)
+                // Fetch segments for intro/outro skip after playback starts, so
+                // the HTTP request doesn't contend with the PlaybackInfo POST.
+                introSkipSetting = appCore.get_setting(moduleRoot.moduleId, "intro_skip") || "Off"
+                outroSkipSetting = appCore.get_setting(moduleRoot.moduleId, "outro_skip") || "Off"
+                if (introSkipSetting !== "Off" || outroSkipSetting !== "Off")
+                    jellyfinBackend.fetchSegments(playerRoot.itemId)
                 return
             }
             if (pendingRetryTranscode) {

--- a/modules/jellyfin/views/Root.qml
+++ b/modules/jellyfin/views/Root.qml
@@ -11,7 +11,7 @@ FocusScope {
     // The module's manifest id — the single place it appears in this module's QML.
     // Child views reference it via moduleRoot.moduleId.
     property string moduleId: "com.240mp.jellyfin"
-    property var _moduleInfo: appCore.get_module_info(moduleId)
+    property var _moduleInfo: appCore ? appCore.get_module_info(moduleId) : ({})
     property string moduleName: _moduleInfo.name || ""
     property string moduleIcon: _moduleInfo.icon || ""
 

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -22,6 +22,7 @@ local focus_row = 0  -- 0: Seek Bar, 1: Buttons
 local focus_btn = 1  -- index into visible left buttons + STOP; varies with track availability
 local update_timer = nil
 local idle_timer = nil
+local skip_active = false
 
 local SEEK_SECONDS = 10
 local MENU_TIMEOUT = 5
@@ -91,9 +92,13 @@ local function has_playlist()
 end
 
 local function build_left_btns(has_sub, has_pl, bar_w)
-    local btns = {
-        {label="AUDIO", width=math.floor(bar_w * 0.109375), action=btn_actions[1]},
-    }
+    local btns = {}
+    if skip_active then
+        btns[#btns + 1] = {label="SKIP", width=math.floor(bar_w * 0.090625), action=function()
+            mp.commandv("script-message", "skip-segment")
+        end}
+    end
+    btns[#btns + 1] = {label="AUDIO", width=math.floor(bar_w * 0.109375), action=btn_actions[1]}
     if has_sub then
         table.insert(btns, {label="SUBTITLE", width=math.floor(bar_w * 0.15625), action=btn_actions[2]})
     end
@@ -364,3 +369,7 @@ mp.add_forced_key_binding("DOWN", "open_menu_down", toggle_menu)
 -- closes those forced bindings are removed and these become active again.
 mp.add_key_binding("ESC", "bg-esc", function() mp.command("quit") end)
 mp.add_key_binding("BS",  "bg-bs",  function() mp.command("quit") end)
+
+mp.register_script_message("skip-overlay-state", function(state)
+    skip_active = (state == "1")
+end)

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -372,4 +372,7 @@ mp.add_key_binding("BS",  "bg-bs",  function() mp.command("quit") end)
 
 mp.register_script_message("skip-overlay-state", function(state)
     skip_active = (state == "1")
+    -- Land focus on SKIP (first button) so ENTER skips immediately —
+    -- focus_btn otherwise persists from the last menu interaction.
+    if skip_active then focus_btn = 1 end
 end)

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -260,6 +260,7 @@ void JellyfinBackend::check_auth() {
             return;
         }
         emit authStateChanged();
+        probeCapabilities();
     });
 }
 
@@ -468,6 +469,7 @@ void JellyfinBackend::quick_connect_authenticate(const QString &secret) {
         cfg["modules"] = modules;
         saveConfig(cfg);
 
+        probeCapabilities();
         emit authStateChanged();
     });
 }
@@ -1371,6 +1373,11 @@ void JellyfinBackend::getLibraries() {
         return;
     }
 
+    // Re-emit cached capabilities so ModuleSettings.qml can filter settings
+    // correctly on every pageload (the signal may have been missed if
+    // ModuleSettings.qml was destroyed/recreated after the initial probe).
+    probeCapabilities();
+
     QUrl url(m_serverUrl + "/Users/" + m_userId + "/Views");
     auto *reply = jellyfinGet(url);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -1460,16 +1467,65 @@ void JellyfinBackend::load_server_preferences() {
     });
 }
 
+void JellyfinBackend::probeCapabilities() {
+    if (!has_auth()) return;
+
+    // Already probed: re-emit cached state. This is important because
+    // ModuleSettings.qml is destroyed/recreated on navigation and the
+    // one-shot dynamicOptionsReady signal may have been missed.
+    if (m_capabilitiesProbed) {
+        if (m_hasCapability)
+            emit dynamicOptionsReady("_capabilities",
+                QVariantList{QString("mediasegments")});
+        else
+            emit dynamicOptionsReady("_capabilities", QVariantList{});
+        return;
+    }
+
+    // First probe: use a null GUID — if the MediaSegments route exists
+    // (plugin installed), the server returns a non-404 HTTP response.
+    // If the route doesn't exist, ASP.NET returns 404.
+    QUrl url(m_serverUrl + "/MediaSegments/00000000-0000-0000-0000-000000000000");
+    auto *reply = jellyfinGet(url);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+
+        // fetchSegments may have handled the probe while we were waiting
+        if (m_capabilitiesProbed) {
+            // fetchSegments already emitted — sync our cached flag
+            // m_hasCapability was already set by fetchSegments
+            return;
+        }
+
+        int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (status >= 200) {
+            // Got a definitive HTTP response from the server
+            m_capabilitiesProbed = true;
+            m_hasCapability = (status != 404);
+            if (m_hasCapability) {
+                emit dynamicOptionsReady("_capabilities",
+                    QVariantList{QString("mediasegments")});
+            } else {
+                emit dynamicOptionsReady("_capabilities", QVariantList{});
+            }
+        }
+        // Network error (status == 0): leave m_capabilitiesProbed false so
+        // fetchSegments can retry with a real item ID
+    });
+}
+
 void JellyfinBackend::fetchSegments(const QString &itemId) {
     QUrl url(m_serverUrl + "/MediaSegments/" + itemId);
     auto *reply = jellyfinGet(url);
     connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
         reply->deleteLater();
 
-        // One-shot capability probe on first call
+        // One-shot capability probe on first call (fallback if
+        // probeCapabilities failed or was never called)
         if (!m_capabilitiesProbed) {
             m_capabilitiesProbed = true;
-            if (reply->error() == QNetworkReply::NoError) {
+            m_hasCapability = (reply->error() == QNetworkReply::NoError);
+            if (m_hasCapability) {
                 emit dynamicOptionsReady("_capabilities",
                     QVariantList{QString("mediasegments")});
             } else {

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1459,3 +1459,45 @@ void JellyfinBackend::load_server_preferences() {
         emit serverLanguagePreferencesReady(audioLang, subLang, subMode);
     });
 }
+
+void JellyfinBackend::fetchSegments(const QString &itemId) {
+    QUrl url(m_serverUrl + "/MediaSegments/" + itemId);
+    auto *reply = jellyfinGet(url);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
+        reply->deleteLater();
+
+        // One-shot capability probe on first call
+        if (!m_capabilitiesProbed) {
+            m_capabilitiesProbed = true;
+            if (reply->error() == QNetworkReply::NoError) {
+                emit dynamicOptionsReady("_capabilities",
+                    QVariantList{QString("mediasegments")});
+            } else {
+                emit dynamicOptionsReady("_capabilities", QVariantList{});
+                return;  // no segments to process, server doesn't support it
+            }
+        }
+
+        // Parse segments from the response
+        if (reply->error() != QNetworkReply::NoError) return;
+
+        QJsonObject root = QJsonDocument::fromJson(reply->readAll()).object();
+        QJsonArray items = root["Items"].toArray();
+
+        QVariantList segments;
+        for (const QJsonValue &val : items) {
+            QJsonObject item = val.toObject();
+            QString type = item["Type"].toString();
+            // Only include Intro and Outro segments
+            if (type != "Intro" && type != "Outro") continue;
+
+            QVariantMap seg;
+            seg["type"]    = type;                                  // "Intro" or "Outro"
+            seg["startMs"] = item["StartTicks"].toDouble() / 10000.0;  // ticks → ms
+            seg["endMs"]   = item["EndTicks"].toDouble()   / 10000.0;
+            segments.append(seg);
+        }
+
+        emit segmentsReady(itemId, segments);
+    });
+}

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1485,6 +1485,13 @@ void JellyfinBackend::probeCapabilities() {
     // First probe: use a null GUID — if the MediaSegments route exists
     // (plugin installed), the server returns a non-404 HTTP response.
     // If the route doesn't exist, ASP.NET returns 404.
+    //
+    // The non-404 on capable servers is because Jellyfin's GetItemById
+    // throws on an empty GUID (→ 400/500) before its item-not-found 404
+    // path is reached. If a future Jellyfin returns plain 404 for the
+    // empty GUID, this probe reports "no capability" and the skip settings
+    // stay hidden; switch to a /System/Info/Public version check (the
+    // MediaSegments API is core since 10.10) if that ever happens.
     QUrl url(m_serverUrl + "/MediaSegments/00000000-0000-0000-0000-000000000000");
     auto *reply = jellyfinGet(url);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -1521,16 +1528,22 @@ void JellyfinBackend::fetchSegments(const QString &itemId) {
         reply->deleteLater();
 
         // One-shot capability probe on first call (fallback if
-        // probeCapabilities failed or was never called)
+        // probeCapabilities failed or was never called). Like
+        // probeCapabilities, only latch on a definitive HTTP response —
+        // a transient network error (status 0) must not permanently mark
+        // the server as lacking the capability.
         if (!m_capabilitiesProbed) {
-            m_capabilitiesProbed = true;
-            m_hasCapability = (reply->error() == QNetworkReply::NoError);
-            if (m_hasCapability) {
-                emit dynamicOptionsReady("_capabilities",
-                    QVariantList{QString("mediasegments")});
-            } else {
-                emit dynamicOptionsReady("_capabilities", QVariantList{});
-                return;  // no segments to process, server doesn't support it
+            int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            if (status >= 200) {
+                m_capabilitiesProbed = true;
+                m_hasCapability = (status != 404);
+                if (m_hasCapability) {
+                    emit dynamicOptionsReady("_capabilities",
+                        QVariantList{QString("mediasegments")});
+                } else {
+                    emit dynamicOptionsReady("_capabilities", QVariantList{});
+                    return;  // no segments to process, server doesn't support it
+                }
             }
         }
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -51,6 +51,7 @@ public:
 
     // Intro/outro skip — MediaSegments API
     Q_INVOKABLE void fetchSegments(const QString &itemId);
+    Q_INVOKABLE void probeCapabilities();
 
     // URL helpers for QML
     Q_INVOKABLE QString image_url(const QString &itemId, const QString &imageType, int width, int height);
@@ -113,6 +114,7 @@ private:
     QString m_currentPlayMethod; // "DirectPlay" or "Transcode" — for /Sessions reporting
     QString m_deviceId;
     bool m_capabilitiesProbed = false;
+    bool m_hasCapability = false;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -49,6 +49,9 @@ public:
     Q_INVOKABLE void report_playback_stopped(const QString &itemId, const QString &mediaSourceId, qint64 positionTicks, bool failed = false);
     Q_INVOKABLE void report_playback_start(const QString &itemId, const QString &mediaSourceId, const QString &audioStreamId, const QString &subtitleStreamId, qint64 startPositionTicks = 0);
 
+    // Intro/outro skip — MediaSegments API
+    Q_INVOKABLE void fetchSegments(const QString &itemId);
+
     // URL helpers for QML
     Q_INVOKABLE QString image_url(const QString &itemId, const QString &imageType, int width, int height);
 
@@ -75,6 +78,7 @@ signals:
     void seriesNextUpReady(const QVariantMap &detail);
     void streamUrlReady(const QString &url);
     void dynamicOptionsReady(const QString &key, const QVariant &options);
+    void segmentsReady(const QString &itemId, const QVariantList &segments);
     void errorOccurred(const QString &message);
     void logoutComplete();
     void authRevoked();
@@ -108,6 +112,7 @@ private:
     QString m_currentPlaySessionId;
     QString m_currentPlayMethod; // "DirectPlay" or "Transcode" — for /Sessions reporting
     QString m_deviceId;
+    bool m_capabilitiesProbed = false;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -418,6 +418,15 @@ void MpvController::sendKey(const QString &key) {
     sendCommand({"keypress", key});
 }
 
+void MpvController::showOsdSkipPrompt() {
+    sendCommand({"script-message", "skip-overlay-state", "1"});
+    sendCommand({"keypress", "DOWN"});
+}
+
+void MpvController::clearOsdPrompt() {
+    sendCommand({"script-message", "skip-overlay-state", "0"});
+}
+
 void MpvController::tryConnectIpc() {
     if (m_ipc->state() == QLocalSocket::ConnectedState ||
         m_ipc->state() == QLocalSocket::ConnectingState)
@@ -437,8 +446,16 @@ void MpvController::onIpcReadyRead() {
             // mpv reports why playback ended: "eof" (played to the end),
             // "quit"/"stop" (user exited), "error", etc. Remember the last one
             // so onProcessFinished can distinguish a natural finish from a quit.
-            if (event == "end-file")
+            if (event == "end-file") {
                 m_lastEndFileReason = obj["reason"].toString();
+            } else if (event == "client-message") {
+                const QJsonArray args = obj["args"].toArray();
+                if (args.size() > 0) {
+                    const QString msg = args[0].toString();
+                    if (msg == "skip-segment")
+                        emit skipRequested();
+                }
+            }
             continue;
         }
 

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -56,6 +56,8 @@ public:
     Q_INVOKABLE void stop();
     Q_INVOKABLE void seekTo(int positionMs);
     Q_INVOKABLE void sendKey(const QString &key);
+    Q_INVOKABLE void showOsdSkipPrompt();
+    Q_INVOKABLE void clearOsdPrompt();
 
     // True only on devices whose smooth-playback decode path can't crop/zoom (the
     // Pi 3 DRM-overlay path). Settings uses this to show the "Smooth Playback"
@@ -77,6 +79,8 @@ signals:
     // connects one handler and branches on `reason`, so it can never silently drop
     // a case the way an unhandled per-reason signal would.
     void playbackEnded(int finalPositionMs, int finalDurationMs, const QString &reason);
+
+    void skipRequested();
 
 private slots:
     void onProcessFinished();

--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -39,10 +39,12 @@ FocusScope {
             }
         }
         authState = needsAuthState ? appCore.get_module_auth_state(moduleId) : ""
+        var caps = dynamicOptions["_capabilities"] || []
         var filtered = []
         for (var i = 0; i < schema.length; i++) {
             var item = schema[i]
             if (item.requires_auth && (authState === "none" || authState === "")) continue
+            if (item.requires_capability && caps.indexOf(item.requires_capability) < 0) continue
             filtered.push(item)
         }
         schemaItems = filtered
@@ -139,7 +141,12 @@ FocusScope {
             var updated = Object.assign({}, moduleSettingsRoot.dynamicOptions)
             updated[key] = items
             moduleSettingsRoot.dynamicOptions = updated
-            settingsList.forceLayout()
+            // Capability changes affect schema filtering — rebuild the model so
+            // settings with requires_capability appear/disappear immediately.
+            if (key === "_capabilities")
+                buildModel()
+            else
+                settingsList.forceLayout()
         }
         function onModuleAuthStateChanged(mid) {
             if (mid !== moduleSettingsRoot.moduleId) return


### PR DESCRIPTION
## Summary

Add intro and credit skip support for the Jellyfin module using the MediaSegments API.

**Intro / Credit Skip**

Three modes per-setting: Off, Auto (silently seeks past segments), and Button (SKIP appears in the OSD, usable with gamepad or keyboard). Settings are hidden on servers that don't have the `mediasegments` capability.

## AI involvement

Built with the help of opencode go models (deepseek-v4-flash/pro, kimi-k2.7-code, mimo-v2.5, qwen-3.7-plus). All testing, code auditing, and research was done by me.

## Testing

- Platform(s) tested: Arch Linux, Raspberry Pi 5 (Raspberry Pi OS)
- Display / output tested: DisplayPort (Arch Linux), Composite (Pi 5)

Tested with:
- Transcode playback
- Keyboard navigation in the Player overlay
- Servers with the `mediasegments` capability

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](CONTRIBUTING.md)

Closes #98