### PR TITLE
fix(mpv): enable media keys to stop screensaver

### DIFF
--- a/scripts/screensaver.lua
+++ b/scripts/screensaver.lua
@@ -84,11 +84,19 @@ local function draw_frame(w, h, tx, ty)
 end
 
 -- ─── key bindings ─────────────────────────────────────────────────────────────
+-- Any key a user would press while interacting with mpv playback should wake
+-- the screen saver, matching the menu-side overlay's "any key dismisses"
+-- behavior (Main.qml). Includes both navigation keys and the HID media-key
+-- names media-keys.lua binds (PLAYPAUSE etc.) — otherwise e.g. a hardware
+-- Play press falls straight through to media-keys.lua and resumes playback
+-- behind the still-active screen saver.
 local DISMISS_KEYS = {
     "SPACE", "ENTER", "KP_ENTER", "ESC",
     "LEFT", "RIGHT", "UP", "DOWN", "PGUP", "PGDWN",
     "HOME", "END",
     "MBTN_LEFT", "MBTN_RIGHT",
+    "PLAYPAUSE", "STOP", "FORWARD", "REWIND", "NEXT", "PREV",
+    "VOLUME_UP", "VOLUME_DOWN", "MUTE",
 }
 
 activate = function()


### PR DESCRIPTION
## Summary

Closes: https://github.com/anthonycaccese/240-MP/issues/126

## AI involvement

Used to double check the keys to be supported referencing previous media keys work

## Testing

tested on both RPi and MacOS
On RPi working as expected now
On MacOS the same limitations described in the original media keys PR exist, specifically that MacOS at the OS level captures some of the media keys for OS level functions so MPV can't see them.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
