### PR TITLE
fix(mpv): pi5 hdmi out aspect ratio

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,7 +161,7 @@ However, if you already have Raspberry Pi OS set up and working on your TV then 
     [pi5]
 
     # Drivers & Video
-    dtoverlay=vc4-kms-v3d,cma-512,composite=1
+    dtoverlay=vc4-kms-v3d
     
     # --- Global ---
     [all]

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -669,11 +669,12 @@ void MpvController::appendVideoArgs(QStringList &args) const {
             else
                 args << "--vo=drm" << "--hwdec=v4l2m2m-copy";
         } else {
-            // Pi 5 (Full KMS) and the safe fallback for unknown headless Linux.
-            // --monitorpixelaspect=0.82 corrects non-square pixel aspect on
-            // composite CRTs (704×432 on 4:3). Pure math, zero rendering cost.
-            args << "--vo=drm" << "--hwdec=auto-safe"
-                 << "--monitorpixelaspect=0.82";
+            // Pi 5 (Full KMS) and a safe fallback for unknown headless Linux for now.
+            // Note: Sometimes on Pi5+composite CRTs the Pi5 reports its composite raster 
+            // inconsistently (sometimes a narrow 704×432 instead of the standard 720×480i)
+            // this can be accomodated for in mpv.conf via a monitorpixelaspect property or
+            // in cmdline.txt/config.txt at the OS level vs hardcoding something here.
+            args << "--vo=drm" << "--hwdec=auto-safe";
         }
     } else {
 #ifdef Q_OS_MACOS


### PR DESCRIPTION
## Summary

the pi5 can sometimes inconsistently report its resolution for CRT output as 704×432 which can result is a horizontally squished video during playback.  we tried to solve for this directly in mpvcontroller via a  hardcoded monitorpixelaspect property but that ended up having 2 downstream impacts... 1) if the pi5 reports things correctly we've now overcompensated for this and 2) on hdmi out for the pi5 it also gets applied which causes 16:9 output to be stretched.  in both cases with the approach we previously took you could only change this through mpv_video_args in our config.json.

so thinking about this and using it practice for the last few weeks I think its more flexible to remove this hardcode and use the native native options for solving this directly instead (e.g. either mpv.conf or cmdline/configtxt at the OS level).  Its not consistent enough to be managed as a hardcoded 240-MP concern from my testing on the pi5 in both composite and hdmi out use cases.

This also fixes a minor mistype in the HDMI config instructions for Pi5

## AI involvement

None 

## Testing

Traced this on a Pi5 output to both a CRT and HDMI and found the inconsistency that can occur with CRT output can be also compensated for sometimes via config.txt or cmdline.txt or through mpv.conf.  

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)