### PR TITLE
fix(mpv): hide crop button on pi3 when 1080p playback is on

### DIFF
--- a/scripts/ambient-osc.lua
+++ b/scripts/ambient-osc.lua
@@ -1,7 +1,7 @@
 local assdraw = require 'mp.assdraw'
 
 local menu_visible = false
-local focus_btn = 1  -- 1: CROP, 2: STOP
+local focus_btn = 1  -- index into buttons (CROP when shown, then STOP)
 local update_timer = nil
 local idle_timer = nil
 
@@ -30,10 +30,13 @@ local function draw_text(ass, x, y, anchor, text, fs, fc, fa)
         anchor, x, y, fs, fc, fa, text))
 end
 
-local buttons = {
-    { label = "CROP", action = function() mp.command("no-osd cycle-values panscan 0 1") end },
-    { label = "STOP", action = function() mp.command("quit") end },
-}
+-- CROP is omitted when MpvController flags a decode path where --panscan
+-- blanks the video (Pi 3 overlay path with 1080p Playback ON).
+local buttons = {}
+if mp.get_opt("hide-crop") ~= "1" then
+    buttons[#buttons + 1] = { label = "CROP", action = function() mp.command("no-osd cycle-values panscan 0 1") end }
+end
+buttons[#buttons + 1] = { label = "STOP", action = function() mp.command("quit") end }
 
 local function draw_menu()
     local ass = assdraw.ass_new()

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -91,6 +91,10 @@ local function has_playlist()
     return (mp.get_property_number("playlist-count", 1) or 1) > 1
 end
 
+-- Set by MpvController on decode paths where --panscan blanks the video
+-- (Pi 3 overlay path with 1080p Playback ON) — the CROP button would be a no-op.
+local hide_crop = mp.get_opt("hide-crop") == "1"
+
 local function build_left_btns(has_sub, has_pl, bar_w)
     local btns = {}
     if skip_active then
@@ -102,7 +106,9 @@ local function build_left_btns(has_sub, has_pl, bar_w)
     if has_sub then
         table.insert(btns, {label="SUBTITLE", width=math.floor(bar_w * 0.15625), action=btn_actions[2]})
     end
-    table.insert(btns, {label="CROP", width=math.floor(bar_w * 0.090625), action=btn_actions[3]})
+    if not hide_crop then
+        table.insert(btns, {label="CROP", width=math.floor(bar_w * 0.090625), action=btn_actions[3]})
+    end
     if has_pl then
         table.insert(btns, {label="<", width=math.floor(bar_w * 0.055), action=btn_actions[5]})
         table.insert(btns, {label=">", width=math.floor(bar_w * 0.055), action=btn_actions[6]})
@@ -214,7 +220,7 @@ local function draw_menu()
     end
 
     -- ── Row 3: Buttons ────────────────────────────────────────────
-    -- Left group: AUDIO, [SUBTITLE], CROP
+    -- Left group: [SKIP], AUDIO, [SUBTITLE], [CROP], [< >]
     local stop_idx = #left_btns + 1
     local bx = lm
     for i, btn in ipairs(left_btns) do

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -253,6 +253,10 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         scriptOpts << QString("transcode-offset=%1").arg(double(transcodeOffsetSec), 0, 'f', 3);
     if (screensaverTimeout > 0)
         scriptOpts << QString("screensaver_timeout=%1").arg(screensaverTimeout);
+    // Tell the OSC scripts to hide their CROP button on decode paths where
+    // --panscan would blank the video (Pi 3 overlay path, 1080p Playback ON).
+    if (cropUnavailable())
+        scriptOpts << QStringLiteral("hide-crop=1");
 
     // Hand the OSC a map of external sub-file URL -> friendly track name so it can show
     // the real subtitle name. mpv otherwise titles an external sub from its URL basename
@@ -315,11 +319,8 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     // Auto Crop: start with panscan=1 unless the current decode path can't crop.
     // The Pi3 overlay (smooth) path blanks video under panscan, so suppress there —
     // matching the 1080p Playback trade-off. The OSC CROP button still toggles live.
-    if (autoCropEnabled()) {
-        const bool cropSafe = !(m_videoProfile == VideoProfile::Pi3 && smoothPlaybackEnabled());
-        if (cropSafe)
-            args << QStringLiteral("--panscan=1");
-    }
+    if (autoCropEnabled() && !cropUnavailable())
+        args << QStringLiteral("--panscan=1");
 
     m_process = new QProcess(this);
     m_process->setProcessChannelMode(QProcess::MergedChannels);
@@ -701,6 +702,13 @@ bool MpvController::autoCropEnabled() const {
         return false;
     const QVariant v = m_appCore->get_setting(QString(), "auto_crop");
     return v.toString().compare(QStringLiteral("On"), Qt::CaseInsensitive) == 0;
+}
+
+bool MpvController::cropUnavailable() const {
+    // The Pi 3 smooth (overlay-plane) path is the one decode path that can't
+    // crop/zoom: --panscan blanks the video there. (Ignores the mpv_video_args
+    // override, same as the auto-crop gate — the setting still reflects intent.)
+    return m_videoProfile == VideoProfile::Pi3 && smoothPlaybackEnabled();
 }
 
 bool MpvController::hasSmoothPlaybackTradeoff() const {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -105,6 +105,10 @@ private:
     // App-level "auto_crop" setting (default OFF). When ON, playback starts with
     // panscan=1 so video fills a CRT/4:3 screen by default (still toggleable live).
     bool autoCropEnabled() const;
+    // True when the active decode path can't crop (Pi 3 overlay path with smooth
+    // playback ON): --panscan blanks the video there. Gates auto-crop and tells
+    // the OSC scripts to hide their CROP button.
+    bool cropUnavailable() const;
     int  getActiveVt() const;
     int  findFreeVt() const;
     int  findQtDrmFd() const;


### PR DESCRIPTION
## Summary

Closes: https://github.com/anthonycaccese/240-MP/issues/143 

Passes the smooth playback setting for pi3 to mpv's osc scripts (using scriptOpts) so that the crop button can hide/show depending on that setting.  Its properly gated to work only on the pi3 when the setting is turned on (which is where crop would not function).

## AI involvement

Used to work through the approach for handling the gating for Pi3 vs all other targets

## Testing

Tested on the Pi 3 with both 1080p playback turned on and off (worked as expected in both cases... on means crop button is hidden / off means crop button is displayed and functional)

Also tested on Pi 4 to confirm the gates hold true and it confirmed to work as expected.   Also this properly gates the functionality for (what i think is likely) an edge case where a user may share their SD card between a pi 3 and pi4 and they had the setting turned on before moving it.  The Pi 4 will still display the crop button (which is expected)

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)