### PR TITLE
Feat: jellyfin track persistence

### DIFF
--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -24,6 +24,7 @@
       "type": "list_single",
       "options_source": "dynamic",
       "options_slot": "getVideoQualities",
+      "default": "720p",
       "requires_auth": true
     },
     {

--- a/modules/jellyfin/manifest.json
+++ b/modules/jellyfin/manifest.json
@@ -24,7 +24,7 @@
       "type": "list_single",
       "options_source": "dynamic",
       "options_slot": "getVideoQualities",
-      "default": "720p",
+      "default": "auto",
       "requires_auth": true
     },
     {

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -247,20 +247,12 @@ FocusScope {
 
     function _saveCurrentLangs() {
         if (!detail) return
-        var aStream = (detail.audioStreams && detail.audioStreams[audioIdx]) ? detail.audioStreams[audioIdx] : null
-        var aLang = aStream ? (aStream.language || "") : ""
-        var aTitle = aStream ? (aStream.displayTitle || aStream.title || "") : ""
-        var sLang = ""
-        var sTitle = ""
-        if (subtitleIdx !== 0) {
-            var sStream = (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
-                          ? detail.subtitleStreams[subtitleIdx - 1] : null
-            if (sStream) {
-                sLang = sStream.language || ""
-                sTitle = sStream.displayTitle || sStream.title || ""
-            }
-        }
-        jellyfinBackend.set_last_track_langs(aLang, sLang, aTitle, sTitle)
+        var aLang = (detail.audioStreams && detail.audioStreams[audioIdx])
+                    ? (detail.audioStreams[audioIdx].language || "") : ""
+        var sLang = (subtitleIdx === 0) ? ""
+                    : (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
+                      ? (detail.subtitleStreams[subtitleIdx - 1].language || "") : ""
+        jellyfinBackend.set_last_track_langs(aLang, sLang)
     }
 
     function applyLanguagePreferences(d) {
@@ -270,28 +262,13 @@ FocusScope {
         // [dev]             " nAudio=" + (d.audioStreams ? d.audioStreams.length : 0) +
         // [dev]             " nSub=" + (d.subtitleStreams ? d.subtitleStreams.length : 0))
 
-        var savedAudioTitle = jellyfinBackend.get_last_audio_title()
-        var savedSubTitle   = jellyfinBackend.get_last_sub_title()
-
-        // Audio: server language preference > saved title match > IsDefault > first stream.
+        // Audio: server language preference > IsDefault > first stream.
         var audioLang = ""
         if (d.audioStreams && d.audioStreams.length > 0) {
             var ai = -1
             if (serverAudioLang) {
-                // Phase 1: match by language
                 for (var i = 0; i < d.audioStreams.length; i++) {
                     if (d.audioStreams[i].language === serverAudioLang) { ai = i; break }
-                }
-                // Phase 2: if we have a saved title, try to refine within same-language tracks
-                if (ai >= 0 && savedAudioTitle) {
-                    var titleMatch = -1
-                    for (var t = 0; t < d.audioStreams.length; t++) {
-                        if (d.audioStreams[t].language === serverAudioLang) {
-                            var tTitle = d.audioStreams[t].displayTitle || d.audioStreams[t].title || ""
-                            if (tTitle === savedAudioTitle) { titleMatch = t; break }
-                        }
-                    }
-                    if (titleMatch >= 0) ai = titleMatch
                 }
             }
             if (ai < 0) {
@@ -304,21 +281,8 @@ FocusScope {
             audioLang = d.audioStreams[ai].language || ""
         }
 
-        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language,
-        // with saved title refinement when multiple subs share the same language.
-        var subPick = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
-        if (subPick > 0 && savedSubTitle) {
-            var exactTitleMatch = -1
-            // Search within the same-language subtitle tracks for a title match
-            for (var si = 0; si < d.subtitleStreams.length; si++) {
-                if (d.subtitleStreams[si].language === serverSubLang) {
-                    var siTitle = d.subtitleStreams[si].displayTitle || d.subtitleStreams[si].title || ""
-                    if (siTitle === savedSubTitle) { exactTitleMatch = si + 1; break }
-                }
-            }
-            if (exactTitleMatch >= 0) subPick = exactTitleMatch
-        }
-        detailRoot.subtitleIdx = subPick
+        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language.
+        detailRoot.subtitleIdx = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
     }
 
     // ---

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -158,15 +158,26 @@ FocusScope {
             if (focusRow < maxRow) focusRow++
         }
     }
+    // Debounce: batch rapid arrow-key changes into a single backend save
+    // to reduce QML→C++ cross-context calls that can crash on Pi.
+    Timer {
+        id: debounceSaveTimer
+        interval: 200
+        repeat: false
+        onTriggered: _saveCurrentLangs()
+    }
+
     Keys.onLeftPressed: {
         if (isLaunching) return
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
             userChangedTracks = true
+            debounceSaveTimer.restart()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
             userChangedTracks = true
+            debounceSaveTimer.restart()
         }
     }
     Keys.onRightPressed: {
@@ -175,9 +186,11 @@ FocusScope {
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
             userChangedTracks = true
+            debounceSaveTimer.restart()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
             userChangedTracks = true
+            debounceSaveTimer.restart()
         }
     }
     Keys.onReturnPressed: {

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -158,8 +158,10 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
+            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
+            _saveCurrentLangs()
         }
     }
     Keys.onRightPressed: {
@@ -167,8 +169,10 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
+            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
+            _saveCurrentLangs()
         }
     }
     Keys.onReturnPressed: {
@@ -241,6 +245,24 @@ FocusScope {
         return idx
     }
 
+    function _saveCurrentLangs() {
+        if (!detail) return
+        var aStream = (detail.audioStreams && detail.audioStreams[audioIdx]) ? detail.audioStreams[audioIdx] : null
+        var aLang = aStream ? (aStream.language || "") : ""
+        var aTitle = aStream ? (aStream.displayTitle || aStream.title || "") : ""
+        var sLang = ""
+        var sTitle = ""
+        if (subtitleIdx !== 0) {
+            var sStream = (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
+                          ? detail.subtitleStreams[subtitleIdx - 1] : null
+            if (sStream) {
+                sLang = sStream.language || ""
+                sTitle = sStream.displayTitle || sStream.title || ""
+            }
+        }
+        jellyfinBackend.set_last_track_langs(aLang, sLang, aTitle, sTitle)
+    }
+
     function applyLanguagePreferences(d) {
         if (!d) return
         // [dev] console.log("[Item] applyPrefs serverAudio=" + serverAudioLang + " serverSub=" + serverSubLang +
@@ -248,13 +270,28 @@ FocusScope {
         // [dev]             " nAudio=" + (d.audioStreams ? d.audioStreams.length : 0) +
         // [dev]             " nSub=" + (d.subtitleStreams ? d.subtitleStreams.length : 0))
 
-        // Audio: server language preference > IsDefault > first stream.
+        var savedAudioTitle = jellyfinBackend.get_last_audio_title()
+        var savedSubTitle   = jellyfinBackend.get_last_sub_title()
+
+        // Audio: server language preference > saved title match > IsDefault > first stream.
         var audioLang = ""
         if (d.audioStreams && d.audioStreams.length > 0) {
             var ai = -1
             if (serverAudioLang) {
+                // Phase 1: match by language
                 for (var i = 0; i < d.audioStreams.length; i++) {
                     if (d.audioStreams[i].language === serverAudioLang) { ai = i; break }
+                }
+                // Phase 2: if we have a saved title, try to refine within same-language tracks
+                if (ai >= 0 && savedAudioTitle) {
+                    var titleMatch = -1
+                    for (var t = 0; t < d.audioStreams.length; t++) {
+                        if (d.audioStreams[t].language === serverAudioLang) {
+                            var tTitle = d.audioStreams[t].displayTitle || d.audioStreams[t].title || ""
+                            if (tTitle === savedAudioTitle) { titleMatch = t; break }
+                        }
+                    }
+                    if (titleMatch >= 0) ai = titleMatch
                 }
             }
             if (ai < 0) {
@@ -267,8 +304,21 @@ FocusScope {
             audioLang = d.audioStreams[ai].language || ""
         }
 
-        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language.
-        detailRoot.subtitleIdx = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language,
+        // with saved title refinement when multiple subs share the same language.
+        var subPick = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        if (subPick > 0 && savedSubTitle) {
+            var exactTitleMatch = -1
+            // Search within the same-language subtitle tracks for a title match
+            for (var si = 0; si < d.subtitleStreams.length; si++) {
+                if (d.subtitleStreams[si].language === serverSubLang) {
+                    var siTitle = d.subtitleStreams[si].displayTitle || d.subtitleStreams[si].title || ""
+                    if (siTitle === savedSubTitle) { exactTitleMatch = si + 1; break }
+                }
+            }
+            if (exactTitleMatch >= 0) subPick = exactTitleMatch
+        }
+        detailRoot.subtitleIdx = subPick
     }
 
     // ---

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -67,6 +67,9 @@ FocusScope {
 
     // Persisted selection so onItemLoaded doesn't wipe it
     property bool hasRestoredState: false
+    // Set true when the user manually changes a track via arrow keys, so the
+    // async onServerLanguagePreferencesReady doesn't override their choice.
+    property bool userChangedTracks: false
 
     // Server-side language preferences — fetched on first load as fallback
     property string serverAudioLang: ""
@@ -89,14 +92,16 @@ FocusScope {
                 detailRoot.audioIdx = 0
                 detailRoot.subtitleIdx = 0
             }
+            detailRoot.userChangedTracks = false
         }
 
         function onServerLanguagePreferencesReady(audioLang, subLang, subMode) {
             serverAudioLang = audioLang
             serverSubLang   = subLang
             serverSubMode   = subMode
-            // Re-apply preferences now that we have server data
-            if (detailRoot.detail && !hasRestoredState) {
+            // Only apply server prefs if the user hasn't manually changed a track
+            // (otherwise the async response would override their arrow-key choice).
+            if (detailRoot.detail && !hasRestoredState && !detailRoot.userChangedTracks) {
                 detailRoot.applyLanguagePreferences(detailRoot.detail)
             }
         }
@@ -158,8 +163,10 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
+            userChangedTracks = true
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
+            userChangedTracks = true
         }
     }
     Keys.onRightPressed: {
@@ -167,14 +174,19 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
+            userChangedTracks = true
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
+            userChangedTracks = true
         }
     }
     Keys.onReturnPressed: {
         if (isLaunching) return
         if (focusRow === 0 && detail) {
             isLaunching = true
+            // Save the current track selection before playback starts so it
+            // persists to the next item via load_server_preferences().
+            _saveCurrentLangs()
             // get_playback_url() reports the playback Start to the server once
             // PlaybackInfo resolves (so session id + play method are correct).
             jellyfinBackend.get_playback_url(detail.itemId, detail.mediaSourceId || detail.itemId,
@@ -248,12 +260,40 @@ FocusScope {
 
     function _saveCurrentLangs() {
         if (!detail) return
-        var aLang = (detail.audioStreams && detail.audioStreams[audioIdx])
-                    ? (detail.audioStreams[audioIdx].language || "") : ""
-        var sLang = (subtitleIdx === 0) ? ""
-                    : (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
-                      ? (detail.subtitleStreams[subtitleIdx - 1].language || "") : ""
-        jellyfinBackend.set_last_track_langs(aLang, sLang)
+        // Audio: save language and the position of this stream within
+        // streams of the same language, so we can pick the exact track
+        // when multiple share a language (e.g. English main + commentary).
+        var aStream = (detail.audioStreams && detail.audioStreams[audioIdx])
+                      ? detail.audioStreams[audioIdx] : null
+        var aLang = aStream ? (aStream.language || "") : ""
+        var aLangIdx = -1
+        if (aLang && detail.audioStreams) {
+            for (var ai = 0; ai < detail.audioStreams.length; ai++) {
+                if (detail.audioStreams[ai].language === aLang) {
+                    aLangIdx++
+                    if (ai === audioIdx) break
+                }
+            }
+        }
+        // Subtitle: same approach. subtitleIdx === 0 means Off.
+        var sLang = ""
+        var sLangIdx = -1
+        if (subtitleIdx !== 0) {
+            var sStream = (detail.subtitleStreams && detail.subtitleStreams[subtitleIdx - 1])
+                          ? detail.subtitleStreams[subtitleIdx - 1] : null
+            if (sStream) {
+                sLang = sStream.language || ""
+                if (sLang && detail.subtitleStreams) {
+                    for (var si = 0; si < detail.subtitleStreams.length; si++) {
+                        if (detail.subtitleStreams[si].language === sLang) {
+                            sLangIdx++
+                            if (si === subtitleIdx - 1) break
+                        }
+                    }
+                }
+            }
+        }
+        jellyfinBackend.set_last_track_langs(aLang, sLang, aLangIdx, sLangIdx)
     }
 
     function applyLanguagePreferences(d) {
@@ -263,13 +303,26 @@ FocusScope {
         // [dev]             " nAudio=" + (d.audioStreams ? d.audioStreams.length : 0) +
         // [dev]             " nSub=" + (d.subtitleStreams ? d.subtitleStreams.length : 0))
 
-        // Audio: server language preference > IsDefault > first stream.
+        var savedAudioLangIdx = jellyfinBackend.get_last_audio_lang_idx()
+        var savedSubLangIdx   = jellyfinBackend.get_last_sub_lang_idx()
+
+        // Audio: server language preference > same-language index match > IsDefault > first.
         var audioLang = ""
         if (d.audioStreams && d.audioStreams.length > 0) {
             var ai = -1
             if (serverAudioLang) {
+                // Collect all streams with the target language
+                var candidates = []
                 for (var i = 0; i < d.audioStreams.length; i++) {
-                    if (d.audioStreams[i].language === serverAudioLang) { ai = i; break }
+                    if (d.audioStreams[i].language === serverAudioLang)
+                        candidates.push(i)
+                }
+                if (candidates.length > 0) {
+                    // Use saved language-group index when valid
+                    if (savedAudioLangIdx >= 0 && savedAudioLangIdx < candidates.length)
+                        ai = candidates[savedAudioLangIdx]
+                    else
+                        ai = candidates[0] // fall back to first
                 }
             }
             if (ai < 0) {
@@ -282,8 +335,21 @@ FocusScope {
             audioLang = d.audioStreams[ai].language || ""
         }
 
-        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio language.
-        detailRoot.subtitleIdx = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        // Subtitles: follow the server's SubtitleMode, keyed off the chosen audio,
+        // with saved language-group index to pick the exact track.
+        var subPick = pickSubtitle(d.subtitleStreams, serverSubLang, serverSubMode, audioLang)
+        if (subPick > 0 && serverSubLang) {
+            var subCandidates = []
+            for (var si = 0; si < d.subtitleStreams.length; si++) {
+                if (d.subtitleStreams[si].language === serverSubLang)
+                    subCandidates.push(si)
+            }
+            if (subCandidates.length > 0) {
+                if (savedSubLangIdx >= 0 && savedSubLangIdx < subCandidates.length)
+                    subPick = subCandidates[savedSubLangIdx] + 1
+            }
+        }
+        detailRoot.subtitleIdx = subPick
     }
 
     // ---

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -158,10 +158,8 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
-            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx - 1 + (detail.subtitleStreams.length + 1)) % (detail.subtitleStreams.length + 1)
-            _saveCurrentLangs()
         }
     }
     Keys.onRightPressed: {
@@ -169,16 +167,17 @@ FocusScope {
         if (!detail) return
         if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1) {
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
-            _saveCurrentLangs()
         } else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 0) {
             subtitleIdx = (subtitleIdx + 1) % (detail.subtitleStreams.length + 1)
-            _saveCurrentLangs()
         }
     }
     Keys.onReturnPressed: {
         if (isLaunching) return
         if (focusRow === 0 && detail) {
             isLaunching = true
+            // Save the current track selection before playback starts so it
+            // persists to the next item via load_server_preferences().
+            _saveCurrentLangs()
             // get_playback_url() reports the playback Start to the server once
             // PlaybackInfo resolves (so session id + play method are correct).
             jellyfinBackend.get_playback_url(detail.itemId, detail.mediaSourceId || detail.itemId,
@@ -188,10 +187,15 @@ FocusScope {
     }
     Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+            _saveCurrentLangs()
             goBack()
             event.accepted = true
         }
     }
+
+    // Safety net: save the current selection when the view is destroyed
+    // (navigating back), even if the debounce timer hadn't fired yet.
+    Component.onDestruction: _saveCurrentLangs()
 
     // ------------------------------------------------------------------
     // Language display — uses Jellyfin's own DisplayTitle when available

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -175,9 +175,6 @@ FocusScope {
         if (isLaunching) return
         if (focusRow === 0 && detail) {
             isLaunching = true
-            // Save the current track selection before playback starts so it
-            // persists to the next item via load_server_preferences().
-            _saveCurrentLangs()
             // get_playback_url() reports the playback Start to the server once
             // PlaybackInfo resolves (so session id + play method are correct).
             jellyfinBackend.get_playback_url(detail.itemId, detail.mediaSourceId || detail.itemId,
@@ -194,7 +191,7 @@ FocusScope {
     }
 
     // Safety net: save the current selection when the view is destroyed
-    // (navigating back), even if the debounce timer hadn't fired yet.
+    // (navigating back), so the cached language is available for the next item.
     Component.onDestruction: _saveCurrentLangs()
 
     // ------------------------------------------------------------------

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -186,9 +186,7 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
-        var aTitle = (audioStreams[audioIdx] && (audioStreams[audioIdx].displayTitle || audioStreams[audioIdx].title)) || ""
-        var sTitle = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && (subtitleStreams[subtitleIdx].displayTitle || subtitleStreams[subtitleIdx].title)) || ""
-        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang, aTitle, sTitle)
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -186,6 +186,9 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
+        var aTitle = (audioStreams[audioIdx] && (audioStreams[audioIdx].displayTitle || audioStreams[audioIdx].title)) || ""
+        var sTitle = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && (subtitleStreams[subtitleIdx].displayTitle || subtitleStreams[subtitleIdx].title)) || ""
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang, aTitle, sTitle)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -56,6 +56,7 @@ FocusScope {
     Keys.onPressed: function(event) {
         if (overlayVisible) {
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                reportStopped(0, 0)
                 goBack()
                 event.accepted = true
             } else if (event.key === Qt.Key_Up) {
@@ -309,7 +310,7 @@ FocusScope {
     // the launch one tick so the loading indicator is rendered first.
     Timer {
         id: startTimer
-        interval: 50
+        interval: 16
         repeat: false
         property int pendingOffset: 0
         onTriggered: doStartPlayback(pendingOffset)
@@ -388,7 +389,14 @@ FocusScope {
 
     Connections {
         target: jellyfinBackend
-        function onErrorOccurred(msg) { console.log("[Jellyfin Player] Backend error: " + msg) }
+        function onErrorOccurred(msg) {
+            console.log("[Jellyfin Player] Backend error: " + msg)
+            if (pendingRetryTranscode) {
+                pendingRetryTranscode = false
+                reportStopped(lastKnownPositionMs, lastKnownDurationMs, true)
+                goBack()
+            }
+        }
 
         function onStreamUrlReady(url) {
             if (pendingNextEpisode) {
@@ -442,6 +450,8 @@ FocusScope {
                     // Direct play failed (e.g. a codec mpv couldn't handle, or a
                     // network drop). Retry transparently with a transcode, resuming
                     // at the last known position. Mirrors the Plex module.
+                    reportStopped(finalPositionMs, finalDurationMs, true)
+                    stoppedReported = false
                     pendingRetryTranscode = true
                     var aIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
                     var sIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
@@ -476,20 +486,28 @@ FocusScope {
         repeat:   true
         running:  true
         onTriggered: {
-            if (mpvController.position > 0)
+            var pos = mpvController.position
+            if (pos > 0) {
+                if (pos > playerRoot.lastKnownPositionMs)
+                    playerRoot.lastKnownPositionMs = pos
                 jellyfinBackend.update_playback_progress(itemId, mediaSourceId,
-                                                         msToTicks(mpvController.position), false)
+                                                         msToTicks(pos), false)
+            }
         }
     }
 
     Component.onCompleted: {
         initStreamIndices()
         if (streamUrl === "") return
-        resumeSetting = appCore.get_setting(moduleRoot.moduleId, "resume_playback") || "ask"
+        var allConfig = appCore.get_settings()
+        var mc = allConfig && allConfig["modules"]
+            ? allConfig["modules"][moduleRoot.moduleId] || {} : {}
+        resumeSetting = mc["resume_playback"] || "ask"
         // Match ModuleSettings.qml's reading of a toggle: stored as a real bool
         // once the user touches it, but accept the legacy "ON" string too.
-        var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
+        var autoplayRaw = mc["autoplay_next_episode"]
         autoplayNext = (autoplayRaw === true || autoplayRaw === "ON")
+
 
         // "ask": prompt resume vs. start over when there's a saved position.
         // "always" (or anything else): resume directly.
@@ -504,7 +522,7 @@ FocusScope {
     // without stopping), report stopped so Jellyfin doesn't show this as
     // still playing. The guard in reportStopped prevents double-reporting.
     Component.onDestruction: {
-        if (lastKnownPositionMs > 0)
+        if (streamUrl !== "")
             reportStopped(lastKnownPositionMs, lastKnownDurationMs)
     }
 

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -228,7 +228,10 @@ FocusScope {
     function reportStopped(finalPositionMs, finalDurationMs, failed) {
         if (stoppedReported) return
         stoppedReported = true
-        var pos = lastKnownPositionMs || finalPositionMs
+        // Fall back to viewOffset when playback never reported a position
+        // (canceled resume overlay, back during LOADING): Stopped with
+        // PositionTicks=0 would wipe the server-side resume point.
+        var pos = lastKnownPositionMs || finalPositionMs || viewOffset
         jellyfinBackend.report_playback_stopped(itemId, mediaSourceId, msToTicks(pos), failed || false)
     }
 

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -33,6 +33,10 @@ FocusScope {
     property bool   pendingRetryTranscode: false
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
+    // Full stream metadata used to disambiguate when several streams share a language.
+    // The persisted cache stays language-only; these are just runtime carry-over hints.
+    property var carryAudioPrefs: ({ language: "", title: "", displayTitle: "", codec: "", channels: "" })
+    property var carrySubPrefs:   ({ language: "__off__", title: "", displayTitle: "", codec: "", forced: false })
 
     property int    audioIdx:    0
     property int    subtitleIdx: -1
@@ -116,27 +120,106 @@ FocusScope {
         captureCarryLanguages()
     }
 
-    // Record the language of the current audio/subtitle selection so the next
-    // episode (which has different per-file stream IDs) can be matched by language.
+    // Record the language and metadata of the current audio/subtitle selection
+    // so the next episode (which has different per-file stream IDs) can be matched
+    // by language, with title/codec/channels used to disambiguate duplicates.
     function captureCarryLanguages() {
         var a = audioStreams[audioIdx]
         carryAudioLang = (a && a.language) ? a.language : ""
+        carryAudioPrefs = a ? {
+            language: a.language || "",
+            title: a.title || "",
+            displayTitle: a.displayTitle || "",
+            codec: a.codec || "",
+            channels: a.channels !== undefined ? a.channels : ""
+        } : { language: "", title: "", displayTitle: "", codec: "", channels: "" }
+
         var s = subtitleStreams[subtitleIdx]
         carrySubLang = (subtitleIdx === -1 || !s) ? "__off__" : (s.language || "")
+        carrySubPrefs = (subtitleIdx === -1 || !s)
+            ? { language: "__off__", title: "", displayTitle: "", codec: "", forced: false }
+            : {
+                language: s.language || "",
+                title: s.title || "",
+                displayTitle: s.displayTitle || "",
+                codec: s.codec || "",
+                forced: s.forced === true
+            }
+    }
+
+    // Score a stream against a previously-selected stream. Returns -1 when the
+    // language doesn't match; higher scores mean a closer match.
+    function streamScore(s, prefs) {
+        if (!s || !prefs) return -1
+        var lang = s.language || ""
+        var prefLang = prefs.language || ""
+        if (lang !== prefLang) return -1
+        var score = 100
+        var st = (s.title || "").toString().toLowerCase()
+        var pt = (prefs.title || "").toString().toLowerCase()
+        if (st && pt && st === pt) score += 100
+        var sd = (s.displayTitle || "").toString().toLowerCase()
+        var pd = (prefs.displayTitle || "").toString().toLowerCase()
+        if (sd && pd && sd === pd) score += 80
+        var sc = (s.codec || "").toString().toLowerCase()
+        var pc = (prefs.codec || "").toString().toLowerCase()
+        if (sc && pc && sc === pc) score += 50
+        if (prefs.channels !== undefined && s.channels !== undefined) {
+            if (String(s.channels).toLowerCase() === String(prefs.channels).toLowerCase())
+                score += 30
+        }
+        if (prefs.forced !== undefined && s.forced === prefs.forced)
+            score += 20
+        return score
+    }
+
+    function bestAudioMatch(streams, prefs) {
+        var best = 0
+        var bestScore = -1
+        for (var i = 0; i < streams.length; i++) {
+            var score = streamScore(streams[i], prefs)
+            if (score > bestScore) {
+                bestScore = score
+                best = i
+            }
+        }
+        return best
+    }
+
+    function bestSubtitleMatch(streams, prefs) {
+        if (!prefs || prefs.language === "__off__" || prefs.language === "") return -1
+        var best = -1
+        var bestScore = -1
+        for (var i = 0; i < streams.length; i++) {
+            var score = streamScore(streams[i], prefs)
+            if (score > bestScore) {
+                bestScore = score
+                best = i
+            }
+        }
+        return best
     }
 
     // Select audioIdx/subtitleIdx on the current stream lists to match the carried
-    // languages. Falls back to the first audio track / subtitles-off when no match.
+    // languages. When several streams share a language, title/codec/channels are
+    // used to pick the closest match; the fallback is the first audio track / off.
     function applyCarryLanguages() {
-        audioIdx = 0
-        for (var i = 0; i < audioStreams.length; i++) {
-            if (carryAudioLang && audioStreams[i].language === carryAudioLang) { audioIdx = i; break }
+        if (audioStreams && audioStreams.length > 0) {
+            if (carryAudioLang && carryAudioPrefs.language)
+                audioIdx = bestAudioMatch(audioStreams, carryAudioPrefs)
+            else
+                audioIdx = 0
+        } else {
+            audioIdx = 0
         }
-        subtitleIdx = -1
-        if (carrySubLang !== "__off__" && carrySubLang !== "") {
-            for (var j = 0; j < subtitleStreams.length; j++) {
-                if (subtitleStreams[j].language === carrySubLang) { subtitleIdx = j; break }
-            }
+
+        if (subtitleStreams && subtitleStreams.length > 0) {
+            if (carrySubLang !== "__off__" && carrySubLang !== "")
+                subtitleIdx = bestSubtitleMatch(subtitleStreams, carrySubPrefs)
+            else
+                subtitleIdx = -1
+        } else {
+            subtitleIdx = -1
         }
     }
 
@@ -186,7 +269,30 @@ FocusScope {
         selectedAudioId    = (audioStreams[audioIdx] && audioStreams[audioIdx].id) ? String(audioStreams[audioIdx].id) : ""
         selectedSubtitleId = (subtitleIdx >= 0 && subtitleStreams[subtitleIdx] && subtitleStreams[subtitleIdx].id) ? String(subtitleStreams[subtitleIdx].id) : ""
         captureCarryLanguages()
-        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang)
+        // Compute same-language index for the cache so menu navigation can
+        // restore the exact track, not just the first stream with that language.
+        var aLangIdx = -1
+        if (carryAudioLang && audioStreams && audioStreams.length > 0) {
+            var found = -1
+            for (var ai2 = 0; ai2 < audioStreams.length; ai2++) {
+                if (audioStreams[ai2].language === carryAudioLang) {
+                    found++
+                    if (ai2 === audioIdx) { aLangIdx = found; break }
+                }
+            }
+        }
+        var sLangIdx = -1
+        if (carrySubLang !== "__off__" && carrySubLang !== "" && subtitleStreams && subtitleStreams.length > 0) {
+            var sfound = -1
+            for (var si2 = 0; si2 < subtitleStreams.length; si2++) {
+                if (subtitleStreams[si2].language === carrySubLang) {
+                    sfound++
+                    if (si2 === subtitleIdx) { sLangIdx = sfound; break }
+                }
+            }
+        }
+        jellyfinBackend.set_last_track_langs(carryAudioLang, carrySubLang === "__off__" ? "" : carrySubLang,
+                                              aLangIdx, sLangIdx)
 
         // Request the new stream URL — get_playback_url() reports the playback
         // Start to the server once PlaybackInfo resolves (correct session/method).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -347,7 +347,7 @@ FocusScope {
         }
         var subTrack
         if (subtitleIdx < 0)
-            subTrack = -1                 // off → forced subs only (matches Plex)
+            subTrack = -2                 // off → --sid=no
         else if (selectedSubUrl)
             subTrack = 0                  // selected sidecar is the first loaded sub-file
         else
@@ -363,9 +363,9 @@ FocusScope {
         if (isTranscoding) {
             // HLS manifest bakes in the selected audio, and the chosen subtitle is
             // burned into the video — so there's no soft sub track for mpv to pick
-            // (subTrack -1 = forced-only, a no-op when nothing soft exists).
+            // (subTrack -2 = --sid=no, a no-op when nothing soft exists).
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                       -1, -1, [], [], false, -1, 0.0, "")
+                                       -1, -2, [], [], false, -1, 0.0, "")
         } else {
             // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
             // --aid; subtitles come from buildSubArgs (sidecars + --sid).

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -34,7 +34,8 @@ FocusScope {
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
     // Full stream metadata used to disambiguate when several streams share a language.
-    // The persisted cache stays language-only; these are just runtime carry-over hints.
+    // These are runtime carry-over hints for autoplay; the persisted backend cache
+    // stores the language plus its position within the language group.
     property var carryAudioPrefs: ({ language: "", title: "", displayTitle: "", codec: "", channels: "" })
     property var carrySubPrefs:   ({ language: "__off__", title: "", displayTitle: "", codec: "", forced: false })
 

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1024,14 +1024,14 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
     body["MediaSourceId"]          = mediaSourceId;
     if (audioStreamIndex >= 0)
         body["AudioStreamIndex"]   = audioStreamIndex;
-    if (directPlay) {
-        // Disable server-side subtitle selection so an unsupported subtitle
-        // codec can't force a transcode. The static stream still carries every
-        // embedded subtitle; mpv selects/renders them client-side (--sid).
-        body["SubtitleStreamIndex"] = -1;
-    } else if (subtitleStreamIndex >= 0) {
+    // For direct play the device profile already advertises Embed for every
+    // subtitle format (including PGS/VOBSUB), so the server knows we handle
+    // them client-side and won't force a transcode.  Pass the user's actual
+    // selection (or omit if off) so the static stream includes all tracks.
+    // Hardcoding -1 here caused newer Jellyfin servers to strip sub tracks
+    // from the stream, breaking both --sid for image subs and sidecar URLs.
+    if (subtitleStreamIndex >= 0)
         body["SubtitleStreamIndex"] = subtitleStreamIndex;
-    }
     if (maxBitrate > 0) body["MaxStreamingBitrate"] = maxBitrate;
     if (maxHeight  > 0) body["MaxHeight"]           = maxHeight;
     body["EnableDirectPlay"]       = directPlay;

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1162,7 +1162,19 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
         m_currentPlaySessionId = playSessionId;
         m_currentPlayMethod    = QStringLiteral("Transcode");
 
-        QString fullUrl = m_serverUrl + transcodeUrl;
+        // Build the full URL. When the user selected OFF, strip any
+        // SubtitleStreamIndex and SubtitleMethod the server may have added
+        // from default metadata.
+        QUrl parsedUrl(m_serverUrl + transcodeUrl);
+        {
+            QUrlQuery q(parsedUrl);
+            if (subtitleStreamIndex < 0) {
+                q.removeAllQueryItems("SubtitleStreamIndex");
+                q.removeAllQueryItems("SubtitleMethod");
+            }
+            parsedUrl.setQuery(q);
+        }
+        QString fullUrl = parsedUrl.toString();
 
         // Pin the URL's PlaySessionId to the one we report with (they should
         // already match; this guarantees it even if the server differs).

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1433,9 +1433,33 @@ void JellyfinBackend::onSettingChanged(const QString &moduleId, const QString &k
     }
 }
 
+QString JellyfinBackend::get_last_audio_lang() const {
+    return m_lastAudioLang;
+}
+
+QString JellyfinBackend::get_last_sub_lang() const {
+    return m_lastSubLang;
+}
+
+QString JellyfinBackend::get_last_audio_title() const {
+    return m_lastAudioTitle;
+}
+
+QString JellyfinBackend::get_last_sub_title() const {
+    return m_lastSubTitle;
+}
+
+void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           const QString &audioTitle, const QString &subTitle) {
+    m_lastAudioLang = audioLang;
+    m_lastSubLang = subLang;
+    if (!audioTitle.isEmpty()) m_lastAudioTitle = audioTitle;
+    if (!subTitle.isEmpty())   m_lastSubTitle   = subTitle;
+}
+
 void JellyfinBackend::load_server_preferences() {
     if (!has_auth()) {
-        emit serverLanguagePreferencesReady(QString(), QString(), QString());
+        emit serverLanguagePreferencesReady(m_lastAudioLang, m_lastSubLang, QString());
         return;
     }
 
@@ -1444,18 +1468,14 @@ void JellyfinBackend::load_server_preferences() {
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
-            emit serverLanguagePreferencesReady(QString(), QString(), QString());
+            emit serverLanguagePreferencesReady(m_lastAudioLang, m_lastSubLang, QString());
             return;
         }
         QJsonObject userData = QJsonDocument::fromJson(reply->readAll()).object();
         QJsonObject config = userData["Configuration"].toObject();
-        QString audioLang = config["AudioLanguagePreference"].toString();
-        QString subLang   = config["SubtitleLanguagePreference"].toString();
-        // SubtitleMode drives the preselect rule (Default/Smart/Always/OnlyForced/None);
-        // Jellyfin's default when the field is absent is "Default".
+        QString audioLang = !m_lastAudioLang.isEmpty() ? m_lastAudioLang : config["AudioLanguagePreference"].toString();
+        QString subLang   = !m_lastSubLang.isEmpty()   ? m_lastSubLang   : config["SubtitleLanguagePreference"].toString();
         QString subMode   = config["SubtitleMode"].toString();
-        // [dev] qDebug("[JellyfinBackend] Server prefs: audio=%s sub=%s mode=%s",
-        // [dev]        qPrintable(audioLang), qPrintable(subLang), qPrintable(subMode));
         emit serverLanguagePreferencesReady(audioLang, subLang, subMode);
     });
 }

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -148,7 +148,7 @@ QJsonObject JellyfinBackend::moduleConfig() const {
 }
 
 int JellyfinBackend::videoQualityBitrate() const {
-    QString quality = moduleConfig()["video_quality"].toString("720p");
+    QString quality = moduleConfig()["video_quality"].toString("auto");
     if (quality == QLatin1String("auto"))  return 0; // direct play — no cap
     if (quality == QLatin1String("1080p")) return 10000000;
     if (quality == QLatin1String("720p"))  return 6000000;
@@ -157,7 +157,7 @@ int JellyfinBackend::videoQualityBitrate() const {
 }
 
 int JellyfinBackend::videoQualityMaxHeight() const {
-    QString quality = moduleConfig()["video_quality"].toString("720p");
+    QString quality = moduleConfig()["video_quality"].toString("auto");
     if (quality == QLatin1String("auto"))  return 0; // direct play — no cap
     if (quality == QLatin1String("1080p")) return 1080;
     if (quality == QLatin1String("720p"))  return 720;
@@ -1013,7 +1013,7 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
     // HLS transcode. forceTranscode overrides "auto" for a fallback retry after
     // a direct-play failure (see Player.qml onPlaybackEnded).
     const bool directPlay = !forceTranscode
-                          && (moduleConfig()["video_quality"].toString("720p")
+                          && (moduleConfig()["video_quality"].toString("auto")
                               == QLatin1String("auto"));
     const int maxBitrate = videoQualityBitrate();
     const int maxHeight  = videoQualityMaxHeight();
@@ -1065,6 +1065,7 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
         addEmbed("ass");
         addEmbed("ssa");
         addEmbed("vtt");
+        addEmbed("webvtt");
         addEmbed("mov_text");
         addEmbed("pgssub");
         addEmbed("dvbsub");
@@ -1094,14 +1095,15 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
     profile["SubtitleProfiles"] = subtitleProfiles;
     QJsonArray directPlayProfiles;
     if (directPlay) {
-        // mpv plays virtually anything — advertise broad support so the server
-        // direct-plays compatible files instead of transcoding. An empty array
-        // (transcode mode) tells the server nothing can be direct-played.
+        // mpv plays virtually anything, so advertise a match-all profile —
+        // omitted Container/VideoCodec/AudioCodec fields match every value in
+        // Jellyfin's profile matcher. A codec whitelist here silently forced
+        // transcodes on exact-name misses (pcm_s16le vs pcm, webvtt vs vtt, …).
+        // If mpv truly can't play a file, the transcode retry in Player.qml
+        // onPlaybackEnded is the safety net. An empty array (transcode mode)
+        // tells the server nothing can be direct-played.
         QJsonObject dp;
-        dp["Type"]       = QStringLiteral("Video");
-        dp["Container"]  = QStringLiteral("mp4,mkv,webm,avi,mov,m4v,ts,mpegts,flv,wmv,3gp,mpg,mpeg,ogv,m2ts");
-        dp["VideoCodec"] = QStringLiteral("h264,hevc,h265,mpeg4,mpeg2video,vc1,vp8,vp9,av1");
-        dp["AudioCodec"] = QStringLiteral("aac,ac3,eac3,mp3,mp2,dts,flac,vorbis,opus,pcm,truehd,alac");
+        dp["Type"] = QStringLiteral("Video");
         directPlayProfiles.append(dp);
     }
     profile["DirectPlayProfiles"] = directPlayProfiles;
@@ -1154,6 +1156,22 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
 
         // Transcode path — used for the bitrate tiers, and as a graceful
         // fallback when the server reports the source can't be direct-played.
+        if (directPlay) {
+            // TranscodeReasons is an array of strings on older servers, a
+            // comma-joined flags string on 10.9+.
+            const QJsonValue tr = source["TranscodeReasons"];
+            QString reasons = tr.toString();
+            if (tr.isArray()) {
+                QStringList list;
+                for (const QJsonValue &r : tr.toArray())
+                    list << r.toString();
+                reasons = list.join(", ");
+            }
+            qWarning("[Jellyfin] direct play denied (SupportsDirectPlay=%d SupportsDirectStream=%d): %s",
+                     source["SupportsDirectPlay"].toBool(),
+                     source["SupportsDirectStream"].toBool(),
+                     reasons.isEmpty() ? "no TranscodeReasons given" : qPrintable(reasons));
+        }
         QString transcodeUrl = source["TranscodingUrl"].toString();
         if (transcodeUrl.isEmpty()) {
             emit errorOccurred("NO TRANSCODE URL");
@@ -1371,11 +1389,16 @@ void JellyfinBackend::report_playback_stopped(const QString &itemId, const QStri
 
     QUrl url(m_serverUrl + "/Sessions/Playing/Stopped");
     auto *reply = jellyfinPost(url, QJsonDocument(body).toJson(QJsonDocument::Compact));
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    // Only clear the session id if it's still the one we reported on — the
+    // transcode retry in Player.qml starts a new session right after reporting
+    // the failed one stopped, and this reply may land after that.
+    const QString reportedSessionId = m_currentPlaySessionId;
+    connect(reply, &QNetworkReply::finished, this, [this, reply, reportedSessionId]() {
         if (reply->error() != QNetworkReply::NoError)
             qWarning("[Jellyfin] report stopped failed: %s", qPrintable(reply->errorString()));
         reply->deleteLater();
-        m_currentPlaySessionId.clear();
+        if (m_currentPlaySessionId == reportedSessionId)
+            m_currentPlaySessionId.clear();
     });
 }
 

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1441,9 +1441,20 @@ QString JellyfinBackend::get_last_sub_lang() const {
     return m_lastSubLang;
 }
 
-void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang) {
+int JellyfinBackend::get_last_audio_lang_idx() const {
+    return m_lastAudioLangIdx;
+}
+
+int JellyfinBackend::get_last_sub_lang_idx() const {
+    return m_lastSubLangIdx;
+}
+
+void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           int audioLangIdx, int subLangIdx) {
     m_lastAudioLang = audioLang;
     m_lastSubLang = subLang;
+    m_lastAudioLangIdx = audioLangIdx;
+    m_lastSubLangIdx = subLangIdx;
 }
 
 void JellyfinBackend::load_server_preferences() {

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1441,20 +1441,9 @@ QString JellyfinBackend::get_last_sub_lang() const {
     return m_lastSubLang;
 }
 
-QString JellyfinBackend::get_last_audio_title() const {
-    return m_lastAudioTitle;
-}
-
-QString JellyfinBackend::get_last_sub_title() const {
-    return m_lastSubTitle;
-}
-
-void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang,
-                                           const QString &audioTitle, const QString &subTitle) {
+void JellyfinBackend::set_last_track_langs(const QString &audioLang, const QString &subLang) {
     m_lastAudioLang = audioLang;
     m_lastSubLang = subLang;
-    if (!audioTitle.isEmpty()) m_lastAudioTitle = audioTitle;
-    if (!subTitle.isEmpty())   m_lastSubTitle   = subTitle;
 }
 
 void JellyfinBackend::load_server_preferences() {

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -148,7 +148,7 @@ QJsonObject JellyfinBackend::moduleConfig() const {
 }
 
 int JellyfinBackend::videoQualityBitrate() const {
-    QString quality = moduleConfig()["video_quality"].toString("auto");
+    QString quality = moduleConfig()["video_quality"].toString("720p");
     if (quality == QLatin1String("auto"))  return 0; // direct play — no cap
     if (quality == QLatin1String("1080p")) return 10000000;
     if (quality == QLatin1String("720p"))  return 6000000;
@@ -157,7 +157,7 @@ int JellyfinBackend::videoQualityBitrate() const {
 }
 
 int JellyfinBackend::videoQualityMaxHeight() const {
-    QString quality = moduleConfig()["video_quality"].toString("auto");
+    QString quality = moduleConfig()["video_quality"].toString("720p");
     if (quality == QLatin1String("auto"))  return 0; // direct play — no cap
     if (quality == QLatin1String("1080p")) return 1080;
     if (quality == QLatin1String("720p"))  return 720;
@@ -1013,7 +1013,7 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
     // HLS transcode. forceTranscode overrides "auto" for a fallback retry after
     // a direct-play failure (see Player.qml onPlaybackEnded).
     const bool directPlay = !forceTranscode
-                          && (moduleConfig()["video_quality"].toString("auto")
+                          && (moduleConfig()["video_quality"].toString("720p")
                               == QLatin1String("auto"));
     const int maxBitrate = videoQualityBitrate();
     const int maxHeight  = videoQualityMaxHeight();
@@ -1336,7 +1336,11 @@ void JellyfinBackend::update_playback_progress(const QString &itemId, const QStr
 
     QUrl url(m_serverUrl + "/Sessions/Playing/Progress");
     auto *reply = jellyfinPost(url, QJsonDocument(body).toJson(QJsonDocument::Compact));
-    connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply->error() != QNetworkReply::NoError)
+            qWarning("[Jellyfin] progress update failed: %s", qPrintable(reply->errorString()));
+        reply->deleteLater();
+    });
 }
 
 void JellyfinBackend::report_playback_stopped(const QString &itemId, const QString &mediaSourceId,
@@ -1356,6 +1360,8 @@ void JellyfinBackend::report_playback_stopped(const QString &itemId, const QStri
     QUrl url(m_serverUrl + "/Sessions/Playing/Stopped");
     auto *reply = jellyfinPost(url, QJsonDocument(body).toJson(QJsonDocument::Compact));
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply->error() != QNetworkReply::NoError)
+            qWarning("[Jellyfin] report stopped failed: %s", qPrintable(reply->errorString()));
         reply->deleteLater();
         m_currentPlaySessionId.clear();
     });

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -59,6 +59,14 @@ public:
     Q_INVOKABLE void get_resume_playback_options();
     Q_INVOKABLE void load_server_preferences();
 
+    Q_INVOKABLE QString get_last_audio_lang() const;
+    Q_INVOKABLE QString get_last_sub_lang() const;
+    Q_INVOKABLE QString get_last_audio_title() const;
+    Q_INVOKABLE QString get_last_sub_title() const;
+    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           const QString &audioTitle = QString(),
+                                           const QString &subTitle = QString());
+
 signals:
     void authStateChanged();
     void librariesLoaded(const QVariant &libraries);
@@ -108,6 +116,10 @@ private:
     QString m_currentPlaySessionId;
     QString m_currentPlayMethod; // "DirectPlay" or "Transcode" — for /Sessions reporting
     QString m_deviceId;
+    QString m_lastAudioLang;
+    QString m_lastSubLang;
+    QString m_lastAudioTitle;
+    QString m_lastSubTitle;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -61,7 +61,10 @@ public:
 
     Q_INVOKABLE QString get_last_audio_lang() const;
     Q_INVOKABLE QString get_last_sub_lang() const;
-    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang);
+    Q_INVOKABLE int get_last_audio_lang_idx() const;
+    Q_INVOKABLE int get_last_sub_lang_idx() const;
+    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang,
+                                           int audioLangIdx = -1, int subLangIdx = -1);
 
 signals:
     void authStateChanged();
@@ -114,6 +117,8 @@ private:
     QString m_deviceId;
     QString m_lastAudioLang;
     QString m_lastSubLang;
+    int m_lastAudioLangIdx = -1;
+    int m_lastSubLangIdx = -1;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/modules/jellyfin/JellyfinBackend.h
+++ b/src/modules/jellyfin/JellyfinBackend.h
@@ -61,11 +61,7 @@ public:
 
     Q_INVOKABLE QString get_last_audio_lang() const;
     Q_INVOKABLE QString get_last_sub_lang() const;
-    Q_INVOKABLE QString get_last_audio_title() const;
-    Q_INVOKABLE QString get_last_sub_title() const;
-    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang,
-                                           const QString &audioTitle = QString(),
-                                           const QString &subTitle = QString());
+    Q_INVOKABLE void set_last_track_langs(const QString &audioLang, const QString &subLang);
 
 signals:
     void authStateChanged();
@@ -118,8 +114,6 @@ private:
     QString m_deviceId;
     QString m_lastAudioLang;
     QString m_lastSubLang;
-    QString m_lastAudioTitle;
-    QString m_lastSubTitle;
 
     static QString normalizeServerUrl(const QString &url);
 

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -67,6 +67,10 @@ MpvController::MpvController(const QString &appRoot, AppCore *appCore, QObject *
         f.close();
     }
 
+    m_hasMpvOscScript     = QFile::exists(m_appRoot + "/scripts/mpv-osc.lua");
+    m_hasAmbientOscScript = QFile::exists(m_appRoot + "/scripts/ambient-osc.lua");
+    m_hasMediaKeysScript  = QFile::exists(m_appRoot + "/scripts/media-keys.lua");
+
     m_ipc = new QLocalSocket(this);
     connect(m_ipc, &QLocalSocket::connected, this, [this] {
         m_connectTimer->stop();
@@ -150,9 +154,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         return;
     }
 
-    const QString oscScriptName = (oscMode == "ambient") ? "ambient-osc.lua" : "mpv-osc.lua";
-    const QString oscScript = m_appRoot + "/scripts/" + oscScriptName;
-    const bool hasOscScript = QFile::exists(oscScript);
+    const bool hasOscScript = (oscMode == "ambient") ? m_hasAmbientOscScript : m_hasMpvOscScript;
+    const QString oscScript = m_appRoot + "/scripts/" + ((oscMode == "ambient") ? "ambient-osc.lua" : "mpv-osc.lua");
 
     // Stamp the log file so each session is identifiable when tailing over SSH.
     {
@@ -160,7 +163,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         if (lf.open(QFile::Append | QFile::Text)) {
             QString safeUrl = url;
             safeUrl.replace(QRegularExpression("Api[_-]?Key=[^&\\s]+", QRegularExpression::CaseInsensitiveOption), "ApiKey=REDACTED");
-            safeUrl.replace(QRegularExpression("X-Plex-Token:[^\\s]+"), "X-Plex-Token=REDACTED");
+            safeUrl.replace(QRegularExpression("X-Plex-Token[=:][^&\\s]+"), "X-Plex-Token=REDACTED");
             safeUrl.replace(QRegularExpression("Token=\"[^\"]+\""), "Token=\"REDACTED\"");
             lf.write(QString("\n=== 240-MP session start %1 ===\n    url: %2\n\n")
                          .arg(QDateTime::currentDateTime().toString(Qt::ISODate))
@@ -181,9 +184,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
 
     // Media-key handling + themed volume bar — loaded for every mode so HID
     // media keys work anytime mpv is playing, not just inside a given module.
-    const QString mediaKeysScript = m_appRoot + "/scripts/media-keys.lua";
-    if (QFile::exists(mediaKeysScript))
-        args << QString("--script=%1").arg(mediaKeysScript);
+    if (m_hasMediaKeysScript)
+        args << QString("--script=%1").arg(m_appRoot + "/scripts/media-keys.lua");
 
     // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
     // primary plane between two consecutive same-size/format stills, so a photo
@@ -394,7 +396,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         QString safeCmd = args.join(" ");
         // Redact all token forms in debug output
         safeCmd.replace(QRegularExpression("Api[_-]?Key=[^&\\s]+", QRegularExpression::CaseInsensitiveOption), "ApiKey=REDACTED");
-        safeCmd.replace(QRegularExpression("X-Plex-Token:[^\\s]+"), "X-Plex-Token=REDACTED");
+        safeCmd.replace(QRegularExpression("X-Plex-Token[=:][^&\\s]+"), "X-Plex-Token=REDACTED");
         safeCmd.replace(QRegularExpression("Token=\"[^\"]+\""), "Token=\"REDACTED\"");
         qDebug("[MpvController] desktop launch: mpv %s", qPrintable(safeCmd));
         m_process->start(bin, args);
@@ -541,7 +543,11 @@ void MpvController::doHeadlessRestore(int pos, int dur, const QString &reason) {
 }
 
 void MpvController::sendCommand(const QJsonArray &args) {
-    if (m_ipc->state() != QLocalSocket::ConnectedState) return;
+    if (m_ipc->state() != QLocalSocket::ConnectedState) {
+        qWarning("[MpvController] IPC not connected, dropping: %s",
+                 QJsonDocument(QJsonObject{{"command", args}}).toJson(QJsonDocument::Compact).constData());
+        return;
+    }
     QJsonObject cmd;
     cmd["command"] = args;
     m_ipc->write(QJsonDocument(cmd).toJson(QJsonDocument::Compact) + "\n");

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -418,6 +418,7 @@ void MpvController::sendKey(const QString &key) {
     sendCommand({"keypress", key});
 }
 
+
 void MpvController::tryConnectIpc() {
     if (m_ipc->state() == QLocalSocket::ConnectedState ||
         m_ipc->state() == QLocalSocket::ConnectingState)

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -419,6 +419,7 @@ void MpvController::sendKey(const QString &key) {
 }
 
 
+
 void MpvController::tryConnectIpc() {
     if (m_ipc->state() == QLocalSocket::ConnectedState ||
         m_ipc->state() == QLocalSocket::ConnectingState)

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -127,6 +127,9 @@ private:
     int           m_playlistPos  = -1;
     bool          m_headlessMode = false;
     int           m_previousVt   = -1;
+    bool          m_hasMpvOscScript     = false;
+    bool          m_hasAmbientOscScript = false;
+    bool          m_hasMediaKeysScript  = false;
     int           m_qtDrmFd      = -1;
 #ifdef Q_OS_LINUX
     DrmSavedState m_savedDrm     = {};


### PR DESCRIPTION
## Summary

Persist audio and subtitle track selection across Jellyfin items.

**Track persistence**

When playing back-to-back episodes or navigating between items, the last chosen audio language and subtitle language are remembered and automatically applied to the next item. If the same track title is available (e.g. "English [DTS-HD MA 5.1]"), it is preferred over a basic language match.

Key changes:
- Saves the current audio/subtitle language (and optionally track title) whenever the user changes tracks or starts playback
- Restores saved preferences when loading a new item, falling back to the server's language defaults if no saved preference exists
- Tracks a language-group index to disambiguate between multiple streams that share the same language
- Debounces rapid arrow-key saves to avoid redundant writes
- Fixes subTrack -2 for "subtitles off" (previously conflated with -1 for "forced only")
- Strips SubtitleStreamIndex and SubtitleMethod from the transcode URL when subs are off, preventing the server from injecting unwanted subtitle tracks

## AI involvement

Built with the help of opencode go models (deepseek-v4-flash/pro, kimi-k2.7-code, mimo-v2.5, qwen-3.7-plus). All testing, code auditing, and research was done by me.

## Testing

- Platform(s) tested: Arch Linux, Raspberry Pi 5 (Raspberry Pi OS)
- Display / output tested: DisplayPort (Arch Linux), Composite (Pi 5)

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](CONTRIBUTING.md)

Closes #97
