### PR TITLE
feat(local files): hide file extensions display option

### DIFF
--- a/modules/local_files/manifest.json
+++ b/modules/local_files/manifest.json
@@ -65,6 +65,13 @@
       "options_slot": "get_image_duration_options",
       "default": "5",
       "description": "How long an image is shown before advancing.\nApplies to images in folders and playlists."
+    },
+    {
+      "key": "hide_extensions",
+      "label": "Hide File Extensions",
+      "type": "toggle",
+      "default": "OFF",
+      "description": "Hide file extensions when browsing."
     }
   ]
 }

--- a/modules/local_files/views/Items.qml
+++ b/modules/local_files/views/Items.qml
@@ -8,6 +8,17 @@ FocusScope {
     property var navListState: navParams.navListState || ({})
     property string folderPath: navParams.folderPath || localFilesBackend.mediaRoot()
     property string folderName: navParams.folderName || ""
+    readonly property bool hideExtensions: {
+        var v = appCore.get_setting(moduleRoot.moduleId, "hide_extensions")
+        return v === true || v === "ON"
+    }
+
+    function displayName(item) {
+        if (item.isFolder) return item.name + "/"
+        if (!hideExtensions) return item.name
+        var dot = item.name.lastIndexOf(".")
+        return dot > 0 ? item.name.substring(0, dot) : item.name
+    }
 
     signal navigateTo(string path, var params, var listState)
     signal goBack()
@@ -105,7 +116,7 @@ FocusScope {
 
                 Text {
                     id: rowText
-                    text: modelData.isFolder ? modelData.name + "/" : modelData.name
+                    text: itemsRoot.displayName(modelData)
                     color: fileList.currentIndex === index ? root.surfaceColor : root.primaryColor
                     font.family: root.globalFont
                     font.capitalization: Font.AllUppercase


### PR DESCRIPTION
## Summary

Add a "Hide File Extensions" toggle (default OFF) that strips the extension from file names in the browse list for a cleaner look.

This change is "display-only"... so navigation, playback, and resume history keep using the full name/path behind the scenes. Folders are never stripped, dotfiles and extension-less names pass through, and .m3u playlist-folder entries also display clean.

## Testing

Tested on Local files module with a set of different file extension use cases.  Confirmed playback is unchanged for each case and that this change is scoped to display only.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)