### PR TITLE
Add independent X/Y crop overscan controls

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -242,6 +242,15 @@ This config is read at each playback event, so a change applies on the next play
 
 The trade-off with this approach: the copy path didn't look like it could reliabilty play back 1080p on the Pi 3 in my testing. I found it can easily peg the CPU and cause stuttering. So enabling crop on a Pi 3 means keeping your source content to **720p and below**. Ultimately its your call: smooth 1080p without crop (keep the default), or enable crop with a 720p ceiling using --hwdec=v4l2m2m-copy.
 
+### CRT overscan tuning (Auto Crop)
+
+If **Auto Crop** fills the screen but goes a bit past the visible CRT area, use:
+
+- **Settings → Crop Overscan X** (horizontal fit)
+- **Settings → Crop Overscan Y** (vertical fit)
+
+Both apply only when Auto Crop is ON and can be tuned independently (0% to 30%).
+
 ## Debugging & logs
 
 240-MP logs to **stdout/stderr** via Qt's `qDebug` / `qWarning` (used throughout `AppCore`, `MpvController`, and the module backends). The trick is knowing where that output goes depending on how you launched the app.

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -9,6 +9,7 @@
 #include <QDateTime>
 #include <QRegularExpression>
 #include <QDebug>
+#include <algorithm>
 
 #ifdef Q_OS_LINUX
 #include <fcntl.h>
@@ -319,8 +320,17 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     // Auto Crop: start with panscan=1 unless the current decode path can't crop.
     // The Pi3 overlay (smooth) path blanks video under panscan, so suppress there —
     // matching the 1080p Playback trade-off. The OSC CROP button still toggles live.
-    if (autoCropEnabled() && !cropUnavailable())
-        args << QStringLiteral("--panscan=1");
+    if (autoCropEnabled() && !cropUnavailable()) {
+            args << QStringLiteral("--panscan=1");
+            const int overscanX = autoCropOverscanHorizontalPercent();
+            const int overscanY = autoCropOverscanVerticalPercent();
+            if (overscanX > 0 || overscanY > 0) {
+                const double scaleX = std::max(0.50, 1.0 - (double(overscanX) / 100.0));
+                const double scaleY = std::max(0.50, 1.0 - (double(overscanY) / 100.0));
+                args << QString("--video-scale-x=%1").arg(scaleX, 0, 'f', 3);
+                args << QString("--video-scale-y=%1").arg(scaleY, 0, 'f', 3);
+            }
+    }
 
     m_process = new QProcess(this);
     m_process->setProcessChannelMode(QProcess::MergedChannels);
@@ -710,6 +720,47 @@ bool MpvController::cropUnavailable() const {
     // crop/zoom: --panscan blanks the video there. (Ignores the mpv_video_args
     // override, same as the auto-crop gate — the setting still reflects intent.)
     return m_videoProfile == VideoProfile::Pi3 && smoothPlaybackEnabled();
+}
+
+static int parseOverscanPercent(const QVariant &value, int maxPct) {
+    if (!value.isValid())
+        return 0;
+    const QString s = value.toString().trimmed();
+    if (s.isEmpty())
+        return 0;
+    bool ok = false;
+    int pct = s.toInt(&ok);
+    if (!ok) {
+        const QString digits = s.left(s.indexOf('%') >= 0 ? s.indexOf('%') : s.size());
+        pct = digits.toInt(&ok);
+    }
+    if (!ok)
+        return 0;
+    if (pct < 0)
+        return 0;
+    if (pct > maxPct)
+        return maxPct;
+    return pct;
+}
+
+int MpvController::autoCropOverscanHorizontalPercent() const {
+    if (!m_appCore)
+        return 0;
+    const QVariant v = m_appCore->get_setting(QString(), "crop_overscan_x");
+    if (v.isValid() && !v.toString().isEmpty())
+        return parseOverscanPercent(v, 30);
+    // Backward compatibility with the old single-axis setting.
+    return parseOverscanPercent(m_appCore->get_setting(QString(), "crop_overscan"), 30);
+}
+
+int MpvController::autoCropOverscanVerticalPercent() const {
+    if (!m_appCore)
+        return 0;
+    const QVariant v = m_appCore->get_setting(QString(), "crop_overscan_y");
+    if (v.isValid() && !v.toString().isEmpty())
+        return parseOverscanPercent(v, 30);
+    // Backward compatibility with the old single-axis setting.
+    return parseOverscanPercent(m_appCore->get_setting(QString(), "crop_overscan"), 30);
 }
 
 bool MpvController::hasSmoothPlaybackTradeoff() const {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -109,6 +109,10 @@ private:
     // playback ON): --panscan blanks the video there. Gates auto-crop and tells
     // the OSC scripts to hide their CROP button.
     bool cropUnavailable() const;
+    // App-level overscan compensation (default 0%). Applies only when auto-crop
+    // is ON and can be tuned independently for horizontal and vertical axes.
+    int autoCropOverscanHorizontalPercent() const;
+    int autoCropOverscanVerticalPercent() const;
     int  getActiveVt() const;
     int  findFreeVt() const;
     int  findQtDrmFd() const;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -111,6 +111,40 @@ FocusScope {
             description: "[ON] Video starts cropped to fill screen\n[OFF] Video starts at its original aspect ratio",
             moduleId: ""
         })
