### PR TITLE
fix(local files): loop + resume fix

### DIFF
--- a/modules/local_files/views/Player.qml
+++ b/modules/local_files/views/Player.qml
@@ -33,13 +33,6 @@ FocusScope {
     property int    lastKnownDurationMs:  0
     property int    lastKnownPlaylistPos: -1
 
-    // Playlist resume correction: --start=T is global so every subsequent
-    // video in the playlist would also start at T. We track which playlist
-    // position was resumed from and seek to 0 on the first position event
-    // after each advancement past that point.
-    property int    resumedFromPlaylistPos: -1
-    property bool   needsSeekToZero:        false
-
     focus: true
 
     Keys.onPressed: function(event) {
@@ -56,8 +49,6 @@ FocusScope {
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                 var startMs    = choiceIndex === 0 ? savedPositionMs  : 0
                 var startPlPos = choiceIndex === 0 ? savedPlaylistPos : -1
-                if (choiceIndex === 0 && startPlPos >= 0)
-                    resumedFromPlaylistPos = startPlPos
                 overlayVisible = false
                 mpvController.loadAndPlay(filePath, startMs / 1000.0, 0, subFlag, [], subtitleLangs, loopOn, startPlPos, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
                 event.accepted = true
@@ -95,22 +86,13 @@ FocusScope {
         target: mpvController
 
         function onPositionChanged(ms) {
-            if (ms > 0) {
-                if (needsSeekToZero) {
-                    needsSeekToZero = false
-                    mpvController.seekTo(0)
-                    return
-                }
-                playerRoot.lastKnownPositionMs = ms
-            }
+            if (ms > 0) playerRoot.lastKnownPositionMs = ms
         }
         function onDurationChanged(ms) {
             if (ms > 0) playerRoot.lastKnownDurationMs = ms
         }
         function onPlaylistPosChanged(pos) {
             if (pos >= 0) {
-                if (resumedFromPlaylistPos >= 0 && pos > resumedFromPlaylistPos)
-                    needsSeekToZero = true
                 playerRoot.lastKnownPlaylistPos = pos
                 playerRoot.lastKnownPositionMs  = 0
             }
@@ -194,8 +176,6 @@ FocusScope {
         var savedPl  = (saved.plPos !== undefined && saved.plPos !== null) ? saved.plPos : -1
 
         if (resumeSetting === "yes") {
-            if (savedPos > 0 && savedPl >= 0)
-                resumedFromPlaylistPos = savedPl
             mpvController.loadAndPlay(filePath, savedPos > 0 ? savedPos / 1000.0 : 0.0,
                                       0, subFlag, [], subtitleLangs, loopOn, savedPos > 0 ? savedPl : -1, 0.0, "", false, "", false, [], imageDurationSec, imageContent)
         } else {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -138,6 +138,7 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     m_playlistPos = -1;
     m_paused      = false;
     m_lastEndFileReason.clear();
+    m_pendingStartClear = false;
 
 #ifdef Q_OS_MACOS
     // .app bundles launched via double-click get a minimal PATH that excludes
@@ -223,8 +224,10 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
 
     if (playlistStart >= 0)
         args << QString("--playlist-start=%1").arg(playlistStart);
-    if (startSeconds > 0.5f)
+    if (startSeconds > 0.5f) {
         args << QString("--start=%1").arg(double(startSeconds), 0, 'f', 3);
+        m_pendingStartClear = true;
+    }
     if (audioTrack > 0)
         args << QString("--aid=%1").arg(audioTrack);
     for (const QString &sf : subFiles)
@@ -480,6 +483,17 @@ void MpvController::onIpcReadyRead() {
             // so onProcessFinished can distinguish a natural finish from a quit.
             if (event == "end-file") {
                 m_lastEndFileReason = obj["reason"].toString();
+            } else if (event == "playback-restart" && m_pendingStartClear) {
+                // --start is a global option that mpv re-applies on *every* file load,
+                // and --loop-playlist reloads its entries on wrap. Left set, a resumed
+                // file would restart at the resume offset on every loop lap (and every
+                // later playlist entry would start there too) instead of at the
+                // beginning. mpv only reads `start` when it loads a file, and
+                // playback-restart means the initial seek is already done — so clearing
+                // it here leaves the current playback alone while every subsequent load
+                // begins at 0. Guarded so it fires once per session, not on every seek.
+                m_pendingStartClear = false;
+                sendCommand({"set_property", "start", "none"});
             } else if (event == "client-message") {
                 const QJsonArray args = obj["args"].toArray();
                 if (args.size() > 0) {

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -132,6 +132,9 @@ private:
     QString       m_logFilePath;
     QString       m_subInfoPath;       // JSON map: external sub URL -> friendly name (for the OSC)
     QString       m_lastEndFileReason;  // mpv end-file "reason" for the current session
+    // Set when this session passed --start; cleared once mpv has applied it. See
+    // onIpcReadyRead's playback-restart handling for why the option can't just stay set.
+    bool          m_pendingStartClear = false;
     int           m_position     = 0;
     int           m_duration     = 0;
     int           m_playlistPos  = -1;


### PR DESCRIPTION
## Summary

in local files we provide a setting that loops playback. there was one bug with this setting related to resume playback.  if the file being played has a resume point and the user starts from that point then when loop occurs at EOF it starts back at that resume point instead of the beginning of the file.

this commit fixes that

Once mpv's playback-restart confirms the initial start-seek has landed, MpvController sends set_property start none over the IPC socket it already maintains. mpv only reads start at file-load time, so the current playback is untouched while every later load begins at 0. That handles single files and playlist wraps in one place. this also made the original QML workaround in local files player.qml redundant so this cleaned that up too.

## AI involvement

used to help regression test against other modules

## Testing

Tested Local Files single and playlist use cases with loop on and resume points
Regression tested against playback in all other modules

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
