### PR TITLE
docs: add wiki reference to install and simplify release details

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,19 +239,10 @@ jobs:
             artifacts/SHA256SUMS
             scripts/install.sh
           body: |
-            ### Downloads:
-
-            | Platform | File |
-            |---|---|
-            | Raspberry Pi OS Trixie (arm64) | `240-MP-${{ github.ref_name }}-linux-arm64.tar.gz` |
-            | macOS (Apple Silicon) | `240-MP-${{ github.ref_name }}-macOS-arm64.dmg` |
-
-            ### Install Instructions:
-
-            - Raspberry Pi OS Trixie (arm64): [Instructions](INSTALL.md#on-a-raspberry-pi)
+            Install:
+            - Raspberry Pi OS Trixie (arm64): Please follow [these instructions](INSTALL.md#on-a-raspberry-pi)
             - macOS (Apple Silicon): Download the `.dmg`, open and move 240mp.app to your applications folder
 
-            ### Update Instructions:
-
-            - Raspberry Pi OS Trixie (arm64): [Instructions](INSTALL.md#update)
-            - macOS (Apple Silicon): Download the `.dmg`, open and move 240mp.app to your applications folder
+            Update:
+            - Raspberry Pi OS Trixie (arm64): Use the in-app updater or follow [these instructions](INSTALL.md#update)
+            - macOS (Apple Silicon): Use the in-app updater or download the `.dmg`, open and move 240mp.app to your applications folder

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -196,6 +196,8 @@ However, if you already have Raspberry Pi OS set up and working on your TV then 
 
 At this point you can type `240mp` at any time to start up the app.  And if you installed the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
 
+The Local Files module will be enabled by default and you can open settings to enable any other modules you would like to display.  Please see the [modules section](https://github.com/anthonycaccese/240-MP/wiki#modules) in the wiki for details on any additional set up that may be needed for the modules you'd like to use.
+
 **If analog / composite audio is unusually quiet:** 
 - Run `amixer sset PCM 100%`
 - If that solves it and you want to keep the level across reboots, run `sudo alsactl store`
@@ -259,6 +261,7 @@ If you don't have a Raspberry Pi and would like to try 240-MP, I also provide a 
 2. Mount it and move the 240mp.app into your Applications folder
 3. Make sure you have mpv installed (240-MP requires MPV for playback): `brew install mpv`
 4. Double click 240-MP and it should open full screen
+5. The Local Files module will be enabled by default and you can open settings to enable any other modules you would like to display.  Please see the [modules section](https://github.com/anthonycaccese/240-MP/wiki#modules) in the wiki for details on any additional set up that may be needed for the modules you'd like to use.
 
 ### Update
 


### PR DESCRIPTION
## Summary

Adds direct link to the module's section of the wiki to provide additional details for enabling modules after first install. 
Simplifies release.yaml output for use in the in-app updater

## AI involvement

None

## Testing

Reviewed in markdown preview

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
