### PR TITLE
feat(jellyfin): sort items in collections by release date

### DIFF
--- a/modules/jellyfin/views/Boxset.qml
+++ b/modules/jellyfin/views/Boxset.qml
@@ -31,16 +31,22 @@ FocusScope {
         return null
     }
 
+    // Sort a bucket's items by release date, oldest first. Items with a missing
+    // or unparseable date sink to the bottom, keeping their incoming (SortName)
+    // order relative to one another.
     function sortCollectionItems(itemArr) {
         if (!itemArr) return []
         var result = itemArr.slice()
         result.sort(function(a, b) {
-            var aValue = a && (a.releaseDate || a.ReleaseDate)
-            var bValue = b && (b.releaseDate || b.ReleaseDate)
-            if (!aValue && !bValue) return 0
-            if (!aValue) return 1
-            if (!bValue) return -1
-            return Date.parse(aValue) - Date.parse(bValue)
+            var av = a && (a.releaseDate || a.ReleaseDate)
+            var bv = b && (b.releaseDate || b.ReleaseDate)
+            var at = av ? Date.parse(av) : NaN
+            var bt = bv ? Date.parse(bv) : NaN
+            var aBad = isNaN(at), bBad = isNaN(bt)
+            if (aBad && bBad) return 0
+            if (aBad) return 1
+            if (bBad) return -1
+            return at - bt
         })
         return result
     }
@@ -51,8 +57,8 @@ FocusScope {
         function onBoxsetChildrenLoaded(children) {
             boxsetRoot.isLoading = false
 
-            // Bucket children by content type, preserving the load order within
-            // each bucket (backend sorts by SortName).
+            // Bucket children by content type. Each bucket is re-sorted by
+            // release date (oldest first) via sortCollectionItems before handoff.
             var buckets = {}
             for (var i = 0; i < children.length; i++) {
                 var c = children[i]

--- a/modules/jellyfin/views/Boxset.qml
+++ b/modules/jellyfin/views/Boxset.qml
@@ -31,6 +31,20 @@ FocusScope {
         return null
     }
 
+    function sortCollectionItems(itemArr) {
+        if (!itemArr) return []
+        var result = itemArr.slice()
+        result.sort(function(a, b) {
+            var aValue = a && (a.releaseDate || a.ReleaseDate)
+            var bValue = b && (b.releaseDate || b.ReleaseDate)
+            if (!aValue && !bValue) return 0
+            if (!aValue) return 1
+            if (!bValue) return -1
+            return Date.parse(aValue) - Date.parse(bValue)
+        })
+        return result
+    }
+
     Connections {
         target: jellyfinBackend
 
@@ -59,7 +73,7 @@ FocusScope {
             if (cats.length === 1) {
                 boxsetRoot.replaceCurrent("Items.qml", {
                     mode: "static",
-                    items: cats[0].items,
+                    items: boxsetRoot.sortCollectionItems(cats[0].items),
                     title: cats[0].label,
                     libraryName: boxsetRoot.item.title || boxsetRoot.libraryName
                 })
@@ -101,7 +115,7 @@ FocusScope {
         if (!cat) return
         boxsetRoot.navigateTo("Items.qml", {
             mode: "static",
-            items: cat.items,
+            items: boxsetRoot.sortCollectionItems(cat.items),
             title: cat.label,
             libraryName: boxsetRoot.item.title || boxsetRoot.libraryName
         }, { currentIndex: categoryList.currentIndex })

--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -58,22 +58,6 @@ FocusScope {
         return result
     }
 
-    function sortStaticItemsForDisplay(itemArr) {
-        if (!itemArr) return []
-        var result = itemArr.slice()
-        if (navParams.mode === "static" && navParams.title === "COLLECTIONS") {
-            result.sort(function(a, b) {
-                var aValue = a && (a.releaseDate || a.ReleaseDate)
-                var bValue = b && (b.releaseDate || b.ReleaseDate)
-                if (!aValue && !bValue) return 0
-                if (!aValue) return 1
-                if (!bValue) return -1
-                return Date.parse(aValue) - Date.parse(bValue)
-            })
-        }
-        return result
-    }
-
     Connections {
         target: jellyfinBackend
 
@@ -146,7 +130,7 @@ FocusScope {
             // Pre-filtered list handed over by Boxset.qml — no fetch needed.
             isLoading = false
             errorMessage = ""
-            items = itemListRoot.sortStaticItemsForDisplay(navParams.items || [])
+            items = navParams.items || []
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 itemList.currentIndex = Math.min(restore, items.length - 1)

--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -58,6 +58,22 @@ FocusScope {
         return result
     }
 
+    function sortStaticItemsForDisplay(itemArr) {
+        if (!itemArr) return []
+        var result = itemArr.slice()
+        if (navParams.mode === "static" && navParams.title === "COLLECTIONS") {
+            result.sort(function(a, b) {
+                var aValue = a && (a.releaseDate || a.ReleaseDate)
+                var bValue = b && (b.releaseDate || b.ReleaseDate)
+                if (!aValue && !bValue) return 0
+                if (!aValue) return 1
+                if (!bValue) return -1
+                return Date.parse(aValue) - Date.parse(bValue)
+            })
+        }
+        return result
+    }
+
     Connections {
         target: jellyfinBackend
 
@@ -130,7 +146,7 @@ FocusScope {
             // Pre-filtered list handed over by Boxset.qml — no fetch needed.
             isLoading = false
             errorMessage = ""
-            items = navParams.items || []
+            items = itemListRoot.sortStaticItemsForDisplay(navParams.items || [])
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 itemList.currentIndex = Math.min(restore, items.length - 1)

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -553,6 +553,9 @@ QVariantMap JellyfinBackend::formatItem(const QJsonObject &item) const {
     map["title"]           = item["Name"].toString();
     map["type"]            = item["Type"].toString().toLower();
     map["overview"]        = item["Overview"].toString();
+    QString releaseDate = item["ReleaseDate"].toString();
+    QString premiereDate = item["PremiereDate"].toString();
+    map["releaseDate"]    = releaseDate.isEmpty() ? premiereDate : releaseDate;
     map["year"]            = item["ProductionYear"].toVariant();
     map["genres"]          = genres;
     map["duration"]        = item["RunTimeTicks"].toDouble() / 10000.0;
@@ -757,7 +760,7 @@ void JellyfinBackend::load_boxset_children(const QString &parentId) {
     QUrlQuery q;
     q.addQueryItem("parentId", parentId);
     q.addQueryItem("recursive", "false");
-    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount");
+    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount,ReleaseDate,PremiereDate");
     q.addQueryItem("sortBy", "SortName");
     q.addQueryItem("sortOrder", "Ascending");
     url.setQuery(q);


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Sorts movies in collections by release date instead of in alphabetical order

## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Used to help with double checking my work

## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->
Tested on MacOS, works perfectly with my setup

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)

I'm very open to feedback if there is anything of note