### PR TITLE
feat(settings): add reset to default option to directorybrowser

### DIFF
--- a/src/modules/ambient_mode/AmbientModeBackend.cpp
+++ b/src/modules/ambient_mode/AmbientModeBackend.cpp
@@ -39,9 +39,10 @@ QString AmbientModeBackend::mediaRoot() const
 
 void AmbientModeBackend::setMediaRoot(const QString &path)
 {
-    m_mediaRoot = path;
-    QDir().mkpath(path);
-    qDebug("[AmbientMode] media root: %s", qPrintable(path));
+    // An empty (reset) setting means back to the dataRoot/ambient default.
+    m_mediaRoot = path.isEmpty() ? m_dataRoot + "/ambient" : path;
+    QDir().mkpath(m_mediaRoot);
+    qDebug("[AmbientMode] media root: %s", qPrintable(m_mediaRoot));
 }
 
 QVariantList AmbientModeBackend::scanFiles(const QStringList &extensions) const

--- a/src/modules/local_files/LocalFilesBackend.cpp
+++ b/src/modules/local_files/LocalFilesBackend.cpp
@@ -162,9 +162,10 @@ QString LocalFilesBackend::mediaRoot() const {
 }
 
 void LocalFilesBackend::setMediaRoot(const QString &path) {
-    m_mediaRoot = path;
-    QDir().mkpath(path);
-    qDebug("[LocalFiles] media root: %s", qPrintable(path));
+    // An empty (reset) setting means back to the dataRoot/media default.
+    m_mediaRoot = path.isEmpty() ? m_dataRoot + "/media" : path;
+    QDir().mkpath(m_mediaRoot);
+    qDebug("[LocalFiles] media root: %s", qPrintable(m_mediaRoot));
 }
 
 void LocalFilesBackend::onSettingChanged(const QString &moduleId, const QString &key, const QVariant &value) {

--- a/views/DirectoryBrowser.qml
+++ b/views/DirectoryBrowser.qml
@@ -16,7 +16,8 @@ FocusScope {
     property var listModel: {
         var items = [
             { name: "..PARENT DIRECTORY", entryType: "up" },
-            { name: "<USE THIS DIRECTORY>", entryType: "select" }
+            { name: "<USE THIS DIRECTORY>", entryType: "select" },
+            { name: "<USE DEFAULT DIRECTORY>", entryType: "default" }
         ]
         for (var i = 0; i < dirEntries.length; i++) {
             items.push({ name: dirEntries[i].name, path: dirEntries[i].path, entryType: "dir" })
@@ -43,6 +44,13 @@ FocusScope {
 
     function selectCurrent() {
         appCore.save_setting(moduleId, settingKey, currentBrowsePath)
+        goBack()
+    }
+
+    // An empty saved value means "module default"; backends resolve it to
+    // their own default directory at read time.
+    function selectDefault() {
+        appCore.save_setting(moduleId, settingKey, "")
         goBack()
     }
 
@@ -84,6 +92,7 @@ FocusScope {
             if (!entry) return
             if (entry.entryType === "up") browserRoot.goUp()
             else if (entry.entryType === "select") browserRoot.selectCurrent()
+            else if (entry.entryType === "default") browserRoot.selectDefault()
             else if (entry.entryType === "dir") browserRoot.navigateInto(entry.path)
         }
         Keys.onPressed: function(event) {
@@ -105,7 +114,7 @@ FocusScope {
                     text: modelData.name || ""
                     color: {
                         if (dirList.currentIndex === index) return root.surfaceColor
-                        if (modelData.entryType === "up" || modelData.entryType === "select") return root.accentColor
+                        if (modelData.entryType === "up" || modelData.entryType === "select" || modelData.entryType === "default") return root.accentColor
                         return root.primaryColor
                     }
                     font.family: root.globalFont


### PR DESCRIPTION
## Summary

Adds a "Use Default Directory" option to DirectoryBrowser implementations so that a user can reset a given modules file path to the default without needing to touch config.json manually.  Updates Local Files and Ambient Mode with new guards for this (NFC Reader changes will come in a separate PR)

## AI involvement

Used to plan through surface area for the change and work through the fallback guard in existing modules

## Testing

Tested on both Raspberry Pi and MacOS in both Local Files and Ambient Mode modules.  Confirmed it allows an easy change back to Default Directory and config.json is updated accordingly.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