+        var cropOverscanOpts = ["0%", "2%", "4%", "6%", "8%", "10%", "12%", "14%", "16%", "18%", "20%", "22%", "24%", "26%", "28%", "30%"]
+        var cropOverscanLegacyRaw = appSettings["crop_overscan"] || "0%"
+        var cropOverscanRawX = appSettings["crop_overscan_x"] || cropOverscanLegacyRaw
+        var cropOverscanRawY = appSettings["crop_overscan_y"] || cropOverscanLegacyRaw
+        var cropOverscanNumX = parseInt(cropOverscanRawX)
+        var cropOverscanNumY = parseInt(cropOverscanRawY)
+        if (isNaN(cropOverscanNumX)) cropOverscanNumX = 0
+        if (isNaN(cropOverscanNumY)) cropOverscanNumY = 0
+        if (cropOverscanNumX < 0) cropOverscanNumX = 0
+        if (cropOverscanNumX > 30) cropOverscanNumX = 30
+        if (cropOverscanNumY < 0) cropOverscanNumY = 0
+        if (cropOverscanNumY > 30) cropOverscanNumY = 30
+        var cropOverscanValueX = cropOverscanNumX + "%"
+        var cropOverscanValueY = cropOverscanNumY + "%"
+        if (!cropOverscanOpts.includes(cropOverscanValueX)) cropOverscanValueX = "0%"
+        if (!cropOverscanOpts.includes(cropOverscanValueY)) cropOverscanValueY = "0%"
+        items.push({
+            type: "list_single",
+            key: "crop_overscan_x",
+            label: "Crop Overscan X",
+            options: cropOverscanOpts,
+            value: cropOverscanValueX,
+            description: "When AUTO CROP is ON, shrink width to fit CRT overscan (higher = narrower image)",
+            moduleId: ""
+        })
+        items.push({
+            type: "list_single",
+            key: "crop_overscan_y",
+            label: "Crop Overscan Y",
+            options: cropOverscanOpts,
+            value: cropOverscanValueY,
+            description: "When AUTO CROP is ON, shrink height to fit CRT overscan (higher = shorter image)",
+            moduleId: ""
+        })
 
         // SCREEN SAVER section — single control: OFF disables, a number sets the
         // timeout for both menu idle and playback pause (handled inside mpv).


### PR DESCRIPTION
## Summary
- Add separate app settings for CRT overscan compensation:
  - Crop Overscan X (horizontal)
  - Crop Overscan Y (vertical)
- Expand overscan adjustment range to 0%..30% (2% steps).
- Apply axis-specific mpv scaling (`--video-scale-x`, `--video-scale-y`) when Auto Crop is enabled, so horizontal/vertical fit can be tuned independently.
- Keep backward compatibility with existing `crop_overscan` config by using it as fallback when new axis keys are not set.
- Document the new CRT tuning flow in BUILDING.md.

## Why
On CRT setups, overscan and geometry often require independent horizontal and vertical compensation. A single global overscan value cannot reliably fit both axes.

## Manual testing
- Verified settings are visible in app settings with 0%..30% options.
- Verified values persist through config and are read at playback start.
- Verified axis-specific scaling arguments are applied only when Auto Crop is enabled.
- Verified legacy `crop_overscan` still works as fallback.

## Media
<img width="1407" height="949" alt="image" src="https://github.com/user-attachments/assets/37021c4b-abf1-4d7b-bda0-1c8181e6eeeb" /><img width="1010" height="936" alt="image" src="https://github.com/user-attachments/assets/3d661430-07c2-4754-aa06-169828312fa2" /><img width="1005" height="853" alt="image" src="https://github.com/user-attachments/assets/6517c0ba-ec0e-4d4b-b229-4418ddf65662" />


## AI use disclosure
AI assistance was used to help draft and implement this change (code edits and PR draft text). The final changes were reviewed and validated before submission