### PR TITLE
feat(nfc reader): file based mapping approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 ### NFC Reader Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-NFC-Reader))
 - Start video playback via NFC cards
 - Tested reader support: `ACS ACR122U`
-- Uses a UID-to-video mapping file (`nfc_mapping.json`) to determine which video to play for a given card
+- Maps cards to videos via per-card text files in the `nfc_tags` data directory — the filename is the display title, line 1 the card UID, line 2 the video path or URL
+- Tapping an unknown card auto-creates a stub tag file for it; rename the file and add a path line to map the card
 
 ### Global
 - [Color Schemes](https://github.com/anthonycaccese/240-MP/wiki/Customizations)

--- a/modules/nfc_reader/manifest.json
+++ b/modules/nfc_reader/manifest.json
@@ -11,6 +11,12 @@
       "default": "OFF"
     },
     {
+      "key": "tags_directory",
+      "label": "Tags Directory",
+      "type": "directory_browser",
+      "default": ""
+    },
+    {
       "key": "resume_playback",
       "label": "Resume Playback",
       "type": "list_single",

--- a/modules/nfc_reader/views/Items.qml
+++ b/modules/nfc_reader/views/Items.qml
@@ -11,15 +11,7 @@ FocusScope {
     signal navigateTo(string path, var params, var listState)
     signal goBack()
 
-    property string errorMessage: ""
-
     focus: true
-
-    Component.onCompleted: {
-        errorMessage = nfcReaderBackend.mappingLoaded ? "" : "REQUIRED FILES NOT FOUND\n\n"
-                             + "ADD NFC_MAPPING.JSON\n\n"
-                             + "PLEASE SEE THE WIKI FOR DETAILS"
-    }
 
     Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
@@ -38,7 +30,6 @@ FocusScope {
     }
 
     Item {
-        visible: errorMessage === ""
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: root.sh * 0.2604167 //125
@@ -117,18 +108,6 @@ FocusScope {
         }
     }
 
-    Text {
-        visible: errorMessage !== ""
-        text: errorMessage
-        color: root.secondaryColor
-        font.family: root.globalFont
-        anchors.centerIn: parent
-        width: root.sw * 0.76875
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-        font.pixelSize: root.sh * 0.05
-    }
-
     // Dwell on the matched-cassette state (PLAYING ► + title) briefly before
     // handing off to the player, so a tap gets on-screen confirmation of what
     // matched instead of a hard cut to the loading screen. Extra taps during
@@ -151,11 +130,6 @@ FocusScope {
             matchedDwell.pendingPath = videoPath
             matchedDwell.pendingTitle = nfcReaderBackend.videoTitle
             matchedDwell.restart()
-        }
-        function onMappingLoadedChanged() {
-            errorMessage = nfcReaderBackend.mappingLoaded ? "" : "REQUIRED FILES NOT FOUND\n\n"
-                             + "ADD NFC_MAPPING.JSON\n\n"
-                             + "PLEASE SEE THE WIKI FOR DETAILS"
         }
     }
 

--- a/src/modules/nfc_reader/NfcReaderBackend.cpp
+++ b/src/modules/nfc_reader/NfcReaderBackend.cpp
@@ -181,6 +181,17 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
     , m_dataRoot(dataRoot)
 {
     qDebug("[NfcReader] Initializing NFC reader backend");
+
+    // Resolve the configured tags directory (falls back to the dataRoot/nfc_tags default).
+    m_tagsDir = m_dataRoot + "/" + kTagsDirName;
+    QFile f(m_dataRoot + "/config.json");
+    if (f.open(QIODevice::ReadOnly)) {
+        const QString dir = QJsonDocument::fromJson(f.readAll()).object()
+            ["modules"].toObject()["com.240mp.nfc_reader"].toObject()
+            ["tags_directory"].toString();
+        if (!dir.isEmpty())
+            m_tagsDir = dir;
+    }
     qDebug("[NfcReader] Tags dir: %s", qPrintable(tagsDirPath()));
 
     QDir().mkpath(tagsDirPath());
@@ -256,7 +267,20 @@ void NfcReaderBackend::abandonWorker(int waitMs) {
 }
 
 QString NfcReaderBackend::tagsDirPath() const {
-    return m_dataRoot + "/" + kTagsDirName;
+    return m_tagsDir;
+}
+
+void NfcReaderBackend::setTagsDir(const QString &path) {
+    // An empty (cleared) setting means back to the dataRoot/nfc_tags default.
+    m_tagsDir = path.isEmpty() ? m_dataRoot + "/" + kTagsDirName : path;
+    QDir().mkpath(m_tagsDir);
+    qDebug("[NfcReader] Tags dir: %s", qPrintable(m_tagsDir));
+    scanTagsDir();
+}
+
+void NfcReaderBackend::onSettingChanged(const QString &moduleId, const QString &key, const QVariant &value) {
+    if (moduleId == QLatin1String("com.240mp.nfc_reader") && key == QLatin1String("tags_directory"))
+        setTagsDir(value.toString());
 }
 
 // One .txt file per card: the filename (minus .txt) is the display title, the

--- a/src/modules/nfc_reader/NfcReaderBackend.cpp
+++ b/src/modules/nfc_reader/NfcReaderBackend.cpp
@@ -1,5 +1,6 @@
 #include "NfcReaderBackend.h"
 
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
@@ -24,7 +25,7 @@
 static constexpr qint64 kStallDisconnectMs = 3000;
 static constexpr qint64 kStallRespawnMs = 10000;
 static constexpr int kMaxRespawns = 5;
-static const char *kMappingFileName = "nfc_mapping.json";
+static const char *kTagsDirName = "nfc_tags";
 
 // ---------------------------------------------------------------------------
 // NfcPollWorker — lives on its own QThread; owns all PC/SC state and calls.
@@ -180,9 +181,10 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
     , m_dataRoot(dataRoot)
 {
     qDebug("[NfcReader] Initializing NFC reader backend");
-    qDebug("[NfcReader] Mapping file: %s", qPrintable(m_dataRoot + "/" + kMappingFileName));
+    qDebug("[NfcReader] Tags dir: %s", qPrintable(tagsDirPath()));
 
-    loadMapping();
+    QDir().mkpath(tagsDirPath());
+    scanTagsDir();
     startWorker();
 
     // If the worker wedges inside a PC/SC call, first report the reader as
@@ -253,69 +255,96 @@ void NfcReaderBackend::abandonWorker(int waitMs) {
     m_worker = nullptr;
 }
 
-bool NfcReaderBackend::loadMapping() {
-    const QString path = m_dataRoot + "/" + kMappingFileName;
+QString NfcReaderBackend::tagsDirPath() const {
+    return m_dataRoot + "/" + kTagsDirName;
+}
 
-    QFile file(path);
+// One .txt file per card: the filename (minus .txt) is the display title, the
+// first non-empty line is the card UID (any formatting — it's normalized), and
+// the second non-empty line is the playback path (absolute, appRoot/dataRoot-
+// relative, or a URL). A file with a UID but no path is a valid "known but
+// unmapped" card. Lines past the second are ignored.
+bool NfcReaderBackend::parseTagFile(const QString &filePath, QString &uidOut, QString &pathOut) const {
+    QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        qWarning("[NfcReader] Cannot open mapping file %s: %s", qPrintable(path), qPrintable(file.errorString()));
-        if (m_mappingLoaded) {
-            m_mappingLoaded = false;
-            emit mappingLoadedChanged();
-        }
+        qWarning("[NfcReader] Cannot open tag file %s: %s",
+                 qPrintable(filePath), qPrintable(file.errorString()));
         return false;
     }
+    QString text = QString::fromUtf8(file.readAll());
+    if (text.startsWith(QChar(0xFEFF)))
+        text.remove(0, 1);
 
-    QJsonParseError err;
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
-    file.close();
-
-    if (err.error != QJsonParseError::NoError) {
-        qWarning("[NfcReader] JSON parse error in %s: %s", qPrintable(path), qPrintable(err.errorString()));
-        if (m_mappingLoaded) {
-            m_mappingLoaded = false;
-            emit mappingLoadedChanged();
-        }
-        return false;
+    QStringList lines;
+    for (QString line : text.split(u'\n')) {
+        line = line.trimmed();  // also strips the \r of CRLF files
+        if (!line.isEmpty()) lines.append(line);
+        if (lines.size() == 2) break;
     }
+    if (lines.isEmpty()) return false;
 
-    // Entries are either "UID": "path" or "UID": { "path": ..., "title": ... }.
-    // Keys are normalized so the file's UID formatting doesn't have to match
-    // the reader's byte formatting exactly.
-    m_mapping.clear();
-    const QJsonObject obj = doc.object();
-    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
-        MappingEntry entry;
-        if (it.value().isObject()) {
-            const QJsonObject v = it.value().toObject();
-            entry.path = v["path"].toString();
-            entry.title = v["title"].toString();
-        } else {
-            entry.path = it.value().toString();
-        }
-        if (entry.path.isEmpty()) {
-            qWarning("[NfcReader] Skipping mapping entry with no path: %s", qPrintable(it.key()));
-            continue;
-        }
-        if (entry.title.isEmpty()) {
-            const QString base = QFileInfo(entry.path).completeBaseName();
-            entry.title = base.isEmpty() ? entry.path : base;
-        }
-        m_mapping.insert(normalizeUid(it.key()), entry);
-    }
-
-    qDebug("[NfcReader] Loaded mapping with %lld entries from %s",
-           static_cast<long long>(m_mapping.size()), qPrintable(path));
-    if (!m_mappingLoaded) {
-        m_mappingLoaded = true;
-        emit mappingLoadedChanged();
-    }
+    uidOut = normalizeUid(lines.at(0));
+    if (uidOut.isEmpty()) return false;
+    pathOut = lines.size() > 1 ? lines.at(1) : QString();
     return true;
 }
 
+void NfcReaderBackend::scanTagsDir() {
+    m_mapping.clear();
+
+    // QDir's default filter excludes hidden files (.DS_Store etc.). The .txt
+    // suffix is checked manually because nameFilters are case-sensitive on
+    // Linux. Alphabetical listing makes duplicate handling deterministic.
+    const QDir dir(tagsDirPath());
+    const QFileInfoList files =
+        dir.entryInfoList(QDir::Files | QDir::Readable, QDir::Name | QDir::IgnoreCase);
+
+    int fileCount = 0;
+    for (const QFileInfo &fi : files) {
+        if (fi.suffix().compare(QLatin1String("txt"), Qt::CaseInsensitive) != 0)
+            continue;
+
+        QString uid, path;
+        if (!parseTagFile(fi.absoluteFilePath(), uid, path)) {
+            qWarning("[NfcReader] Skipping tag file with no usable UID: %s",
+                     qPrintable(fi.fileName()));
+            continue;
+        }
+        if (m_mapping.contains(uid)) {
+            qWarning("[NfcReader] Duplicate UID %s in %s - keeping earlier file",
+                     qPrintable(uid), qPrintable(fi.fileName()));
+            continue;
+        }
+        m_mapping.insert(uid, MappingEntry{path, fi.completeBaseName()});
+        fileCount++;
+    }
+    qDebug("[NfcReader] Scanned %d tag files from %s", fileCount, qPrintable(tagsDirPath()));
+}
+
+// A tapped card with no tag file gets a stub written for it so the user only
+// has to rename the file and add a path line. NewOnly never overwrites: if a
+// same-named file already exists (e.g. it holds a different UID), skip + warn.
+void NfcReaderBackend::writeStubFile(const QString &normalizedUid) {
+    QDir().mkpath(tagsDirPath());  // recreate if deleted at runtime
+    QString name = normalizedUid;
+    name.replace(QLatin1Char(':'), QLatin1Char('-'));
+    const QString path = tagsDirPath() + "/" + name + ".txt";
+
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::NewOnly)) {
+        qWarning("[NfcReader] Could not create stub tag file %s: %s",
+                 qPrintable(path), qPrintable(file.errorString()));
+        return;
+    }
+    file.write((normalizedUid + "\n").toUtf8());
+    qDebug("[NfcReader] Created stub tag file: %s", qPrintable(path));
+    // Register as known-unmapped so a lift-and-retap doesn't re-scan/re-write.
+    m_mapping.insert(normalizedUid, MappingEntry{QString(), name});
+}
+
 void NfcReaderBackend::reloadMapping() {
-    qDebug("[NfcReader] Reloading mapping file");
-    loadMapping();
+    qDebug("[NfcReader] Rescanning tags dir");
+    scanTagsDir();
 }
 
 void NfcReaderBackend::setModuleActive(bool active) {
@@ -522,15 +551,29 @@ void NfcReaderBackend::onSampled(bool readerConnected, const QString &uid) {
         return;
     }
 
-    const auto it = m_mapping.constFind(normalizedUid);
-    if (it != m_mapping.constEnd()) {
+    auto it = m_mapping.constFind(normalizedUid);
+    if (it == m_mapping.constEnd() || it->path.isEmpty()) {
+        // Unknown or not-yet-mapped card: the user may have just added or
+        // edited a tag file. Re-scan once before deciding. Cheap (tiny dir)
+        // and naturally rate-limited by the uid == m_lastUid early return.
+        scanTagsDir();
+        it = m_mapping.constFind(normalizedUid);
+    }
+
+    if (it != m_mapping.constEnd() && !it->path.isEmpty()) {
         QString resolvedPath = resolveVideoPath(it->path);
         qDebug("[NfcReader] Mapping found: %s -> %s", qPrintable(normalizedUid), qPrintable(resolvedPath));
         m_playbackActive = true;
         setCardState("matched", normalizedUid, it->title);
         emit playbackRequested(resolvedPath);
     } else {
-        qWarning("[NfcReader] No mapping for UID: %s", qPrintable(normalizedUid));
+        if (it == m_mapping.constEnd()) {
+            qWarning("[NfcReader] No tag file for UID %s - creating stub", qPrintable(normalizedUid));
+            writeStubFile(normalizedUid);
+        } else {
+            qWarning("[NfcReader] Tag file for UID %s has no path line: %s",
+                     qPrintable(normalizedUid), qPrintable(it->title));
+        }
         setCardState("unmatched", normalizedUid);
     }
 }

--- a/src/modules/nfc_reader/NfcReaderBackend.h
+++ b/src/modules/nfc_reader/NfcReaderBackend.h
@@ -34,7 +34,6 @@ private:
 class NfcReaderBackend : public QObject {
     Q_OBJECT
     Q_PROPERTY(bool available READ available CONSTANT)
-    Q_PROPERTY(bool mappingLoaded READ mappingLoaded NOTIFY mappingLoadedChanged)
     Q_PROPERTY(bool readerConnected READ readerConnected NOTIFY readerConnectedChanged)
     Q_PROPERTY(QString cardState READ cardState NOTIFY cardStateChanged)
     Q_PROPERTY(QString cardUid READ cardUid NOTIFY cardStateChanged)
@@ -67,15 +66,13 @@ public:
         return false;
 #endif
     }
-    bool mappingLoaded() const { return m_mappingLoaded; }
     bool readerConnected() const { return m_readerConnected; }
-    // "none" (no card / idle), "unmatched" (card with no mapping), "matched" (playing)
+    // "none" (no card / idle), "unmatched" (card with no tag file or no path yet), "matched" (playing)
     QString cardState() const { return m_cardState; }
     QString cardUid() const { return m_cardUid; }
     QString videoTitle() const { return m_videoTitle; }
 
 signals:
-    void mappingLoadedChanged();
     void readerConnectedChanged();
     void cardStateChanged();
     void playbackRequested(const QString &videoPath);
@@ -86,14 +83,13 @@ private slots:
 
 private:
     struct MappingEntry {
-        QString path;
+        QString path;  // empty = known card with a tag file but no path yet
         QString title;
     };
 
     QString m_appRoot;
     QString m_dataRoot;
     QHash<QString, MappingEntry> m_mapping;
-    bool m_mappingLoaded = false;
     QThread *m_workerThread = nullptr;
     NfcPollWorker *m_worker = nullptr;
     QTimer *m_watchdog = nullptr;
@@ -111,7 +107,10 @@ private:
     QVariantMap loadHistory() const;
     void        saveHistory(const QVariantMap &history);
 
-    bool loadMapping();
+    QString tagsDirPath() const;
+    void scanTagsDir();
+    bool parseTagFile(const QString &filePath, QString &uidOut, QString &pathOut) const;
+    void writeStubFile(const QString &normalizedUid);
     void startWorker();
     void abandonWorker(int waitMs);
     void setCardState(const QString &state, const QString &uid = {}, const QString &title = {});

--- a/src/modules/nfc_reader/NfcReaderBackend.h
+++ b/src/modules/nfc_reader/NfcReaderBackend.h
@@ -78,6 +78,9 @@ signals:
     void playbackRequested(const QString &videoPath);
     void dynamicOptionsReady(const QString &key, const QVariant &options);
 
+public slots:
+    void onSettingChanged(const QString &moduleId, const QString &key, const QVariant &value);
+
 private slots:
     void onSampled(bool readerConnected, const QString &uid);
 
@@ -89,6 +92,7 @@ private:
 
     QString m_appRoot;
     QString m_dataRoot;
+    QString m_tagsDir;
     QHash<QString, MappingEntry> m_mapping;
     QThread *m_workerThread = nullptr;
     NfcPollWorker *m_worker = nullptr;
@@ -108,6 +112,7 @@ private:
     void        saveHistory(const QVariantMap &history);
 
     QString tagsDirPath() const;
+    void setTagsDir(const QString &path);
     void scanTagsDir();
     bool parseTagFile(const QString &filePath, QString &uidOut, QString &pathOut) const;
     void writeStubFile(const QString &normalizedUid);


### PR DESCRIPTION
## Summary

The PR proposes moving from nfc_mapping.json to individual file based mapping files instead.  The idea is to make it simpler for non technical users to add mappings for their NFC cards (no need to edit a .json file)

It implements a directory for storing mappings called nfc_tags in the main config directory alongside a setting that allows a user to change that directory

And implements a file based mapping approach through .txt files.  The file shape is:
- Filename = Title
- First line of the file = CardID
- Second line of the file = Path

So a user can manage each mapping they like in individual text files with the above shape

It also adds a auto create of un-matched cards so that users won't need to manually copy IDs to create a new mapping. Just tap an unmatched card it and will create a .txt file with the ID already included (a user will just need to add their path and rename the file to give it their preferred title)

I cover the above in this video walkthrough:

https://github.com/user-attachments/assets/84927531-aef8-4149-bcc8-0acf37275c82

## AI involvement

Used to plan the approach and backend implementation for reading and writing from .txt files instead of nfc_mapping.json

## Testing

Verified on Raspberry Pi and MacOS using mapped and un-mapped cards along with cards with bad or missing paths

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
