### PR TITLE
Fix white border around fullscreen mpv window on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,166 +1,40 @@
-<img src="https://github.com/user-attachments/assets/73c3e46f-a74a-4d96-9c4f-ae30f28378be" />
+<img 
+src="https://github.com/user-attachments/assets/73c3e46f-a74a-4d96-9c4f-ae30f28378be" 
+/>
 
-# 240-MP
+# 240-MP — Monterey Intel Edition
 
-## Monterey Intel Fork
+This repository is a fork of the original **240-MP** project by Anthony 
+Caccese.
 
-This fork focuses on running 240-MP reliably on Intel Macs running 
-macOS Monterey.
+Its primary goal is to provide a stable, native Intel (x86_64) build for 
+**macOS Monterey**, while keeping the fork as close as possible to the 
+upstream project. Whenever possible, improvements developed here are 
+contributed back to the original repository through Pull Requests.
 
-### Current changes
+## What's different in this fork
 
-- Intel x86_64 build target (macOS 12 Monterey)
-- Portable application bundle
-- Fixed the macOS fullscreen white border by removing `--no-native-fs` 
-from the mpv launch arguments
-- Upstream Pull Request: #140
+- Native Intel (x86_64) target for macOS Monterey.
+- Portable macOS application bundle.
+- Fixes the thin white border around fullscreen mpv playback by removing the 
+`--no-native-fs` launch argument.
+- Tracks upstream development while keeping Monterey Intel compatibility.
+- Fullscreen fix submitted upstream as Pull Request #140.
 
-### Planned improvements
+## Philosophy
 
-- Better YouTube configuration experience
-- Playback information overlay
-- Plex music library support
+This fork intentionally keeps its changes to a minimum.
+
+Features and improvements that are useful to all platforms are proposed to 
+the upstream project whenever possible. Changes that are specific to Intel 
+Macs or macOS Monterey remain in this fork.
+
+## Upstream Project
+
+The original 240-MP project is available at:
+
+https://github.com/anthonycaccese/240-MP
 
 ---
 
