### PR TITLE
feat(plex): add extras display and playback

### DIFF
--- a/modules/plex/views/Extras.qml
+++ b/modules/plex/views/Extras.qml
@@ -1,0 +1,272 @@
+import QtQuick
+import Components
+
+FocusScope {
+    id: extrasRoot
+
+    property var navParams: ({})
+
+    signal navigateTo(string path, var params, var listState)
+    signal goBack()
+
+    // Extras arrive fully-formed via navParams (fetched by the detail view that
+    // pushed us), so there is no loading state — each entry is a playable
+    // detail (buildItemDetail shape) plus extraTypeLabel. They are re-fetched
+    // on load anyway (see Component.onCompleted): the navParams copy is a
+    // snapshot whose viewOffsets go stale once an extra is partially played.
+    property var extras: navParams.extras || []
+    property string itemTitle: navParams.itemTitle || ""
+    property string libraryName: navParams.libraryName || ""
+
+    // The extra whose stream is being prepared; set on ENTER, cleared on error.
+    // Doubles as the launch guard so stray streamUrlReady signals are ignored.
+    property var launchingExtra: null
+
+    // Fresh session per play so Plex builds a new transcode for each launch
+    // instead of reusing the prior one (mirrors Item.qml).
+    property string sessionId: ""
+
+    function newSessionId() {
+        var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var id = ""
+        for (var i = 0; i < 12; i++) id += chars[Math.floor(Math.random() * chars.length)]
+        return id
+    }
+
+    Connections {
+        target: plexBackend
+
+        function onExtrasLoaded(items) {
+            // Fresh viewOffsets so replaying a partially-watched extra can
+            // resume. Ignore empty results — a transient fetch failure must
+            // not blank a list we already have.
+            if (!items || items.length === 0) return
+            var idx = itemList.currentIndex
+            extrasRoot.extras = items
+            itemList.currentIndex = Math.min(Math.max(idx, 0), items.length - 1)
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+        }
+
+        function onStreamUrlReady(url, plexToken) {
+            var d = extrasRoot.launchingExtra
+            if (!d) return
+
+            var subId = "0", subUrl = ""
+            if (d.subtitleStreams) {
+                for (var k = 0; k < d.subtitleStreams.length; k++) {
+                    if (d.subtitleStreams[k].id === d.selectedSubtitleId) {
+                        subId = d.subtitleStreams[k].id
+                        subUrl = d.subtitleStreams[k].subUrl || ""
+                        break
+                    }
+                }
+            }
+            var imageSubs = []
+            if (d.subtitleStreams) {
+                for (var m = 0; m < d.subtitleStreams.length; m++) {
+                    if (d.subtitleStreams[m].imageSubtitle) imageSubs.push(d.subtitleStreams[m].id)
+                }
+            }
+
+            extrasRoot.navigateTo("Player.qml", {
+                streamUrl: url,
+                plexToken: plexToken,
+                ratingKey: d.ratingKey,
+                partKey: d.partKey,
+                partId: d.partId,
+                title: d.title,
+                viewOffset: d.viewOffset || 0,
+                duration: d.duration || 0,
+                audioStreams: d.audioStreams || [],
+                subtitleStreams: d.subtitleStreams || [],
+                selectedAudioId: d.selectedAudioId || "",
+                selectedSubtitleId: subId,
+                selectedSubtitleUrl: subUrl,
+                sessionId: extrasRoot.sessionId,
+                isTranscoding: d.forceTranscode || false,
+                imageSubtitleIds: imageSubs,
+                allowAutoplay: false
+            }, { currentIndex: itemList.currentIndex })
+        }
+
+        function onErrorOccurred(msg) {
+            console.log("[Extras] Error: " + msg)
+            extrasRoot.launchingExtra = null
+        }
+    }
+
+    Component.onCompleted: {
+        if (extras.length > 0) {
+            var st = navParams.navListState || {}
+            itemList.currentIndex = Math.min(st.currentIndex ?? 0, extras.length - 1)
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+        }
+        if (navParams.ratingKey) plexBackend.load_extras(navParams.ratingKey)
+    }
+
+    focus: true
+
+    Keys.onUpPressed: {
+        if (launchingExtra) return
+        if (itemList.currentIndex > 0) itemList.currentIndex--
+    }
+    Keys.onDownPressed: {
+        if (launchingExtra) return
+        if (itemList.currentIndex < extras.length - 1) itemList.currentIndex++
+    }
+    Keys.onReturnPressed: {
+        if (launchingExtra) return
+        var d = extras[itemList.currentIndex]
+        if (!d) return
+        launchingExtra = d
+        sessionId = newSessionId()
+        // No track persistence here: extras play with the server's default
+        // audio/subtitle selection (there is no track UI on this screen).
+        if (d.forceTranscode) {
+            // Always transcode from the start so the full timeline is seekable;
+            // the Player resumes by seeking mpv to viewOffset (see Item.qml).
+            plexBackend.request_transcode(d.ratingKey, d.partKey, sessionId,
+                                          d.selectedAudioId || "",
+                                          d.selectedSubtitleId || "0", 0)
+        } else {
+            plexBackend.build_stream_url(d.ratingKey, d.partKey, sessionId)
+        }
+    }
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+            goBack()
+            event.accepted = true
+        }
+    }
+
+    // ---
+    // UI
+    // ---
+
+    AppBar {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125
+        anchors.leftMargin: root.sw * 0.125
+        iconSource: moduleRoot.moduleIcon
+        title: moduleRoot.moduleName
+        subtitle: itemTitle
+    }
+
+    // List
+    ListView {
+        id: itemList
+        model: extras
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.25
+        anchors.leftMargin: root.sw * 0.115625
+        width: root.sw * 0.76875
+        height: root.sh * 0.525
+        clip: true
+        focus: true
+
+        delegate: Item {
+            width: itemList.width
+            height: root.sh * 0.075 //36
+
+            // Full-width background highlight for the active row
+            Rectangle {
+                color: root.accentColor
+                anchors.fill: parent
+                visible: itemList.currentIndex === index
+            }
+
+            // Vertical stack for Type and Title
+            Column {
+                id: textColumn
+                anchors.left: parent.left
+                anchors.leftMargin: root.sw * 0.0109375 //7
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: root.sh * 0.0041667 //2
+
+                Text {
+                    id: extraType
+                    text: modelData.extraTypeLabel || ""
+                    color: itemList.currentIndex === index ? root.surfaceColor : root.secondaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    font.pixelSize: root.sh * 0.0208333 //10
+                }
+
+                // Clipped title with marquee scroll when it overflows the row
+                Item {
+                    id: extraTitleClip
+                    width: Math.min(extraTitle.implicitWidth, itemList.width - root.sw * 0.021875) //14
+                    height: extraTitle.implicitHeight
+                    clip: true
+
+                    Text {
+                        id: extraTitle
+                        text: modelData.title || ""
+                        color: itemList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                        font.family: root.globalFont
+                        font.capitalization: Font.AllUppercase
+                        font.pixelSize: root.sh * 0.0333333 //16
+                        x: 0
+                    }
+
+                    SequentialAnimation {
+                        running: (itemList.currentIndex === index) &&
+                                 (extraTitle.implicitWidth > extraTitleClip.width)
+                        loops: Animation.Infinite
+                        onRunningChanged: if (!running) extraTitle.x = 0
+                        PauseAnimation { duration: 1500 }
+                        NumberAnimation {
+                            target: extraTitle; property: "x"
+                            to: extraTitleClip.width - extraTitle.implicitWidth
+                            duration: Math.abs(to) * 20
+                        }
+                        PauseAnimation { duration: 2000 }
+                        PropertyAction { target: extraTitle; property: "x"; value: 0 }
+                    }
+                }
+            }
+        }
+    }
+
+    // Footer
+    Text {
+        id: footer
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":SELECT"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667 //50
+        anchors.leftMargin: root.sw * 0.125 //80
+        font.pixelSize: root.sh * 0.0333333 //16
+    }
+
+    // Launch overlay — covers the list while Plex prepares the stream so a
+    // slow server doesn't make the app look frozen after pressing SELECT.
+    Rectangle {
+        anchors.fill: parent
+        color: root.surfaceColor
+        visible: launchingExtra !== null
+        z: 100
+
+        Text {
+            text: "LOADING..."
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            anchors.centerIn: parent
+            font.pixelSize: root.sh * 0.05 //24
+        }
+
+        Text {
+            text: root.hints.back + ":CANCEL"
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: root.sh * 0.1041667 //50
+            font.pixelSize: root.sh * 0.0333333 //16
+        }
+    }
+}

