### PR TITLE
fix(mpv): osc duration update while playing items in a playlist

### DIFF
--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -118,13 +118,16 @@ end
 
 local transcode_offset = tonumber(mp.get_opt("transcode-offset") or "0") or 0
 
--- Latch duration on first valid read; used to detect PTS base shifts during HLS seeking
+-- Latch duration on the first valid read of each file: when Plex restarts an HLS
+-- transcode after rapid seeking, `duration` can spike mid-stream and corrupt the
+-- end-time display. Cleared per file so each playlist item latches its own duration.
 local stable_duration = nil
 mp.observe_property("duration", "number", function(_, value)
     if value and value > 0 and not stable_duration then
         stable_duration = value
     end
 end)
+mp.register_event("start-file", function() stable_duration = nil end)
 
 local function format_time(seconds)
     if not seconds or seconds < 0 then seconds = 0 end


### PR DESCRIPTION
## Summary

fixes the duration display of the currently playing file.  before this the duration would always display as the first item in the playlist.

## AI involvement

helped plan an approach that wouldn't cause regression issues across other modules (as this only occurs as a use case in local files currently)

## Testing

Ran tests with playlists in local files (navigating back and forth) and a test with plex transcoding turned on to double check for regressions against the existing seek behavior in that module when transcoding is active

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)