-240-MP is a retro VCR style 
-frontend to play content 
-on [Raspberry 
-Pi](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) (preferably hooked up to a CRT TV).
-
-Playback experiences are handled via modules to enable new integrations without requiring major changes to the overall frontend. There are 6 currently included playback modules; [Local Files](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files), [Plex](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex), [Jellyfin](https://github.com/anthonycaccese/240-MP/wiki/Module:-Jellyfin), [YouTube](https://github.com/anthonycaccese/240-MP/wiki/Module:-YouTube), [NFC Reader](https://github.com/anthonycaccese/240-MP/wiki/Module:-NFC-Reader) and a module similar to art/wallpaper modes on modern tvs called [Ambient:Mode](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode).
-
-It's built to work in conjuction with MPV which will be installed (or updated) as a dependency during the [install](#Install) steps outlined below.  Some modules (like YouTube and NFC Reader) have additional dependencies which are covered on their associated wiki pages under the "To Enable" section.
-
-## Video Overview
-
-Watch on YouTube: https://youtu.be/r-gylGDoELY
-
-## Photos
-
-| Module Selection | Item Detail |
-| --- | --- |
-| <img src="https://github.com/user-attachments/assets/9472d55a-4617-4a7f-80c4-32aa28494048" /> | <img src="https://github.com/user-attachments/assets/4f7d8230-860a-4ace-9370-9f59f43289c0" /> |
-
-| Resume Option | Playback | Settings |
-| --- | --- | --- |
-| <img src="https://github.com/user-attachments/assets/490e9ebd-fab2-4fd1-9959-35ebb619eff0" /> | <img src="https://github.com/user-attachments/assets/a3c768c7-6ede-4cdf-9d03-90aee7b8cdfb" /> | <img src="https://github.com/user-attachments/assets/0fd48977-8776-4334-b34e-d12256f23b97" /> |
-
-## Current Features
-
-### Local Files Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files))
-- Supported file types: `"mp4", "mkv", "avi", "mov", "m4v", "webm", "wmv", "flv", "f4v", "mpg", "mpeg", "vob"`
-- Playlist support using `m3u` and `m3u8` files
-- Folder browsing
-- Loop playback
-- Shuffle playback
-- Playback history
-- Switch audio/subtitle tracks during playback
-
-### Plex Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex))
-- Designed for CRT navigation (simple, fast, list browsing)
-- Supported library types: `Movies, TV Shows, Other Videos`
-- Server switching
-- User profile switching and auto sign in
-- Select specific libraries to display
-- Continue Watching and Resume
-- Autoplay next episode in a season (optional, off by default)
-- Hub, Playlist, Collection and Category support
-- Movie editions
-- Select preferred audio/subtitle track before playback and switch tracks during playback
-- Full library browsing by letter
-- Show/Season browsing
-- Video quality selection: Direct Playback (Default) or Transcode options
-
-### Jellyfin Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-Jellyfin))
-- Designed for CRT navigation (simple, fast, list browsing)
-- Supported library types: `movies, tvshows, homevideos, boxsets`
-- "Quick Connect" authentication
-- Select specific libraries to display
-- Continue Watching, Next Up and Resume Playback
-- Autoplay next episode in a season (optional, off by default)
-- Collections support
-- Select preferred audio/subtitle track before playback and switch tracks during playback
-- Full library browsing by letter
-- Show/Season browsing
-- Video quality selection: Direct Playback (Default) or Transcode options
-
-### YouTube Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-YouTube))
-- Designed for CRT navigation (simple, fast, list browsing)
-- Built to list content from YouTube RSS feeds and playback via mpv + yt-dl (no auth required)
-- View Subscriptions: Browse the latest videos from your configured channels as a reverse chronological list
-- Browse by Channel: Browse videos by Channel
-- Save to Watch Later: Save videos to watch later. This is local to 240-MP (on device only), not associated to any account and the list can be cleared in settings at any time.
-- View Watch History: Displays a list of recently watch videos via the module. This is local to 240-MP (on device only), not associated to any account and the list can be cleared in settings at any time.
-- Resume Playback: Resume from your last playback position or restart from the beginning
-- Set Playback Resolution: 480p (default and good for the RaspberryPi), 720p and 1080p
-- Choose to Display Shorts or not (default is On)
-
-### Ambient:Mode Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode))
-- Supported video file types: `"mp4", "mkv", "avi", "mov", "m4v", "webm", "wmv", "flv", "f4v", "mpg", "mpeg", "vob"`
-- Playlist support for audio tracks using `m3u` and `m3u8` files
-- Mix video with a different audio track
-- Loops forever until you stop it
-
-### NFC Reader Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-NFC-Reader))
-- Start video playback via NFC cards
-- Tested reader support: `ACS ACR122U`
-- Maps cards to videos via per-card text files in the `nfc_tags` data directory — the filename is the display title, line 1 the card UID, line 2 the video path or URL
-- Tapping an unknown card auto-creates a stub tag file for it; rename the file and add a path line to map the card
-
-### Global
-- [Color Schemes](https://github.com/anthonycaccese/240-MP/wiki/Customizations)
-- [Keyboard & Controller](https://github.com/anthonycaccese/240-MP/wiki/Input) input support
-- Media Keys during video playback (volume +/-, mute, play/pause, stop, seek, next chapter, previous chapter)
-
-## Install
-- [On a Raspberry Pi](INSTALL.md#on-a-raspberry-pi)
-- [On macOS (ARM)](INSTALL.md#on-macos-arm)
-
-## Hardware Testing
-- [Raspberry Pi 3B](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing#raspberry-pi-3b)
-- [Raspberry Pi 3B+](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing#raspberry-pi-3b-1)
-- [Raspberry Pi 4B](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing#raspberry-pi-4b)
-- [Raspberry Pi 5](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing#raspberry-pi-5)
-
-## FAQs
-
-- Why didn't you use Kodi/LibreELEC/OSMC?
-    - I've used all of those distros and they are all excellent but I also like making things and wanted something simpler without as many options.  Something that felt like a VCR from my youth.
-- Should I use 240-MP instead of Kodi/LibreELEC/OSMC?
-    - I would recommend thinking about it like this...
-    - All of those distros are amazing, feature rich, work across a ton of devices and have awesome supportive teams behind them.
-    - I on the other hand am just one person making nostalgic things for my own niche use cases.
-    - If those use cases match with what you're looking for, then 240-MP is a bunch of fun and I'd be happy for you to try it.
-    - Otherwise, the well known distros are spectacular and you should likely open those doors instead.
-- Will this work on other Raspberry Pi models? (like the 5, 2 zero, etc...)
-    - I've tested on the 4b, 3b+ and 3b. Other users have confimred the 5 works well too and all the details on what we've confimred can be found here: https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing
-    - If its not on that list then the short answer is "we don't know but please feel free try and let us know if it works"
-- Where does the name "240-MP" come from?
-    - 240 has a double meaning referring to the longest [VHS tape length](https://en.wikipedia.org/wiki/VHS#Tape_lengths) and love for [CRT TVs](https://consolemods.org/wiki/CRT:What_is_240p%3F) as a display type.
-    - MP also has a double meaning of "Media Player" and a play on the "SP/LP/EP/SLP" terminology that was used to refer to the recording quality for VHS recordings.
-- Does the 240 in the name mean that it outputs at 240p resolution?
-    - The UI scales based on the OS config and output cables you are using.
-    - For example: the output resolution for the menu and video playback when using it on a CRT with the configs I use is 480i/576i
-- Does 240-MP support RGB out instead of composite?
-    - 240-MP is just an app that runs on top of an already configured Operating System. If you are able to configure your OS on the Raspberry Pi to output over RGB then 240-MP will simply scale and display to that output when it boots up as well.
-    - If you have a combination of RGB out + OS configuration that works well then please add a comment here with your set up details: https://github.com/anthonycaccese/240-MP/discussions/44
-- Does 240-MP work over HDMI on a modern television too?
-    - Yes! The UI was built to scale on modern televisions over HDMI as well.
-    - Please make sure you use the config.txt I provide for HDMI and it will output at the proper resolution for a modern tv.
-- Does 240-MP support bluetooth keyboards/remotes/controllers?
-    - 240-MP is just an app that runs on top of an already configured Operating System. If your OS has a way to configure and set up bluetooh controllers then 240-MP will simply see them as controllers when it boots up.
-
-## Credits & Acknowledgments
-
-- The `VCR OSD Mono` font was created by Riciery Santos Leal (a.k.a. mrmanet) https://www.dafont.com/vcr-osd-mono.font
-- Because this is a hobby project (and a fairly niche use case), I am using [Claude Code](https://www.anthropic.com/product/claude-code) to build a large part of the backend C++ code and structure the modules.  If you have concerns with that, I am glad to talk through it.  Also, please feel free to fork this repo, update any aspects and tailor things to your own use case; that's why the source is fully open and available.
-- Thank you to Plex for providing an open and free [API](https://developer.plex.tv/) with all the endpoints needed for me to make my own custom client
-- Thank you to [the MPV team](https://mpv.io/) for a simple, extensible and cross platform media player
-- And thank you to the [Raspberry Pi Foundation](https://www.raspberrypi.org/) for helping me fill a drawer with SBCs to tinker with and inspire fun ideas like this project ❤️
-
-## License
-
-This project is licensed under the GNU General Public License v3.0. See [LICENSE](LICENSE) for the full text.
-
-You are free to use, study, and modify this code. If you distribute a modified version, you must also distribute it under GPL-3.0 and make the source available.
+The remainder of this README is the original upstream documentation.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,211 @@
-<img 
-src="https://github.com/user-attachments/assets/73c3e46f-a74a-4d96-9c4f-ae30f28378be" 
-/>
+<img src="https://github.com/user-attachments/assets/73c3e46f-a74a-4d96-9c4f-ae30f28378be" />
 
 # 240-MP — Monterey Intel Edition
 
-This repository is a fork of the original **240-MP** project by Anthony 
-Caccese.
-
-Its primary goal is to provide a stable, native Intel (x86_64) build for 
-**macOS Monterey**, while keeping the fork as close as possible to the 
-upstream project. Whenever possible, improvements developed here are 
-contributed back to the original repository through Pull Requests.
-
-## What's different in this fork
-
-- Native Intel (x86_64) target for macOS Monterey.
-- Portable macOS application bundle.
-- Fixes the thin white border around fullscreen mpv playback by removing the 
-`--no-native-fs` launch argument.
-- Tracks upstream development while keeping Monterey Intel compatibility.
-- Fullscreen fix submitted upstream as Pull Request #140.
-
-## Philosophy
-
-This fork intentionally keeps its changes to a minimum.
-
-Features and improvements that are useful to all platforms are proposed to 
-the upstream project whenever possible. Changes that are specific to Intel 
-Macs or macOS Monterey remain in this fork.
-
-## Upstream Project
-
-The original 240-MP project is available at:
+This repository is a fork of the original **240-MP** project by
+Anthony Caccese:
 
 https://github.com/anthonycaccese/240-MP
 
+Its purpose is to maintain a stable Intel x86_64 build for
+**macOS Monterey**, while remaining as close as possible to the
+upstream project. Changes that are useful to all platforms may be
+proposed back to the original repository.
+
+## Current fork changes
+
+- Native Intel x86_64 build targeting macOS Monterey 12.
+- Portable macOS application bundle and downloadable DMG.
+- Fixes the thin white border around fullscreen mpv playback by
+  removing the `--no-native-fs` launch argument.
+- Improved playback OSD with:
+  - video codec, simplified resolution, aspect ratio and normalized
+    encoded frame rate;
+  - audio codec, Mono/Stereo/Surround classification and `TRACK x/y`;
+  - useful audio language metadata when available;
+  - subtitle format, `TRACK x/y` and useful language metadata;
+  - embedded, local-file and online titles, while filtering technical
+    Plex URLs and identifiers.
+- The fullscreen correction was proposed upstream in Pull Request #140.
+
+## Running the Monterey Intel release
+
+The downloadable application is intended for:
+
+- Intel x86_64 Macs;
+- macOS Monterey 12 or later;
+- systems with working `mpv` and `yt-dlp` executables.
+
+The application bundle includes Qt and its required application
+resources, but it does **not** bundle the external `mpv` player or
+`yt-dlp`.
+
+Runtime requirements:
+
+- `mpv` is required for media playback.
+- `yt-dlp` is required for YouTube playback.
+- Both commands should be accessible through the shell PATH, normally
+  under `/usr/local/bin` on an Intel Mac.
+
+Verify the installation with:
+
+    command -v mpv
+    mpv --version
+
+    command -v yt-dlp
+    yt-dlp --version
+
+## Installing Homebrew
+
+Homebrew is a package manager for macOS. Its official website and
+installation instructions are available at:
+
+https://brew.sh/
+
+Install Homebrew from Terminal with the official installer:
+
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+On an Intel Mac, the supported Homebrew prefix is normally:
+
+    /usr/local
+
+After installation, verify it with:
+
+    brew --version
+    brew --prefix
+
+## Installing mpv and yt-dlp with Homebrew
+
+Update Homebrew and install both runtime dependencies:
+
+    brew update
+    brew install mpv yt-dlp
+
+Verify them afterward:
+
+    command -v mpv
+    command -v yt-dlp
+
+    mpv --version
+    yt-dlp --version
+
+On older macOS releases such as Monterey, Homebrew may need to compile
+some packages locally instead of downloading prebuilt bottles. In that
+case, the full Xcode application may be required in addition to the
+Command Line Tools.
+
+## Tested external executables
+
+The release was tested with working local Intel copies of:
+
+- mpv 0.39.0 at:
+
+      /Applications/mpv.app/Contents/MacOS/mpv
+
+- yt-dlp 2026.07.04 at:
+
+      /usr/local/bin/yt-dlp
+
+The tested mpv.app executable was exposed on the PATH with:
+
+    sudo ln -s /Applications/mpv.app/Contents/MacOS/mpv /usr/local/bin/mpv
+
+If `/usr/local/bin/mpv` already exists, do not recreate the symbolic
+link without first checking where it points:
+
+    ls -l /usr/local/bin/mpv
+
+The tested yt-dlp executable could also be updated directly with:
+
+    sudo yt-dlp -U
+
+## Build environment used for this release
+
+The Monterey Intel build and DMG were produced on:
+
+- Mac architecture: Intel x86_64
+- Operating system: macOS Monterey 12.7.4
+- macOS build: 21H1123
+- Apple Clang: 14.0.0
+- Git: Apple Git 2.37.1
+- CMake: 4.4.0
+- Qt: 6.5.3 macOS kit
+- Homebrew: Intel installation under `/usr/local`
+- Homebrew version observed during development: 5.1.6
+- OpenSSL: openssl@3 3.6.3
+- SDL compatibility layer: sdl2-compat 2.32.70
+- SDL runtime used by sdl2-compat: SDL3 3.4.12
+- mpv: Intel mpv.app 0.39.0
+- yt-dlp: 2026.07.04
+
+The application was configured with:
+
+- `CMAKE_OSX_ARCHITECTURES=x86_64`
+- `CMAKE_OSX_DEPLOYMENT_TARGET=12.0`
+- Qt 6.5.3 from `~/Qt/6.5.3/macos`
+- Homebrew libraries from `/usr/local`
+
+## Build dependencies
+
+Rebuilding the application requires:
+
+- Git
+- CMake
+- Apple Command Line Tools or Xcode
+- Qt 6.5.3 with its macOS desktop kit
+- OpenSSL 3
+- SDL2 compatibility libraries
+- SDL3
+- `mpv` and `yt-dlp` for runtime testing
+
+The Homebrew-provided build libraries used in the tested environment
+were:
+
+    brew install cmake openssl@3 sdl2-compat
+
+Qt 6.5.3 was installed separately through the official Qt installer,
+because newer Qt releases may require a newer macOS version and may
+not run on Monterey.
+
+## Artificial-intelligence assistance disclosure
+
+The porting, troubleshooting, code modification, build preparation,
+packaging workflow and documentation for this Monterey Intel edition
+were developed by **Al Garcia with assistance from ChatGPT**.
+
+AI assistance details:
+
+- Service: ChatGPT by OpenAI
+- Model: GPT-5.6 Thinking
+- Main working dates: July 11–12, 2026
+- Scope of assistance:
+  - analysis of build and runtime errors;
+  - generation and review of Terminal commands;
+  - C++, QML and Lua modification proposals;
+  - macOS bundle and DMG packaging guidance;
+  - Git, GitHub fork, release and Pull Request guidance;
+  - drafting and organization of technical documentation.
+
+All commands, builds and functional changes were reviewed and tested
+by the repository owner on actual hardware. AI-generated suggestions
+were iteratively corrected whenever testing showed that an assumption
+or proposed change was inaccurate.
+
+This disclosure is included to document the development process
+transparently and to distinguish AI assistance from human validation,
+testing and project ownership.
+
+## Fork philosophy
+
+This fork intentionally keeps its platform-specific changes limited.
+
+- Upstream changes should be incorporated regularly.
+- Generally useful corrections should be proposed upstream.
+- Monterey Intel-specific compatibility work may remain in this fork.
+- Build and runtime assumptions should be documented and reproducible.
+
 ---
 
-The remainder of this README is the original upstream documentation.
+## Original upstream documentation
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,31 @@
 
 # 240-MP
 
-240-MP is a retro VCR style frontend to play content on [Raspberry Pi](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) (preferably hooked up to a CRT TV).
+## Monterey Intel Fork
+
+This fork focuses on running 240-MP reliably on Intel Macs running 
+macOS Monterey.
+
+### Current changes
+
+- Intel x86_64 build target (macOS 12 Monterey)
+- Portable application bundle
+- Fixed the macOS fullscreen white border by removing `--no-native-fs` 
+from the mpv launch arguments
+- Upstream Pull Request: #140
+
+### Planned improvements
+
+- Better YouTube configuration experience
+- Playback information overlay
+- Plex music library support
+
+---
+
+240-MP is a retro VCR style 
+frontend to play content 
+on [Raspberry 
+Pi](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) (preferably hooked up to a CRT TV).
 
 Playback experiences are handled via modules to enable new integrations without requiring major changes to the overall frontend. There are 6 currently included playback modules; [Local Files](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files), [Plex](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex), [Jellyfin](https://github.com/anthonycaccese/240-MP/wiki/Module:-Jellyfin), [YouTube](https://github.com/anthonycaccese/240-MP/wiki/Module:-YouTube), [NFC Reader](https://github.com/anthonycaccese/240-MP/wiki/Module:-NFC-Reader) and a module similar to art/wallpaper modes on modern tvs called [Ambient:Mode](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode).
 

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -34,40 +34,451 @@ local A_OPAQUE = "&H00&"
 local A_TRANS  = "&HFF&"
 local A_DIM    = "&H99&"  -- 40% opacity for unfocused seek fill
 
+local function format_decimal(value, decimals)
+    if not value or value <= 0 then return "" end
+    local text = string.format("%." .. decimals .. "f", value)
+    text = text:gsub("0+$", ""):gsub("%.$", "")
+    return text
+end
+
+local function video_codec_name(codec)
+    codec = (codec or ""):lower()
+
+    local names = {
+        h264       = "H.264",
+        hevc       = "HEVC",
+        h265       = "HEVC",
+        mpeg2video = "MPEG-2",
+        mpeg4      = "MPEG-4",
+        vp8        = "VP8",
+        vp9        = "VP9",
+        av1        = "AV1",
+        vc1        = "VC-1",
+        theora     = "THEORA"
+    }
+
+    return names[codec] or codec:upper()
+end
+
+local function audio_codec_name(codec)
+    codec = (codec or ""):lower()
+
+    if codec:match("^pcm") then return "PCM" end
+
+    local names = {
+        aac      = "AAC",
+        mp3      = "MP3",
+        mp2      = "MP2",
+        ac3      = "AC-3",
+        eac3     = "E-AC-3",
+        dts      = "DTS",
+        truehd   = "TrueHD",
+        flac     = "FLAC",
+        alac     = "ALAC",
+        opus     = "Opus",
+        vorbis   = "Vorbis",
+        wavpack  = "WAVPACK"
+    }
+
+    return names[codec] or codec:upper()
+end
+
+local function resolution_name(height, interlaced)
+    if not height or height <= 0 then return "" end
+
+    local label
+    if height <= 240 then
+        label = "240"
+    elseif height <= 360 then
+        label = "360"
+    elseif height <= 480 then
+        label = "480"
+    elseif height <= 576 then
+        label = "576"
+    elseif height <= 720 then
+        label = "720"
+    elseif height <= 1080 then
+        label = "1080"
+    elseif height <= 1440 then
+        label = "1440"
+    elseif height <= 2160 then
+        label = "2160"
+    else
+        label = tostring(math.floor(height + 0.5))
+    end
+
+    return label .. (interlaced and "i" or "p")
+end
+
+local function aspect_name(aspect)
+    if not aspect or aspect <= 0 then return "" end
+
+    if math.abs(aspect - (4 / 3)) < 0.035 then
+        return "4:3"
+    elseif math.abs(aspect - (16 / 9)) < 0.035 then
+        return "16:9"
+    elseif math.abs(aspect - 1.85) < 0.035 then
+        return "1.85:1"
+    elseif aspect >= 2.35 and aspect <= 2.43 then
+        return "2.39:1"
+    end
+
+    return format_decimal(aspect, 2) .. ":1"
+end
+
+local function channel_name(channels)
+    if not channels or channels <= 0 then
+        return ""
+    elseif channels == 1 then
+        return "MONO"
+    elseif channels == 2 then
+        return "STEREO"
+    else
+        return "SURROUND"
+    end
+end
+
+local function sample_rate_name(rate)
+    if not rate or rate <= 0 then return "" end
+
+    local khz = rate / 1000
+    return format_decimal(khz, 1) .. " KHZ"
+end
+
+local function clean_media_filename(value)
+    if not value or value == "" then return "" end
+
+    value = value:gsub("^.*[/\\]", "")
+    value = value:gsub("%.[^%.]+$", "")
+    value = value:gsub("[._]+", " ")
+    value = value:gsub("%s+", " ")
+    value = value:gsub("^%s+", ""):gsub("%s+$", "")
+
+    -- Eliminar descriptores comunes desde la resolución.
+    value = value:gsub("%s+2160[Pp].*$", "")
+    value = value:gsub("%s+1080[PpIi].*$", "")
+    value = value:gsub("%s+720[Pp].*$", "")
+    value = value:gsub("%s+576[PpIi].*$", "")
+    value = value:gsub("%s+480[PpIi].*$", "")
+
+    -- TITLE 1999 -> TITLE (1999)
+    local base, year = value:match("^(.-)%s+(19%d%d)$")
+    if not base then
+        base, year = value:match("^(.-)%s+(20%d%d)$")
+    end
+
+    if base and year then
+        value = base .. " (" .. year .. ")"
+    end
+
+    return value:upper()
+end
+
+local function get_display_title()
+    local function is_technical(value)
+        if not value or value == "" then
+            return true
+        end
+
+        local lower = value:lower()
+
+        if lower:match("^https?://")
+                or lower:match("^ytdl://")
+                or lower:find("x%-plex%-")
+                or lower:find("client%-identifier")
+                or lower:find("/library/")
+                or lower:find("library/metadata")
+                or lower:find("metadata/")
+                or lower:find("%.mkv%?")
+                or lower:find("%.mp4%?")
+                or lower:find("%.avi%?")
+                or lower:find("%.ts%?")
+                or lower:find("%.m4v%?") then
+            return true
+        end
+
+        if #value > 180 then
+            return true
+        end
+
+        local slash_count = select(2, value:gsub("[/\\]", ""))
+        local equals_count = select(2, value:gsub("=", ""))
+        local amp_count = select(2, value:gsub("&", ""))
+
+        if slash_count >= 2 or equals_count >= 2 or amp_count >= 3 then
+            return true
+        end
+
+        return false
+    end
+
+    local embedded =
+        mp.get_property("metadata/by-key/title", "") or ""
+
+    if embedded == "" then
+        embedded =
+            mp.get_property("metadata/by-key/Title", "") or ""
+    end
+
+    if embedded ~= "" and not is_technical(embedded) then
+        return embedded:upper()
+    end
+
+    local source_path = mp.get_property("path", "") or ""
+    local media_title = mp.get_property("media-title", "") or ""
+
+    if media_title ~= ""
+            and media_title ~= source_path
+            and not is_technical(media_title) then
+        return media_title:upper()
+    end
+
+    if source_path ~= ""
+            and not source_path:match("^https?://")
+            and not source_path:match("^ytdl://")
+            and not is_technical(source_path) then
+        return clean_media_filename(source_path)
+    end
+
+    return ""
+end
+
+local function get_video_str()
+    local id = mp.get_property_number("current-tracks/video/id", 0)
+    if id == 0 then return "" end
+
+    local codec = video_codec_name(
+        mp.get_property("current-tracks/video/codec", "") or ""
+    )
+
+    local height = mp.get_property_number(
+        "current-tracks/video/demux-h", 0
+    )
+
+    if height == 0 then
+        height = mp.get_property_number("video-params/h", 0)
+    end
+
+    local interlaced_value =
+        mp.get_property_native("video-params/interlaced", false)
+
+    local interlaced =
+        interlaced_value == true
+        or interlaced_value == "yes"
+        or interlaced_value == "true"
+
+    local resolution = resolution_name(height, interlaced)
+
+    -- FPS declarados por la pista, no FPS variables del renderizado.
+    local fps = mp.get_property_number(
+        "current-tracks/video/demux-fps", 0
+    )
+
+    local fps_text = ""
+    if fps > 0 then
+        if math.abs(fps - 23.976) < 0.08 then
+            fps_text = "23.97 FPS"
+        elseif math.abs(fps - 29.97) < 0.08 then
+            fps_text = "29.97 FPS"
+        elseif math.abs(fps - 59.94) < 0.08 then
+            fps_text = "59.94 FPS"
+        else
+            fps_text = string.format("%d FPS", math.floor(fps + 0.5))
+        end
+    end
+
+    local aspect = aspect_name(
+        mp.get_property_number("video-params/aspect", 0)
+    )
+
+    local parts = {}
+    if codec ~= ""      then parts[#parts + 1] = codec      end
+    if resolution ~= "" then parts[#parts + 1] = resolution end
+    if aspect ~= ""     then parts[#parts + 1] = aspect     end
+    if fps_text ~= ""   then parts[#parts + 1] = fps_text   end
+
+    return table.concat(parts, " · ")
+end
+
+local function useful_language(value)
+    value = (value or ""):upper()
+    value = value:gsub("^%s+", ""):gsub("%s+$", "")
+
+    local aliases = {
+        EN = "ENG",
+        ENG = "ENG",
+        ENGLISH = "ENG",
+
+        ES = "SPA",
+        SPA = "SPA",
+        SPANISH = "SPA",
+        ESPANOL = "SPA",
+        ["ESPAÑOL"] = "SPA",
+        LATINO = "SPA",
+
+        FR = "FRA",
+        FRA = "FRA",
+        FRE = "FRA",
+        FRENCH = "FRA",
+
+        DE = "GER",
+        DEU = "GER",
+        GER = "GER",
+        GERMAN = "GER",
+
+        IT = "ITA",
+        ITA = "ITA",
+
+        PT = "POR",
+        POR = "POR",
+
+        JA = "JPN",
+        JPN = "JPN",
+        JAPANESE = "JPN"
+    }
+
+    if aliases[value] then
+        return aliases[value]
+    end
+
+    local ignored = {
+        AUDIO = true,
+        LANGUAGE = true,
+        LANG = true,
+        TEXT = true,
+        SUB = true,
+        SUBS = true,
+        SUBTITLE = true,
+        SUBTITLES = true,
+        STEREO = true,
+        MONO = true,
+        SURROUND = true,
+        DEFAULT = true,
+        FORCED = true,
+        TRACK = true,
+        UNKNOWN = true
+    }
+
+    if ignored[value] then
+        return ""
+    end
+
+    if value:match("^[A-Z][A-Z][A-Z]$") then
+        return value
+    end
+
+    return ""
+end
+
+local function track_position(track_type)
+    local tracks = mp.get_property_native("track-list", {}) or {}
+    local current_id = mp.get_property_number(
+        "current-tracks/" .. track_type .. "/id", 0
+    )
+
+    if current_id == 0 then
+        return ""
+    end
+
+    local total = 0
+    local current = 0
+
+    for _, track in ipairs(tracks) do
+        if track.type == track_type then
+            total = total + 1
+
+            if track.id == current_id then
+                current = total
+            end
+        end
+    end
+
+    if current == 0 or total == 0 then
+        return ""
+    end
+
+    return string.format("TRACK %d/%d", current, total)
+end
+
 local function get_audio_str()
     local id = mp.get_property_number("current-tracks/audio/id", 0)
-    if id == 0 then return "(NONE)" end
-    local title    = (mp.get_property("current-tracks/audio/title", "") or ""):upper()
-    local lang     = (mp.get_property("current-tracks/audio/lang",  "") or ""):upper()
-    local codec    = (mp.get_property("current-tracks/audio/codec", "") or ""):upper()
-    local channels = mp.get_property_number("current-tracks/audio/audio-channels", 0)
-    local rate     = mp.get_property_number("current-tracks/audio/demux-samplerate", 0)
+    if id == 0 then return "" end
+
+    local codec = audio_codec_name(
+        mp.get_property("current-tracks/audio/codec", "") or ""
+    )
+
+    local channels = channel_name(
+        mp.get_property_number(
+            "current-tracks/audio/audio-channels", 0
+        )
+    )
+
+    local track_text = track_position("audio")
+
+    local lang = useful_language(
+        mp.get_property("current-tracks/audio/lang", "") or ""
+    )
+
+    if lang == "" then
+        lang = useful_language(
+            mp.get_property("current-tracks/audio/title", "") or ""
+        )
+    end
+
     local parts = {}
-    if title    ~= "" then parts[#parts+1] = title end
-    if lang     ~= "" then parts[#parts+1] = lang  end
-    if codec    ~= "" then parts[#parts+1] = codec end
-    if channels  > 0  then parts[#parts+1] = channels .. "CH" end
-    if rate      > 0  then parts[#parts+1] = rate .. " HZ" end
-    return table.concat(parts, " ")
+
+    if codec ~= "" then
+        parts[#parts + 1] = codec
+    end
+
+    if channels ~= "" then
+        parts[#parts + 1] = channels
+    end
+
+    if track_text ~= "" then
+        parts[#parts + 1] = track_text
+    end
+
+    if lang ~= "" then
+        parts[#parts + 1] = lang
+    end
+
+    return table.concat(parts, " · ")
 end
 
 local function get_sub_str()
     local id = mp.get_property_number("current-tracks/sub/id", 0)
-    if id == 0 then return "(NONE)" end
-    -- External sidecar with an app-provided friendly name (e.g. Jellyfin): use it
-    -- instead of mpv's URL-derived title.
-    local ext = mp.get_property("current-tracks/sub/external-filename", "") or ""
+    if id == 0 then return "" end
+
+    local ext =
+        mp.get_property(
+            "current-tracks/sub/external-filename", ""
+        ) or ""
+
     if ext ~= "" and subinfo[ext] and subinfo[ext] ~= "" then
         return tostring(subinfo[ext]):upper()
     end
-    local title = (mp.get_property("current-tracks/sub/title", "") or ""):upper()
-    local lang  = (mp.get_property("current-tracks/sub/lang",  "") or ""):upper()
-    local codec = (mp.get_property("current-tracks/sub/codec", "") or ""):upper()
+
+    local codec = (
+        mp.get_property("current-tracks/sub/codec", "") or ""
+    ):upper()
+
+    local title = (
+        mp.get_property("current-tracks/sub/title", "") or ""
+    ):upper()
+
+    local lang = (
+        mp.get_property("current-tracks/sub/lang", "") or ""
+    ):upper()
+
+    local track = title ~= "" and title or lang
+
     local parts = {}
-    if title ~= "" then parts[#parts+1] = title end
-    if lang  ~= "" then parts[#parts+1] = lang  end
-    if codec ~= "" then parts[#parts+1] = codec end
-    return table.concat(parts, " ")
+    if codec ~= "" then parts[#parts + 1] = codec end
+    if track ~= "" then parts[#parts + 1] = track end
+
+    return table.concat(parts, " · ")
 end
 
 local btn_actions = {
@@ -184,9 +595,38 @@ local function draw_menu()
     local info_lh  = math.floor(info_fs * 1.5)
     local info_y   = math.floor(wh * 0.125)
 
-    draw_text(ass, lm, info_y, 4, "AUDIO: " .. get_audio_str(), info_fs, C_WHITE, A_OPAQUE)
-    if has_sub then
-        draw_text(ass, lm, info_y + info_lh, 4, "SUBTITLE: " .. get_sub_str(),  info_fs, C_WHITE, A_OPAQUE)
+    local display_title = get_display_title()
+    local video_info = get_video_str()
+    local audio_info = get_audio_str()
+    local sub_info = get_sub_str()
+
+    local info_line_y = info_y
+
+    if display_title ~= "" then
+        draw_text(ass, lm, info_line_y, 4,
+                  display_title,
+                  info_fs, C_WHITE, A_OPAQUE)
+        info_line_y = info_line_y + info_lh
+    end
+
+    if video_info ~= "" then
+        draw_text(ass, lm, info_line_y, 4,
+                  "VIDEO: " .. video_info,
+                  info_fs, C_WHITE, A_OPAQUE)
+        info_line_y = info_line_y + info_lh
+    end
+
+    if audio_info ~= "" then
+        draw_text(ass, lm, info_line_y, 4,
+                  "AUDIO: " .. audio_info,
+                  info_fs, C_WHITE, A_OPAQUE)
+        info_line_y = info_line_y + info_lh
+    end
+
+    if sub_info ~= "" then
+        draw_text(ass, lm, info_line_y, 4,
+                  "SUBTITLE: " .. sub_info,
+                  info_fs, C_WHITE, A_OPAQUE)
     end
 
     -- ── Row 1: Time text ──────────────────────────────────────────

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -412,7 +412,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         m_process->setProcessEnvironment(env);
         args << QString("--input-conf=%1").arg(m_inputConfPath)
              << "--video-sync=audio"
-             << "--fullscreen" << "--no-native-fs";
+             << "--fullscreen";
         appendVideoArgs(args);
 #ifdef Q_OS_MACOS
         // mpv runs as a separate process and can't see the app-bundle font via


### PR DESCRIPTION
Removes --no-native-fs from the macOS mpv launch arguments while keeping --fullscreen. The option causes a thin white border around the fullscreen window on both the official Apple Silicon release and a locally compiled Intel Monterey build. Tested on macOS Monterey 12.7.4 with mpv 0.39.0.