--- a/modules/plex/views/Item.qml
+++ b/modules/plex/views/Item.qml
@@ -6,7 +6,7 @@ FocusScope {
 
     property var navParams: ({})
 
-    signal navigateTo(string path, var params)
+    signal navigateTo(string path, var params, var listState)
     signal goBack()
 
     property var item: navParams.item || {}
@@ -15,8 +15,36 @@ FocusScope {
     // Loaded detail from backend
     property var detail: null
 
-    // Focus rows: 0=play button, 1=audio, 2=subtitles
+    // Extras attached to this item (trailers, deleted scenes, …)
+    property var extras: []
+    readonly property bool hasExtras: extras.length > 0
+
+    // Displayed name — also used as the Extras view's header subtitle
+    readonly property string displayName: {
+        var base = (item.type === "episode" && item.grandparentTitle)
+                   ? item.grandparentTitle : item.title
+        return item.editionTitle ? base + " (" + item.editionTitle + ")" : base
+    }
+
+    // Focus rows: 0=play button, 1=extras (when hasExtras), 2=audio, 3=subtitles
     property int focusRow: 0
+
+    // Ordered list of currently reachable focus rows
+    function activeRows() {
+        var rows = [0]
+        if (hasExtras) rows.push(1)
+        if (detail && detail.audioStreams && detail.audioStreams.length > 0) rows.push(2)
+        if (detail && detail.subtitleStreams && detail.subtitleStreams.length > 1) rows.push(3)
+        return rows
+    }
+
+    function stepFocus(dir) {
+        var rows = activeRows()
+        var i = rows.indexOf(focusRow)
+        if (i === -1) { focusRow = 0; return }
+        var next = i + dir
+        if (next >= 0 && next < rows.length) focusRow = rows[next]
+    }
 
     // True from when PLAY is pressed until we navigate to the Player (or error
     // out). Plex can take a few seconds to hand back a stream/transcode URL, so
@@ -102,7 +130,11 @@ FocusScope {
                 sessionId: detailRoot.sessionId,
                 isTranscoding: d.forceTranscode || false,
                 imageSubtitleIds: imageSubs
-            })
+            }, {})
+        }
+
+        function onExtrasLoaded(items) {
+            detailRoot.extras = items
         }
 
         function onErrorOccurred(msg) {
@@ -112,7 +144,10 @@ FocusScope {
     }
 
     Component.onCompleted: {
-        if (item.ratingKey) plexBackend.load_item_detail(item.ratingKey)
+        if (item.ratingKey) {
+            plexBackend.load_item_detail(item.ratingKey)
+            plexBackend.load_extras(item.ratingKey)
+        }
         focusRow = 0
     }
 
@@ -120,35 +155,39 @@ FocusScope {
 
     Keys.onUpPressed: {
         if (isLaunching) return
-        if (focusRow > 0) focusRow--
+        stepFocus(-1)
     }
     Keys.onDownPressed: {
         if (isLaunching) return
-        if (detail) {
-            var maxRow = 0
-            if (detail.audioStreams && detail.audioStreams.length > 0) maxRow = 1
-            if (detail.subtitleStreams && detail.subtitleStreams.length > 1) maxRow = 2
-            if (focusRow < maxRow) focusRow++
-        }
+        stepFocus(1)
     }
     Keys.onLeftPressed: {
         if (isLaunching) return
         if (!detail) return
-        if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1)
+        if (focusRow === 2 && detail.audioStreams && detail.audioStreams.length > 1)
             audioIdx = (audioIdx - 1 + detail.audioStreams.length) % detail.audioStreams.length
-        else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 1)
+        else if (focusRow === 3 && detail.subtitleStreams && detail.subtitleStreams.length > 1)
             subtitleIdx = (subtitleIdx - 1 + detail.subtitleStreams.length) % detail.subtitleStreams.length
     }
     Keys.onRightPressed: {
         if (isLaunching) return
         if (!detail) return
-        if (focusRow === 1 && detail.audioStreams && detail.audioStreams.length > 1)
+        if (focusRow === 2 && detail.audioStreams && detail.audioStreams.length > 1)
             audioIdx = (audioIdx + 1) % detail.audioStreams.length
-        else if (focusRow === 2 && detail.subtitleStreams && detail.subtitleStreams.length > 1)
+        else if (focusRow === 3 && detail.subtitleStreams && detail.subtitleStreams.length > 1)
             subtitleIdx = (subtitleIdx + 1) % detail.subtitleStreams.length
     }
     Keys.onReturnPressed: {
         if (isLaunching) return
+        if (focusRow === 1 && hasExtras) {
+            navigateTo("Extras.qml", {
+                extras: extras,
+                ratingKey: item.ratingKey,
+                itemTitle: displayName,
+                libraryName: libraryName
+            }, {})
+            return
+        }
         if (focusRow === 0 && detail) {
             // Show the loading overlay immediately; clears on navigate or error.
             isLaunching = true
@@ -228,21 +267,44 @@ FocusScope {
             height: root.sh * 0.35 //168
             spacing: root.sw * 0.0375 //24
 
-            // PLAY / RSUM button
-            Rectangle {
-                id: playButton
-                color: focusRow === 0 ? root.accentColor : root.surfaceColor
-                border.color: focusRow === 0 ? root.accentColor : root.tertiaryColor
+            Column {
                 width: root.sw * 0.1875 //120
-                height: root.sh * 0.1166667 //56
-                border.width: root.sh * 0.003125 //2
 
-                Text {
-                    anchors.centerIn: parent
-                    text: (detail && detail.viewOffset > 0) ? "RSUM \u25BA" : "PLAY \u25BA"
-                    color: focusRow === 0 ? root.surfaceColor : root.primaryColor
-                    font.family: root.globalFont
-                    font.pixelSize: root.sh * 0.05 //24
+                // PLAY / RSUM button
+                Rectangle {
+                    id: playButton
+                    color: focusRow === 0 ? root.accentColor : root.surfaceColor
+                    border.color: focusRow === 0 ? root.accentColor : root.tertiaryColor
+                    width: root.sw * 0.1875 //120
+                    height: root.sh * 0.1166667 //56
+                    border.width: root.sh * 0.003125 //2
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: (detail && detail.viewOffset > 0) ? "RSUM \u25BA" : "PLAY \u25BA"
+                        color: focusRow === 0 ? root.surfaceColor : root.primaryColor
+                        font.family: root.globalFont
+                        font.pixelSize: root.sh * 0.05 //24
+                    }
+                }
+
+                // Extras Button
+                Rectangle {
+                    id: extrasButton
+                    visible: detailRoot.hasExtras
+                    color: focusRow === 1 ? root.accentColor : "transparent"
+                    width: parent.width
+                    height: extrasLabel.implicitHeight + root.sh * 0.025 //12
+                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Text {
+                        id: extrasLabel
+                        text: "VIEW EXTRAS"
+                        color: focusRow === 1 ? root.surfaceColor : root.secondaryColor
+                        font.family: root.globalFont
+                        anchors.centerIn: parent
+                        font.pixelSize: root.sh * 0.025 //12
+                    }
                 }
             }
 
@@ -253,11 +315,7 @@ FocusScope {
 
                 //Name
                 Text {
-                    text: {
-                        var base = (item.type === "episode" && item.grandparentTitle)
-                                   ? item.grandparentTitle : item.title
-                        return item.editionTitle ? base + " (" + item.editionTitle + ")" : base
-                    }
+                    text: detailRoot.displayName
                     color: root.primaryColor
                     font.family: root.globalFont
                     font.capitalization: Font.AllUppercase
@@ -352,12 +410,12 @@ FocusScope {
 
             Rectangle {
                 anchors.fill: parent
-                color: focusRow === 1 ? root.accentColor : "transparent"
+                color: focusRow === 2 ? root.accentColor : "transparent"
             }
 
             Text {
                 text: "Audio"
-                color: focusRow === 1 ? root.surfaceColor : root.primaryColor
+                color: focusRow === 2 ? root.surfaceColor : root.primaryColor
                 font.family: root.globalFont
                 font.capitalization: Font.AllUppercase
                 anchors.verticalCenter: parent.verticalCenter
@@ -374,7 +432,7 @@ FocusScope {
 
                 Text {
                     text: "\u25C4"
-                    color: focusRow === 1 ? root.surfaceColor : root.tertiaryColor
+                    color: focusRow === 2 ? root.surfaceColor : root.tertiaryColor
                     font.family: root.globalFont
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: root.sh * 0.0375 //18
@@ -382,7 +440,7 @@ FocusScope {
                 Text {
                     text: (detail && detail.audioStreams && detail.audioStreams[audioIdx])
                           ? detail.audioStreams[audioIdx].displayTitle : ""
-                    color: focusRow === 1 ? root.surfaceColor : root.primaryColor
+                    color: focusRow === 2 ? root.surfaceColor : root.primaryColor
                     font.family: root.globalFont
                     font.capitalization: Font.AllUppercase
                     anchors.verticalCenter: parent.verticalCenter
@@ -390,7 +448,7 @@ FocusScope {
                 }
                 Text {
                     text: "\u25BA"
-                    color: focusRow === 1 ? root.surfaceColor : root.tertiaryColor
+                    color: focusRow === 2 ? root.surfaceColor : root.tertiaryColor
                     font.family: root.globalFont
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: root.sh * 0.0375 //18
@@ -409,12 +467,12 @@ FocusScope {
 
             Rectangle {
                 anchors.fill: parent
-                color: focusRow === 2 ? root.accentColor : "transparent"
+                color: focusRow === 3 ? root.accentColor : "transparent"
             }
 
             Text {
                 text: "Subtitles"
-                color: focusRow === 2 ? root.surfaceColor : root.primaryColor
+                color: focusRow === 3 ? root.surfaceColor : root.primaryColor
                 font.family: root.globalFont
                 font.capitalization: Font.AllUppercase
                 anchors.left: parent.left
@@ -431,7 +489,7 @@ FocusScope {
 
                 Text {
                     text: "\u25C4"
-                    color: focusRow === 2 ? root.surfaceColor : root.tertiaryColor
+                    color: focusRow === 3 ? root.surfaceColor : root.tertiaryColor
                     font.family: root.globalFont
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: root.sh * 0.0375 //18
@@ -439,7 +497,7 @@ FocusScope {
                 Text {
                     text: (detail && detail.subtitleStreams && detail.subtitleStreams[subtitleIdx])
                           ? detail.subtitleStreams[subtitleIdx].displayTitle : ""
-                    color: focusRow === 2 ? root.surfaceColor : root.primaryColor
+                    color: focusRow === 3 ? root.surfaceColor : root.primaryColor
                     font.family: root.globalFont
                     font.capitalization: Font.AllUppercase
                     anchors.verticalCenter: parent.verticalCenter
@@ -447,7 +505,7 @@ FocusScope {
                 }
                 Text {
                     text: "\u25BA"
-                    color: focusRow === 2 ? root.surfaceColor : root.tertiaryColor
+                    color: focusRow === 3 ? root.surfaceColor : root.tertiaryColor
                     font.family: root.globalFont
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: root.sh * 0.0375 //18

--- a/modules/plex/views/ItemSeason.qml
+++ b/modules/plex/views/ItemSeason.qml
@@ -16,7 +16,11 @@ FocusScope {
     property var episodes: []
     property bool isLoading: false
 
-    // Focus rows: 0 = play button, 1 = episode list
+    // Extras attached to this season (trailers, behind the scenes, …)
+    property var extras: []
+    readonly property bool hasExtras: extras.length > 0
+
+    // Focus rows: 0 = play button, 1 = extras (when hasExtras), 2 = episode list
     property int focusRow: 0
 
     Connections {
@@ -30,6 +34,10 @@ FocusScope {
             }
         }
 
+        function onExtrasLoaded(items) {
+            seasonRoot.extras = items
+        }
+
         function onErrorOccurred(msg) {
             seasonRoot.isLoading = false
             console.log("[SeasonItem] Error: " + msg)
@@ -39,23 +47,38 @@ FocusScope {
     Component.onCompleted: {
         isLoading = true
         focusRow = 0
-        if (item.ratingKey) plexBackend.load_children(item.ratingKey)
+        if (item.ratingKey) {
+            plexBackend.load_children(item.ratingKey)
+            plexBackend.load_extras(item.ratingKey)
+        }
     }
 
     focus: true
 
+    // Season label as displayed in the header line ("SPECIALS" / "SEASON n")
+    function seasonLabel() {
+        if (item.index === 0) return "Specials"
+        if (item.index) return "Season " + item.index
+        return ""
+    }
+
     Keys.onUpPressed: {
-        if (focusRow === 1) {
+        if (focusRow === 2) {
             if (episodeList.currentIndex > 0) {
                 episodeList.currentIndex--
             } else {
-                focusRow = 0
+                focusRow = hasExtras ? 1 : 0
             }
+        } else if (focusRow === 1) {
+            focusRow = 0
         }
     }
     Keys.onDownPressed: {
         if (focusRow === 0) {
-            if (episodes.length > 0) focusRow = 1
+            if (hasExtras) focusRow = 1
+            else if (episodes.length > 0) focusRow = 2
+        } else if (focusRow === 1) {
+            if (episodes.length > 0) focusRow = 2
         } else {
             if (episodeList.currentIndex < episodes.length - 1)
                 episodeList.currentIndex++
@@ -64,6 +87,14 @@ FocusScope {
     Keys.onReturnPressed: {
         if (focusRow === 0) {
             playBestEpisode()
+        } else if (focusRow === 1) {
+            var label = seasonLabel()
+            seasonRoot.navigateTo("Extras.qml", {
+                extras: extras,
+                ratingKey: item.ratingKey,
+                itemTitle: showTitle + (label ? " - " + label : ""),
+                libraryName: libraryName
+            }, {})
         } else {
             var ep = episodes[episodeList.currentIndex]
             if (!ep) return
@@ -144,27 +175,50 @@ FocusScope {
             height: root.sh * 0.175 //84
             spacing: root.sw * 0.0375 //24
 
-            // PLAY / RSUM button
-            Rectangle {
-                id: playButton
-                color: focusRow === 0 ? root.accentColor : root.surfaceColor
-                border.color: focusRow === 0 ? root.accentColor : root.tertiaryColor
+            Column {
                 width: root.sw * 0.1875 //120
-                height: root.sh * 0.1166667 //56
-                border.width: root.sh * 0.003125 //2
 
-                Text {
-                    anchors.centerIn: parent
-                    text: {
-                        // Show RSUM if any in-progress episode exists
-                        for (var i = 0; i < seasonRoot.episodes.length; i++) {
-                            if (seasonRoot.episodes[i].viewOffset > 0) return "RSUM \u25BA"
+                // PLAY / RSUM button
+                Rectangle {
+                    id: playButton
+                    color: focusRow === 0 ? root.accentColor : root.surfaceColor
+                    border.color: focusRow === 0 ? root.accentColor : root.tertiaryColor
+                    width: root.sw * 0.1875 //120
+                    height: root.sh * 0.1166667 //56
+                    border.width: root.sh * 0.003125 //2
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: {
+                            // Show RSUM if any in-progress episode exists
+                            for (var i = 0; i < seasonRoot.episodes.length; i++) {
+                                if (seasonRoot.episodes[i].viewOffset > 0) return "RSUM \u25BA"
+                            }
+                            return "PLAY \u25BA"
                         }
-                        return "PLAY \u25BA"
+                        color: focusRow === 0 ? root.surfaceColor : root.primaryColor
+                        font.family: root.globalFont
+                        font.pixelSize: root.sh * 0.05 //24
                     }
-                    color: focusRow === 0 ? root.surfaceColor : root.primaryColor
-                    font.family: root.globalFont
-                    font.pixelSize: root.sh * 0.05 //24
+                }
+
+                // Extras Button
+                Rectangle {
+                    id: extrasButton
+                    visible: seasonRoot.hasExtras
+                    color: focusRow === 1 ? root.accentColor : "transparent"
+                    width: parent.width
+                    height: extrasLabel.implicitHeight + root.sh * 0.025 //12
+                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Text {
+                        id: extrasLabel
+                        text: "VIEW EXTRAS"
+                        color: focusRow === 1 ? root.surfaceColor : root.secondaryColor
+                        font.family: root.globalFont
+                        anchors.centerIn: parent
+                        font.pixelSize: root.sh * 0.025 //12
+                    }
                 }
             }
 
@@ -241,7 +295,7 @@ FocusScope {
                     Rectangle {
                         color: root.accentColor
                         anchors.fill: rowText
-                        visible: episodeList.currentIndex === index && focusRow === 1
+                        visible: episodeList.currentIndex === index && focusRow === 2
                     }
 
                     Text {
@@ -252,7 +306,7 @@ FocusScope {
                             var prefix = (s || e) ? (s + e + ": ") : ""
                             return prefix + (modelData.title || "")
                         }
-                        color: (episodeList.currentIndex === index && focusRow === 1)
+                        color: (episodeList.currentIndex === index && focusRow === 2)
                                ? root.surfaceColor : root.primaryColor
                         font.family: root.globalFont
                         font.capitalization: Font.AllUppercase
@@ -267,7 +321,7 @@ FocusScope {
 
                     SequentialAnimation {
                         running: (episodeList.currentIndex === index) &&
-                                 (focusRow === 1) &&
+                                 (focusRow === 2) &&
                                  (rowText.implicitWidth > textClip.width)
                         loops: Animation.Infinite
                         onRunningChanged: if (!running) rowText.x = 0

--- a/modules/plex/views/ItemShow.qml
+++ b/modules/plex/views/ItemShow.qml
@@ -15,7 +15,11 @@ FocusScope {
     property var seasons: []
     property bool isLoading: false
 
-    // Focus rows: 0 = play button, 1 = season list
+    // Extras attached to this show (trailers, behind the scenes, …)
+    property var extras: []
+    readonly property bool hasExtras: extras.length > 0
+
+    // Focus rows: 0 = play button, 1 = extras (when hasExtras), 2 = season list
     property int focusRow: 0
 
     // When true, the next childrenLoaded signal carries episodes to play, not seasons to display
@@ -34,6 +38,10 @@ FocusScope {
                 showRoot.seasons = loadedItems
                 if (loadedItems.length > 0) seasonList.currentIndex = 0
             }
+        }
+
+        function onExtrasLoaded(items) {
+            showRoot.extras = items
         }
 
         function onInProgressEpisodeLoaded(episodeItem) {
@@ -87,23 +95,31 @@ FocusScope {
     Component.onCompleted: {
         isLoading = true
         focusRow = 0
-        if (item.ratingKey) plexBackend.load_children(item.ratingKey)
+        if (item.ratingKey) {
+            plexBackend.load_children(item.ratingKey)
+            plexBackend.load_extras(item.ratingKey)
+        }
     }
 
     focus: true
 
     Keys.onUpPressed: {
-        if (focusRow === 1) {
+        if (focusRow === 2) {
             if (seasonList.currentIndex > 0) {
                 seasonList.currentIndex--
             } else {
-                focusRow = 0
+                focusRow = hasExtras ? 1 : 0
             }
+        } else if (focusRow === 1) {
+            focusRow = 0
         }
     }
     Keys.onDownPressed: {
         if (focusRow === 0) {
-            if (seasons.length > 0) focusRow = 1
+            if (hasExtras) focusRow = 1
+            else if (seasons.length > 0) focusRow = 2
+        } else if (focusRow === 1) {
+            if (seasons.length > 0) focusRow = 2
         } else {
             if (seasonList.currentIndex < seasons.length - 1)
                 seasonList.currentIndex++
@@ -114,6 +130,13 @@ FocusScope {
             if (seasons.length === 0) return
             showRoot.waitingForOnDeck = true
             plexBackend.load_on_deck_for(item.ratingKey)
+        } else if (focusRow === 1) {
+            showRoot.navigateTo("Extras.qml", {
+                extras: extras,
+                ratingKey: item.ratingKey,
+                itemTitle: item.title,
+                libraryName: libraryName
+            }, {})
         } else {
             var season = seasons[seasonList.currentIndex]
             if (!season) return
@@ -169,21 +192,44 @@ FocusScope {
             height: root.sh * 0.2916667 //140
             spacing: root.sw * 0.0375 //24
 
-            // PLAY / RSUM button
-            Rectangle {
-                id: playButton
-                color: focusRow === 0 ? root.accentColor : root.surfaceColor
-                border.color: focusRow === 0 ? root.accentColor : root.tertiaryColor
+            Column {
                 width: root.sw * 0.1875 //120
-                height: root.sh * 0.1166667 //56
-                border.width: root.sh * 0.003125 //2
 
-                Text {
-                    anchors.centerIn: parent
-                    text: (item.viewOffset && item.viewOffset > 0) ? "RSUM \u25BA" : "PLAY \u25BA"
-                    color: focusRow === 0 ? root.surfaceColor : root.primaryColor
-                    font.family: root.globalFont
-                    font.pixelSize: root.sh * 0.05 //24
+                // PLAY / RSUM button
+                Rectangle {
+                    id: playButton
+                    color: focusRow === 0 ? root.accentColor : root.surfaceColor
+                    border.color: focusRow === 0 ? root.accentColor : root.tertiaryColor
+                    width: root.sw * 0.1875 //120
+                    height: root.sh * 0.1166667 //56
+                    border.width: root.sh * 0.003125 //2
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: (item.viewOffset && item.viewOffset > 0) ? "RSUM \u25BA" : "PLAY \u25BA"
+                        color: focusRow === 0 ? root.surfaceColor : root.primaryColor
+                        font.family: root.globalFont
+                        font.pixelSize: root.sh * 0.05 //24
+                    }
+                }
+
+                // Extras Button
+                Rectangle {
+                    id: extrasButton
+                    visible: showRoot.hasExtras
+                    color: focusRow === 1 ? root.accentColor : "transparent"
+                    width: parent.width
+                    height: extrasLabel.implicitHeight + root.sh * 0.025 //12
+                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Text {
+                        id: extrasLabel
+                        text: "VIEW EXTRAS"
+                        color: focusRow === 1 ? root.surfaceColor : root.secondaryColor
+                        font.family: root.globalFont
+                        anchors.centerIn: parent
+                        font.pixelSize: root.sh * 0.025 //12
+                    }
                 }
             }
 
@@ -294,13 +340,13 @@ FocusScope {
                     Rectangle {
                         color: root.accentColor
                         anchors.fill: rowText
-                        visible: seasonList.currentIndex === index && focusRow === 1
+                        visible: seasonList.currentIndex === index && focusRow === 2
                     }
 
                     Text {
                         id: rowText
                         text: modelData.title || ""
-                        color: (seasonList.currentIndex === index && focusRow === 1)
+                        color: (seasonList.currentIndex === index && focusRow === 2)
                                ? root.surfaceColor : root.primaryColor
                         font.family: root.globalFont
                         font.capitalization: Font.AllUppercase
@@ -315,7 +361,7 @@ FocusScope {
 
                     SequentialAnimation {
                         running: (seasonList.currentIndex === index) &&
-                                 (focusRow === 1) &&
+                                 (focusRow === 2) &&
                                  (rowText.implicitWidth > textClip.width)
                         loops: Animation.Infinite
                         onRunningChanged: if (!running) rowText.x = 0

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -27,6 +27,9 @@ FocusScope {
     property var    imageSubtitleIds: navParams.imageSubtitleIds || []
     property string selectedAudioId:    navParams.selectedAudioId    || ""
     property string selectedSubtitleId: navParams.selectedSubtitleId || "0"
+    // Extras pass false: "next episode" has no meaning for a trailer/clip, so a
+    // natural end must return to the Extras list instead of probing for one.
+    property bool   allowAutoplay:      navParams.allowAutoplay !== false
 
     property bool stoppedReported:    false
     property bool playbackStarted:    false
@@ -390,7 +393,7 @@ FocusScope {
         // Match ModuleSettings.qml's reading of a toggle: stored as a real bool
         // once the user touches it, but accept the legacy "ON" string too.
         var autoplayRaw = appCore.get_setting(moduleRoot.moduleId, "autoplay_next_episode")
-        autoplayNext  = (autoplayRaw === true || autoplayRaw === "ON")
+        autoplayNext  = allowAutoplay && (autoplayRaw === true || autoplayRaw === "ON")
 
         if (resumeSetting === "ask" && viewOffset > 0) {
             overlayVisible = true

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -749,8 +749,12 @@ void PlexBackend::build_stream_url(const QString &ratingKey,
                                    const QString &sessionId) {
     QString uri = serverUrl();
     QString token = serverToken();
+    // Cloud-hosted extras have part keys that already carry a query string
+    // (e.g. /services/iva/assets/…/video.mp4?fmt=4&bitrate=750), so join with
+    // '&' in that case — a second '?' makes PMS reject the request with a 400.
     QString url = uri + partKey
-                + "?X-Plex-Client-Identifier="  + clientId()
+                + (partKey.contains('?') ? "&" : "?")
+                + "X-Plex-Client-Identifier="   + clientId()
                 + "&X-Plex-Session-Identifier=" + sessionId;
     qDebug() << "[Plex] Playback: DIRECT PLAY";
     emit streamUrlReady(url, token);
@@ -1705,6 +1709,47 @@ void PlexBackend::load_children(const QString &ratingKey) {
         QVariantList items;
         for (const auto &mv : metadata) items.append(formatItem(mv.toObject()));
         emit childrenLoaded(items);
+    });
+}
+
+void PlexBackend::load_extras(const QString &ratingKey) {
+    QString uri = serverUrl(), token = serverToken();
+    auto *reply = plexGet(QUrl(uri + "/library/metadata/" + ratingKey + "/extras"), token);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, ratingKey]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                handle498([this, ratingKey]{ load_extras(ratingKey); }); return;
+            }
+            // No errorOccurred here: the detail views' error handlers reset
+            // loading/play state, and a failed extras fetch must not do that.
+            qDebug() << "[Plex] Load extras failed:" << reply->errorString();
+            emit extrasLoaded(QVariantList{}); return;
+        }
+        QJsonArray metadata = QJsonDocument::fromJson(reply->readAll())
+                              .object()["MediaContainer"].toObject()["Metadata"].toArray();
+        QVariantList items;
+        for (const auto &mv : metadata) {
+            QJsonObject meta = mv.toObject();
+            QVariantMap detail = buildItemDetail(meta);
+            if (detail.isEmpty()) continue; // metadata-only extra, nothing playable
+
+            // "behindTheScenes" → "BEHIND THE SCENES". Plex's own UI shortens
+            // the raw "sceneOrSample" subtype to just "Scene"; match that.
+            QString subtype = meta["subtype"].toString();
+            QString label;
+            if (subtype == "sceneOrSample") {
+                label = QStringLiteral("SCENE");
+            } else {
+                for (const QChar &c : subtype) {
+                    if (c.isUpper() && !label.isEmpty()) label += ' ';
+                    label += c.toUpper();
+                }
+            }
+            detail["extraTypeLabel"] = label.isEmpty() ? QStringLiteral("EXTRA") : label;
+            items.append(detail);
+        }
+        emit extrasLoaded(items);
     });
 }
 

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -45,6 +45,11 @@ public:
     Q_INVOKABLE void load_category_items(const QString &sectionId, const QString &filterKey);
     Q_INVOKABLE void check_section_capabilities(const QString &sectionId);
     Q_INVOKABLE void load_children(const QString &ratingKey);
+    // Loads the extras (trailers, deleted scenes, …) attached to an item and
+    // emits extrasLoaded with a list of playable details (buildItemDetail shape
+    // plus extraTypeLabel). Emits an empty list on failure — extras are an
+    // enhancement, so errors must not disturb the detail views' main flows.
+    Q_INVOKABLE void load_extras(const QString &ratingKey);
     Q_INVOKABLE void load_on_deck_for(const QString &ratingKey);
     // Resolves the next episode in the same season as currentRatingKey and emits
     // nextEpisodeReady with a full playable detail (same shape as load_item_detail),
@@ -105,6 +110,7 @@ signals:
     void itemLoaded(const QVariant &detail);
     void streamUrlReady(const QString &url, const QString &plexToken);
     void childrenLoaded(const QVariant &items);
+    void extrasLoaded(const QVariant &items);
     void inProgressEpisodeLoaded(const QVariant &item);
     void nextEpisodeReady(const QVariant &detail);
 

--- a/views/Components/AppBar.qml
+++ b/views/Components/AppBar.qml
@@ -4,10 +4,14 @@ import QtQuick.Effects
 Row {
     id: appBar
     
-    // Custom Properties 
+    // Custom Properties
     property url iconSource: "../../assets/images/logo.svg"
     property string title: "240-MP"
     property string subtitle: ""
+
+    // Fits the standard screen gutter — 80px (root.sw * 0.125) on each side.
+    // The subtitle elides when it would overflow this width.
+    width: root.sw * 0.75 //480
 
     spacing: root.sw * 0.025 //16
     Item {
@@ -54,5 +58,9 @@ Row {
         font.capitalization: Font.AllUppercase
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: root.sh * 0.0333333 //16
+        // x is this Text's Row position, i.e. everything before it (icon,
+        // title, separator, spacings) — cap to the bar's remaining space.
+        elide: Text.ElideRight
+        width: Math.max(0, Math.min(implicitWidth, appBar.width - x))
     }
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/anthonycaccese/240-MP/issues/92

Adds the display and playback of extras for Movies, Shows, Seasons and Episodes for the Plex module

It supports the following:
- Plex cloud and Local extras (if both exist they are merged into a single list just like on official clients)
- Resume playback (matches the Plex official clients where resume playback is supported for all extras except trailers)
- Only displays the "View Extras" button if the item has extras available to view
- Supports extras for all item types Plex does and layers in the button at the correct level for each as well: Movie, Show, Season, Episode

File details: 
- src/modules/plex/PlexBackend.{h,cpp} — load_extras + extrasLoaded, SCENE label mapping, and the cloud-extra ?/& URL fix in build_stream_url so that plex extras also work
- modules/plex/views/Item.qml, ItemShow.qml, ItemSeason.qml — VIEW EXTRAS button + focus-row wiring (+ your spacing/size polish)
- modules/plex/views/Extras.qml — the new list view with refresh-on-load for fresh resume offsets
- modules/plex/views/Player.qml — allowAutoplay param
- views/Components/AppBar.qml — default width + subtitle elide added to better handle text overlow (also backwards compatible with other modules)

Screenshots:
| Movie with extras | Select extras | View Extras |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/15ed4176-0cba-4a0f-8c40-4f1703e3756e" /> |  <img src="https://github.com/user-attachments/assets/07758efa-e725-4951-a8b1-e9c675faaf33" /> | <img src="https://github.com/user-attachments/assets/8bb3b50a-049c-44ca-81a4-076092e6a448" /> |

## AI involvement

Used to probe the API for the options to handle extras at each level of the tree (movies, shows, seasons and epsiodes) also worked out how to support both plex extras and local extras that a user has directly on their server

## Testing

Tested on MacOS and RPi against my local Plex server with extras for Movies, Shows, Seasons and Epsiodes.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)