### PR TITLE
feat(input): remote/keyboard button remapping

### DIFF
--- a/assets/images/keyboard.svg
+++ b/assets/images/keyboard.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="100%" height="100%" viewBox="0 0 22 18" version="1.1" xmlns="http://www.w3.org/2000/svg" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+  <path d="M 0 18 L 0 0 L 22 0 L 22 18 L 0 18 Z M 20 2 L 2 2 L 2 16 L 20 16 L 20 2 Z M 10 6 L 8 6 L 8 4 L 10 4 L 10 6 Z M 6 6 L 4 6 L 4 4 L 6 4 L 6 6 Z M 17 14 L 5 14 L 5 12 L 17 12 L 17 14 Z M 12 10 L 10 10 L 10 8 L 12 8 L 12 10 Z M 16 10 L 14 10 L 14 8 L 16 8 L 16 10 Z M 14 6 L 12 6 L 12 4 L 14 4 L 14 6 Z M 18 6 L 16 6 L 16 4 L 18 4 L 18 6 Z M 8 10 L 6 10 L 6 8 L 8 8 L 8 10 Z" style="fill:white;"/>
+</svg>

--- a/src/AppCore.cpp
+++ b/src/AppCore.cpp
@@ -123,6 +123,12 @@ QVariant AppCore::get_setting(const QString &moduleId, const QString &key) {
         target = config["app"].toObject();
     else
         target = config["modules"].toObject()[moduleId].toObject();
+
+    // Mirror save_setting's dot-notation handling: "libraries.somekey" reads
+    // target["libraries"]["somekey"], not a literal "libraries.somekey" key.
+    QStringList parts = key.split('.', Qt::KeepEmptyParts);
+    if (parts.size() == 2)
+        return target[parts[0]].toObject()[parts[1]].toVariant();
     return target[key].toVariant();
 }
 

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -1,18 +1,41 @@
 #include "InputManager.h"
+#include "../AppCore.h"
 
 #include <QCoreApplication>
 #include <QGuiApplication>
 #include <QInputMethodQueryEvent>
 #include <QQuickWindow>
 #include <QKeyEvent>
+#include <QKeySequence>
+#include <QMouseEvent>
 #include <QFile>
 #include <QFileInfo>
 #include <QTextStream>
+#ifdef Q_OS_LINUX
+#include <QSocketNotifier>
+#include <QDir>
+#include <linux/input.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#endif
 
 namespace {
 // Planted in nativeScanCode of synthesized events so the keyboard detector in
 // eventFilter() can tell our gamepad-originated key events from real key presses.
 constexpr quint32 kSyntheticScanCode = 0x240F00D;
+
+// Extended key ids for the Consumer Control evdev path (see
+// openConsumerControlDevice()) are stored in m_keyRemap as kEvdevKeyBase plus
+// the raw Linux KEY_* code. Qt::Key's own values (ASCII range, or the
+// "special key" range starting at 0x01000000) never reach this high, so the
+// two id spaces can share one QHash with no risk of collision.
+constexpr int kEvdevKeyBase = 0x02000000;
+
+// Same idea, for a mouse button (Qt::MouseButton), some "air mouse" remotes
+// wire their center/OK button as a literal left click rather than any kind of
+// key, so it never generates a QKeyEvent at all. Distinct base, same QHash.
+constexpr int kMouseButtonBase = 0x03000000;
 
 // Analog stick thresholds (of ±32768). Engage above one, release below the
 // other — the gap prevents flutter when the stick rests near the threshold.
@@ -50,8 +73,9 @@ bool textInputHasFocus() {
 }
 }
 
-InputManager::InputManager(const QString &dataRoot, QObject *parent)
+InputManager::InputManager(const QString &dataRoot, AppCore *appCore, QObject *parent)
     : QObject(parent)
+    , m_appCore(appCore)
     , m_dataRoot(dataRoot)
 {
     m_repeatDelayTimer.setSingleShot(true);
@@ -63,6 +87,14 @@ InputManager::InputManager(const QString &dataRoot, QObject *parent)
 
     rebuildMapping();
     initSdl();
+
+    loadKeyRemap();
+    if (m_appCore)
+        connect(m_appCore, &AppCore::appSettingChanged, this, &InputManager::onAppSettingChanged);
+
+#ifdef Q_OS_LINUX
+    openConsumerControlDevice();
+#endif
 
     // Watch the data dir (not the file) so input.cfg can appear later and so
     // replace-on-save editors are caught; mtime check filters unrelated writes
@@ -82,6 +114,10 @@ InputManager::~InputManager() {
     m_controllers.clear();
     if (m_sdlReady)
         SDL_Quit();
+#ifdef Q_OS_LINUX
+    if (m_consumerFd >= 0)
+        ::close(m_consumerFd);
+#endif
 }
 
 void InputManager::setTargetWindow(QQuickWindow *window) {
@@ -323,6 +359,146 @@ void InputManager::loadUserMapping() {
     qInfo("[input] input.cfg: applied %d binding(s)", applied);
 }
 
+// Keyboard/remote-button remap, config.json's app.remote_keymap.<action>,
+// each an int Qt::Key value (or unset/0, meaning "no extra key for this
+// action"). Set from Settings > Remote Controls (views/RemapControls.qml).
+// Unlike input.cfg's gamepad rebinds, this is additive: it never removes an
+// action's default key, it only adds one more physical key that also fires
+// it, so a bad remap can't lock the menus out from a plain keyboard.
+void InputManager::loadKeyRemap() {
+    m_keyRemap.clear();
+    if (!m_appCore)
+        return;
+    static const struct { const char *name; Action action; } kRemapActions[] = {
+        { "up",     Action::Up },
+        { "down",   Action::Down },
+        { "left",   Action::Left },
+        { "right",  Action::Right },
+        { "select", Action::Select },
+        { "back",   Action::Back },
+    };
+    for (const auto &entry : kRemapActions) {
+        bool ok = false;
+        const int qtKey = m_appCore->get_setting(QString(), QStringLiteral("remote_keymap.") + entry.name).toInt(&ok);
+        if (ok && qtKey != 0)
+            m_keyRemap[qtKey] = entry.action;
+    }
+}
+
+void InputManager::onAppSettingChanged(const QString &key, const QString &value) {
+    Q_UNUSED(value)
+    if (key.startsWith(QStringLiteral("remote_keymap.")))
+        loadKeyRemap();
+}
+
+#ifdef Q_OS_LINUX
+// Some remote/keyboard USB combos expose their "Consumer Page" HID buttons
+// (Home, Back, Menu, colored buttons, zoom, media transport…) as a *separate*
+// /dev/input/eventN device from the plain keyboard interface, confirmed via
+// `cat /proc/bus/input/devices` showing three sibling interfaces (Keyboard,
+// Consumer Control, Mouse) off one USB composite device. Qt's EGLFS/libinput
+// backend doesn't classify "Consumer Control" as a keyboard, so those button
+// presses never reach QML as ordinary QKeyEvents no matter what the device is
+// capable of sending. This opens that device directly (read-only) and feeds
+// it into the same Action/remap system as everything else, bypassing Qt's
+// input pipeline entirely for this one device.
+//
+// Scanned once at startup, no hotplug, this is a fixed USB dongle here, not
+// something swapped mid-session. Harmless no-op on a machine with no such
+// device (nothing matches the name, nothing is opened).
+void InputManager::openConsumerControlDevice() {
+    QDir dir(QStringLiteral("/dev/input"));
+    const QStringList entries = dir.entryList(QStringList() << QStringLiteral("event*"), QDir::System);
+    for (const QString &entry : entries) {
+        const QString path = dir.filePath(entry);
+        const int fd = ::open(path.toUtf8().constData(), O_RDONLY | O_NONBLOCK);
+        if (fd < 0)
+            continue;
+        char name[256] = {0};
+        const bool isConsumerControl = ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0
+            && QString::fromUtf8(name).contains(QStringLiteral("Consumer Control"), Qt::CaseInsensitive);
+        if (isConsumerControl) {
+            m_consumerFd = fd;
+            m_consumerNotifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
+            connect(m_consumerNotifier, &QSocketNotifier::activated, this, &InputManager::onConsumerControlReadable);
+            qInfo("[input] Consumer Control device found: %s (%s)", name, qPrintable(path));
+            return;
+        }
+        ::close(fd);
+    }
+    qInfo("[input] no Consumer Control device found, remote's extra buttons (if any) won't be remappable");
+}
+
+void InputManager::onConsumerControlReadable() {
+    struct input_event ev;
+    while (::read(m_consumerFd, &ev, sizeof(ev)) == sizeof(ev)) {
+        if (ev.type != EV_KEY || ev.value == 2)   // ignore autorepeat and non-key events
+            continue;
+        const int extendedId = kEvdevKeyBase + ev.code;
+        if (ev.value == 1)
+            emit auxButtonPressed(extendedId);
+
+        const Action a = m_keyRemap.value(extendedId, Action::None);
+        if (a == Action::None)
+            continue;
+        if (ev.value == 1)
+            deliverPress(a, false);
+        else if (windowActive())
+            postKey(qtKeyForAction(a), QEvent::KeyRelease, false);
+    }
+}
+#endif
+
+// Display name for a Consumer Control button (extendedId - kEvdevKeyBase is
+// the raw Linux KEY_* code). Covers the codes an ordinary remote is likely to
+// send; anything else falls back to "Button <code>" rather than nothing.
+QString InputManager::evdevKeyName(int linuxCode) {
+#ifndef Q_OS_LINUX
+    // The Consumer Control evdev path only exists on Linux (see
+    // openConsumerControlDevice()); nothing ever stores a code in this range
+    // on other platforms, but the function still has to compile everywhere.
+    return QStringLiteral("Button %1").arg(linuxCode);
+#else
+    switch (linuxCode) {
+    case KEY_HOMEPAGE:    return QStringLiteral("Home");
+    case KEY_BACK:        return QStringLiteral("Back");
+    case KEY_MENU:        return QStringLiteral("Menu");
+    case KEY_INFO:        return QStringLiteral("Info");
+    case KEY_EXIT:        return QStringLiteral("Exit");
+    case KEY_SEARCH:      return QStringLiteral("Search");
+    case KEY_WWW:         return QStringLiteral("WWW");
+    case KEY_MAIL:        return QStringLiteral("Mail");
+    case KEY_RED:         return QStringLiteral("Red");
+    case KEY_GREEN:       return QStringLiteral("Green");
+    case KEY_YELLOW:      return QStringLiteral("Yellow");
+    case KEY_BLUE:        return QStringLiteral("Blue");
+    case KEY_ZOOMIN:      return QStringLiteral("Zoom In");
+    case KEY_ZOOMOUT:     return QStringLiteral("Zoom Out");
+    case KEY_ZOOMRESET:   return QStringLiteral("Zoom Reset");
+    case KEY_PLAY:        return QStringLiteral("Play");
+    case KEY_PLAYPAUSE:   return QStringLiteral("Play/Pause");
+    case KEY_PAUSE:       return QStringLiteral("Pause");
+    case KEY_STOP:        return QStringLiteral("Stop");
+    case KEY_REWIND:      return QStringLiteral("Rewind");
+    case KEY_FASTFORWARD: return QStringLiteral("Fast Forward");
+    case KEY_NEXTSONG:    return QStringLiteral("Next");
+    case KEY_PREVIOUSSONG:return QStringLiteral("Previous");
+    case KEY_RECORD:      return QStringLiteral("Record");
+    case KEY_VOLUMEUP:    return QStringLiteral("Volume Up");
+    case KEY_VOLUMEDOWN:  return QStringLiteral("Volume Down");
+    case KEY_MUTE:        return QStringLiteral("Mute");
+    case KEY_CHANNELUP:   return QStringLiteral("Channel Up");
+    case KEY_CHANNELDOWN: return QStringLiteral("Channel Down");
+    case KEY_BUTTONCONFIG:return QStringLiteral("Tools");
+    case KEY_CONFIG:      return QStringLiteral("Config");
+    case KEY_SELECT:      return QStringLiteral("Select");
+    case KEY_POWER:       return QStringLiteral("Power");
+    case KEY_SLEEP:       return QStringLiteral("Sleep");
+    default:              return QStringLiteral("Button %1").arg(linuxCode);
+    }
+#endif
+}
+
 void InputManager::onDataDirChanged(const QString &) {
     const QFileInfo cfg(m_dataRoot + "/input.cfg");
     const QDateTime modified = cfg.exists() ? cfg.lastModified() : QDateTime();
@@ -487,6 +663,27 @@ bool InputManager::isDirectional(Action a) {
     return a == Action::Up || a == Action::Down || a == Action::Left || a == Action::Right;
 }
 
+QString InputManager::keyDisplayName(int qtKey) const {
+    if (qtKey == 0)
+        return QString();
+    if (qtKey >= kMouseButtonBase)
+        return mouseButtonName(qtKey - kMouseButtonBase);
+    if (qtKey >= kEvdevKeyBase)
+        return evdevKeyName(qtKey - kEvdevKeyBase);
+    return QKeySequence(qtKey).toString(QKeySequence::NativeText);
+}
+
+QString InputManager::mouseButtonName(int qtButton) {
+    switch (Qt::MouseButton(qtButton)) {
+    case Qt::LeftButton:    return QStringLiteral("Mouse: Left Click");
+    case Qt::RightButton:   return QStringLiteral("Mouse: Right Click");
+    case Qt::MiddleButton:  return QStringLiteral("Mouse: Middle Click");
+    case Qt::BackButton:    return QStringLiteral("Mouse: Back");
+    case Qt::ForwardButton: return QStringLiteral("Mouse: Forward");
+    default:                return QStringLiteral("Mouse Button %1").arg(qtButton);
+    }
+}
+
 // HID media keys are a separate concern from navigation actions — they always
 // target mpv, never QML — so they bypass the Action enum and map straight to the
 // canonical mpv key names media-keys.lua binds.
@@ -512,6 +709,29 @@ QString InputManager::mpvKeyForMediaEvent(const QKeyEvent *ke) {
 bool InputManager::eventFilter(QObject *obj, QEvent *event) {
     Q_UNUSED(obj)
     const QEvent::Type type = event->type();
+
+    // Some remotes wire their center/OK button as a literal mouse click (see
+    // openConsumerControlDevice()'s comment for the sibling-devices story).
+    // Qt still delivers that as an ordinary QMouseEvent regardless of what
+    // libinput thinks the device is, so no raw evdev reader is needed here,
+    // just the same remap table and capture signal as everything else.
+    if (type == QEvent::MouseButtonPress || type == QEvent::MouseButtonRelease) {
+        const auto *me = static_cast<QMouseEvent *>(event);
+        const int extendedId = kMouseButtonBase + int(me->button());
+        if (type == QEvent::MouseButtonPress)
+            emit auxButtonPressed(extendedId);
+
+        const Action remapped = m_keyRemap.value(extendedId, Action::None);
+        if (remapped != Action::None) {
+            if (type == QEvent::MouseButtonPress)
+                deliverPress(remapped, false);
+            else if (windowActive())
+                postKey(qtKeyForAction(remapped), QEvent::KeyRelease, false);
+            return true;
+        }
+        return false;
+    }
+
     if (type != QEvent::KeyPress && type != QEvent::KeyRelease)
         return false;
     const auto *ke = static_cast<QKeyEvent *>(event);
@@ -541,6 +761,26 @@ bool InputManager::eventFilter(QObject *obj, QEvent *event) {
                 releaseAction(Action::Back);
         }
         return true;
+    }
+
+    // Custom remote/keyboard remap (Settings > Remote Controls): an extra
+    // physical key that also fires one of the six actions, delivered the same
+    // way a gamepad press is: a synthesized key event carrying that action's
+    // *default* Qt key, so every existing Keys.onPressed handler sees exactly
+    // what it always has. The default key itself is untouched (this table is
+    // additive), so remapping can't remove the app's own keyboard controls.
+    // Skipped for our own synthesized events (nativeScanCode check) so two
+    // remapped keys can never feed into each other, and skipped while a text
+    // field has focus so typing a remapped character still works normally.
+    if (ke->nativeScanCode() != kSyntheticScanCode && !textInputHasFocus()) {
+        const Action remapped = m_keyRemap.value(ke->key(), Action::None);
+        if (remapped != Action::None) {
+            if (type == QEvent::KeyPress)
+                deliverPress(remapped, ke->isAutoRepeat());
+            else if (windowActive())
+                postKey(qtKeyForAction(remapped), QEvent::KeyRelease, false);
+            return true;
+        }
     }
 
     // HID media keys drive mpv directly over IPC (sendKey no-ops when mpv isn't

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -15,6 +15,7 @@
 #include <QSocketNotifier>
 #include <QDir>
 #include <linux/input.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
@@ -391,6 +392,10 @@ void InputManager::onAppSettingChanged(const QString &key, const QString &value)
         loadKeyRemap();
 }
 
+void InputManager::setRemapCapture(bool active) {
+    m_remapCapture = active;
+}
+
 #ifdef Q_OS_LINUX
 // Some remote/keyboard USB combos expose their "Consumer Page" HID buttons
 // (Home, Back, Menu, colored buttons, zoom, media transport…) as a *separate*
@@ -431,20 +436,45 @@ void InputManager::openConsumerControlDevice() {
 
 void InputManager::onConsumerControlReadable() {
     struct input_event ev;
-    while (::read(m_consumerFd, &ev, sizeof(ev)) == sizeof(ev)) {
+    for (;;) {
+        const ssize_t n = ::read(m_consumerFd, &ev, sizeof(ev));
+        if (n != ssize_t(sizeof(ev))) {
+            if (n < 0 && errno == EINTR)
+                continue;
+            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+                break;   // drained
+            // EOF or a hard error (ENODEV once the dongle is unplugged): tear
+            // the notifier down, or it keeps firing on the dead fd and
+            // busy-spins the event loop.
+            qWarning("[input] Consumer Control device lost — disabling");
+            m_consumerNotifier->setEnabled(false);
+            m_consumerNotifier->deleteLater();
+            m_consumerNotifier = nullptr;
+            ::close(m_consumerFd);
+            m_consumerFd = -1;
+            return;
+        }
         if (ev.type != EV_KEY || ev.value == 2)   // ignore autorepeat and non-key events
             continue;
         const int extendedId = kEvdevKeyBase + ev.code;
-        if (ev.value == 1)
-            emit auxButtonPressed(extendedId);
+
+        if (m_remapCapture) {
+            // Capture mode: report the button, never act on it. Acting is what
+            // must not happen here — finishing a capture writes the binding
+            // into m_keyRemap before this function resumes, so a lookup after
+            // the emit would fire the action on the very press that bound it.
+            if (ev.value == 1)
+                emit auxButtonPressed(extendedId);
+            continue;
+        }
 
         const Action a = m_keyRemap.value(extendedId, Action::None);
         if (a == Action::None)
             continue;
         if (ev.value == 1)
-            deliverPress(a, false);
-        else if (windowActive())
-            postKey(qtKeyForAction(a), QEvent::KeyRelease, false);
+            beginPress(a);
+        else
+            releaseAction(a);
     }
 }
 #endif
@@ -563,6 +593,15 @@ void InputManager::pressAction(Action a) {
     if (a == Action::None)
         return;
     setLastInputDevice(QStringLiteral("gamepad"));
+    beginPress(a);
+}
+
+// Deliver a press and arm the held-direction auto-repeat. Shared by gamepad
+// buttons/axes and remapped consumer-control/mouse inputs — the evdev path
+// filters out autorepeat (and many remotes never send it), so a held direction
+// button repeats through the same timers a held d-pad does. Remapped keyboard
+// keys don't come through here: the OS supplies their repeat.
+void InputManager::beginPress(Action a) {
     deliverPress(a, false);
 
     if (isDirectional(a)) {
@@ -715,18 +754,27 @@ bool InputManager::eventFilter(QObject *obj, QEvent *event) {
     // Qt still delivers that as an ordinary QMouseEvent regardless of what
     // libinput thinks the device is, so no raw evdev reader is needed here,
     // just the same remap table and capture signal as everything else.
-    if (type == QEvent::MouseButtonPress || type == QEvent::MouseButtonRelease) {
+    if (type == QEvent::MouseButtonPress || type == QEvent::MouseButtonDblClick
+        || type == QEvent::MouseButtonRelease) {
         const auto *me = static_cast<QMouseEvent *>(event);
+        // A fast second press arrives as DblClick instead of Press — for a
+        // remapped button it must count as a press, or every other click
+        // leaks into the UI as a real one.
+        const bool isPress = type != QEvent::MouseButtonRelease;
         const int extendedId = kMouseButtonBase + int(me->button());
-        if (type == QEvent::MouseButtonPress)
-            emit auxButtonPressed(extendedId);
+
+        if (m_remapCapture) {
+            if (isPress)
+                emit auxButtonPressed(extendedId);
+            return true;
+        }
 
         const Action remapped = m_keyRemap.value(extendedId, Action::None);
         if (remapped != Action::None) {
-            if (type == QEvent::MouseButtonPress)
-                deliverPress(remapped, false);
-            else if (windowActive())
-                postKey(qtKeyForAction(remapped), QEvent::KeyRelease, false);
+            if (isPress)
+                beginPress(remapped);
+            else
+                releaseAction(remapped);
             return true;
         }
         return false;
@@ -735,8 +783,9 @@ bool InputManager::eventFilter(QObject *obj, QEvent *event) {
     if (type != QEvent::KeyPress && type != QEvent::KeyRelease)
         return false;
     const auto *ke = static_cast<QKeyEvent *>(event);
+    const bool synthetic = ke->nativeScanCode() == kSyntheticScanCode;
 
-    if (type == QEvent::KeyPress && ke->nativeScanCode() != kSyntheticScanCode)
+    if (type == QEvent::KeyPress && !synthetic)
         setLastInputDevice(QStringLiteral("keyboard"));
 
     // Right shift acts as Back so the keyboard works one-handed: reuse the
@@ -763,6 +812,19 @@ bool InputManager::eventFilter(QObject *obj, QEvent *event) {
         return true;
     }
 
+    // Capture mode (see setRemapCapture): swallow every real key and report
+    // presses through auxButtonPressed instead of letting them reach QML.
+    // Going through the signal rather than key delivery is what lets an
+    // already-remapped key be captured as itself — the remap branch below
+    // would otherwise consume it and hand the overlay its action's default
+    // key. Sits after the right-shift block so that alias still cancels the
+    // overlay via its normal Back path.
+    if (m_remapCapture && !synthetic) {
+        if (type == QEvent::KeyPress && !ke->isAutoRepeat())
+            emit auxButtonPressed(ke->key());
+        return true;
+    }
+
     // Custom remote/keyboard remap (Settings > Remote Controls): an extra
     // physical key that also fires one of the six actions, delivered the same
     // way a gamepad press is: a synthesized key event carrying that action's
@@ -771,14 +833,16 @@ bool InputManager::eventFilter(QObject *obj, QEvent *event) {
     // additive), so remapping can't remove the app's own keyboard controls.
     // Skipped for our own synthesized events (nativeScanCode check) so two
     // remapped keys can never feed into each other, and skipped while a text
-    // field has focus so typing a remapped character still works normally.
-    if (ke->nativeScanCode() != kSyntheticScanCode && !textInputHasFocus()) {
+    // field has focus so typing a remapped character still works normally
+    // (the hash miss is checked first — it's cheap, while textInputHasFocus
+    // is a synchronous input-method query and shouldn't run per keystroke).
+    if (!synthetic) {
         const Action remapped = m_keyRemap.value(ke->key(), Action::None);
-        if (remapped != Action::None) {
+        if (remapped != Action::None && !textInputHasFocus()) {
             if (type == QEvent::KeyPress)
                 deliverPress(remapped, ke->isAutoRepeat());
-            else if (windowActive())
-                postKey(qtKeyForAction(remapped), QEvent::KeyRelease, false);
+            else
+                releaseAction(remapped);
             return true;
         }
     }

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -72,7 +72,11 @@ private slots:
     void onRepeatTick();
     void onDataDirChanged(const QString &path);
     void onAppSettingChanged(const QString &key, const QString &value);
+#ifdef Q_OS_LINUX
+    // Defined in the Q_OS_LINUX section of InputManager.cpp; the ifdef keeps
+    // moc from emitting a metacall reference to it on other platforms.
     void onConsumerControlReadable();
+#endif
 
 private:
     enum class Action { None, Up, Down, Left, Right, Select, Back, PlayPause };
@@ -84,7 +88,9 @@ private:
     void loadDefaultMapping();
     void loadUserMapping();
     void loadKeyRemap();
+#ifdef Q_OS_LINUX
     void openConsumerControlDevice();
+#endif
     static QString evdevKeyName(int linuxCode);
     static QString mouseButtonName(int qtButton);
     void noteActiveController(SDL_JoystickID which);

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -46,6 +46,16 @@ public:
     // the remap screen to show what's currently bound. Used from QML.
     Q_INVOKABLE QString keyDisplayName(int qtKey) const;
 
+    // Remap-capture mode, held on by the remap screen while its "press a
+    // button" overlay is up. While active, remap delivery is suspended and
+    // every real input — keyboard key, Consumer Control button, mouse button —
+    // is reported through auxButtonPressed() instead of acting, so the overlay
+    // sees the physical input itself even when it's already bound to an action
+    // (the eventFilter would otherwise consume it and synthesize that action's
+    // default key). Synthesized gamepad key events keep flowing to QML so a
+    // pad's Back button can still cancel the overlay.
+    Q_INVOKABLE void setRemapCapture(bool active);
+
 signals:
     void gamepadConnectedChanged();
     void lastInputDeviceChanged();
@@ -54,13 +64,12 @@ signals:
     // (fullscreen mpv holds OS focus on macOS, which clears QML active focus).
     // main.cpp connects this to MpvController::sendKey.
     void mpvKeyRequested(const QString &key);
-    // A raw press on the auxiliary "Consumer Control" input device (Linux
-    // only, see openConsumerControlDevice()) that Qt's own key event delivery
-    // never sees, e.g. a remote's Home/Back/Menu/colored/zoom buttons. Carries
-    // an opaque extended key id (keyDisplayName() and the remote_keymap.*
-    // settings both accept it the same as a real Qt::Key). The remap capture
-    // screen listens for this alongside Keys.onPressed so those buttons are
-    // bindable too.
+    // Capture-mode reporting (see setRemapCapture): a raw press on any of the
+    // three remappable input paths — a real keyboard key (its Qt::Key), a
+    // Consumer Control button (kEvdevKeyBase + Linux KEY_* code; Linux only,
+    // see openConsumerControlDevice()), or a mouse button (kMouseButtonBase +
+    // Qt::MouseButton). keyDisplayName() and the remote_keymap.* settings
+    // accept all three id spaces alike. Only emitted while capture is active.
     void auxButtonPressed(int extendedKeyId);
 
 protected:
@@ -97,6 +106,7 @@ private:
     void handleButton(SDL_JoystickID which, Uint8 button, bool pressed);
     void handleAxis(SDL_JoystickID which, Uint8 axis, Sint16 value);
     void pressAction(Action a);
+    void beginPress(Action a);
     void releaseAction(Action a);
     void deliverPress(Action a, bool autoRepeat);
     void postKey(int qtKey, QEvent::Type type, bool autoRepeat);
@@ -132,6 +142,7 @@ private:
     QHash<int, Action> m_keyRemap;                   // Qt::Key or extended evdev id → Action
     SDL_JoystickID m_lastActiveController = -1;      // labels follow the pad last touched
     Action m_heldDirection = Action::None;
+    bool m_remapCapture = false;                     // see setRemapCapture()
 
 #ifdef Q_OS_LINUX
     int m_consumerFd = -1;

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -11,6 +11,8 @@
 
 class QQuickWindow;
 class QKeyEvent;
+class QSocketNotifier;
+class AppCore;
 
 // Centralized gamepad input. SDL controller buttons/axes are mapped to a small
 // set of named actions (up/down/left/right/select/back/play_pause), and each
@@ -18,6 +20,12 @@ class QKeyEvent;
 // root window — so every existing Keys.onPressed handler (including the Player
 // views that forward keys to mpv over IPC) works without gamepad-specific code.
 // Defaults can be overridden per-input in $DATA_ROOT/input.cfg (live-reloaded).
+//
+// The same Action/synthesized-key machinery also backs keyboard/remote-button
+// remapping (Settings > Remote Controls): an extra physical key can be bound to
+// one of the six actions via config.json's "remote_keymap.<action>" settings,
+// on top of (never replacing) that action's default key, see keyRemap handling
+// in eventFilter().
 class InputManager : public QObject {
     Q_OBJECT
     Q_PROPERTY(bool gamepadConnected READ gamepadConnected NOTIFY gamepadConnectedChanged)
@@ -25,7 +33,7 @@ class InputManager : public QObject {
     Q_PROPERTY(QVariantMap hints READ hints NOTIFY hintsChanged)
 
 public:
-    explicit InputManager(const QString &dataRoot, QObject *parent = nullptr);
+    explicit InputManager(const QString &dataRoot, AppCore *appCore, QObject *parent = nullptr);
     ~InputManager() override;
 
     void setTargetWindow(QQuickWindow *window);
@@ -33,6 +41,10 @@ public:
     bool gamepadConnected() const { return !m_controllers.isEmpty(); }
     QString lastInputDevice() const { return m_lastInputDevice; }
     QVariantMap hints() const { return m_hints; }
+
+    // Human-readable name for a Qt::Key value (e.g. "Return", "O", "F5"), for
+    // the remap screen to show what's currently bound. Used from QML.
+    Q_INVOKABLE QString keyDisplayName(int qtKey) const;
 
 signals:
     void gamepadConnectedChanged();
@@ -42,6 +54,14 @@ signals:
     // (fullscreen mpv holds OS focus on macOS, which clears QML active focus).
     // main.cpp connects this to MpvController::sendKey.
     void mpvKeyRequested(const QString &key);
+    // A raw press on the auxiliary "Consumer Control" input device (Linux
+    // only, see openConsumerControlDevice()) that Qt's own key event delivery
+    // never sees, e.g. a remote's Home/Back/Menu/colored/zoom buttons. Carries
+    // an opaque extended key id (keyDisplayName() and the remote_keymap.*
+    // settings both accept it the same as a real Qt::Key). The remap capture
+    // screen listens for this alongside Keys.onPressed so those buttons are
+    // bindable too.
+    void auxButtonPressed(int extendedKeyId);
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event) override;
@@ -51,6 +71,8 @@ private slots:
     void onRepeatDelayElapsed();
     void onRepeatTick();
     void onDataDirChanged(const QString &path);
+    void onAppSettingChanged(const QString &key, const QString &value);
+    void onConsumerControlReadable();
 
 private:
     enum class Action { None, Up, Down, Left, Right, Select, Back, PlayPause };
@@ -61,6 +83,10 @@ private:
     void rebuildMapping();
     void loadDefaultMapping();
     void loadUserMapping();
+    void loadKeyRemap();
+    void openConsumerControlDevice();
+    static QString evdevKeyName(int linuxCode);
+    static QString mouseButtonName(int qtButton);
     void noteActiveController(SDL_JoystickID which);
     void handleButton(SDL_JoystickID which, Uint8 button, bool pressed);
     void handleAxis(SDL_JoystickID which, Uint8 axis, Sint16 value);
@@ -82,6 +108,7 @@ private:
     static bool isDirectional(Action a);
 
     QQuickWindow *m_window = nullptr;
+    AppCore *m_appCore = nullptr;
     QString m_dataRoot;
     bool m_sdlReady = false;
 
@@ -96,8 +123,14 @@ private:
     QHash<int, QPair<Action, Action>> m_axisMap;     // SDL_GameControllerAxis → (negative, positive)
     QHash<int, int> m_axisState;                     // per-axis engaged direction: -1 / 0 / +1
     QHash<int, QString> m_labelOverrides;            // SDL button → user display label (input.cfg)
+    QHash<int, Action> m_keyRemap;                   // Qt::Key or extended evdev id → Action
     SDL_JoystickID m_lastActiveController = -1;      // labels follow the pad last touched
     Action m_heldDirection = Action::None;
+
+#ifdef Q_OS_LINUX
+    int m_consumerFd = -1;
+    QSocketNotifier *m_consumerNotifier = nullptr;
+#endif
 
     QString m_lastInputDevice = "keyboard";
     QVariantMap m_hints;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
     NfcReaderBackend    nfcReader(appRoot, dataRoot);
     YouTubeBackend      youtubeBackend(appRoot, dataRoot);
     MpvController       mpvController(appRoot, &appCore);
-    InputManager        inputManager(dataRoot);
+    InputManager        inputManager(dataRoot, &appCore);
     IdleTracker         idleTracker(60);   // disabled until Main.qml applies the saved setting
     UpdateManager       updateManager(appRoot, dataRoot);
 

--- a/views/RemapControls.qml
+++ b/views/RemapControls.qml
@@ -30,16 +30,27 @@ FocusScope {
     property bool capturing: false
     property int captureIndex: -1
 
+    // While capturing, InputManager suspends remap delivery and reports every
+    // real input (keyboard key, Consumer Control button, mouse button) through
+    // auxButtonPressed instead — without this, a key that's already bound
+    // would be consumed by the remap filter and captured as its action's
+    // default key rather than as itself, and capturing a bound mouse/remote
+    // button would fire the action on the same press that bound it.
+    onCapturingChanged: inputManager.setRemapCapture(capturing)
+    Component.onDestruction: inputManager.setRemapCapture(false)
+
     function buildRows() {
         var list = []
         for (var i = 0; i < actions.length; i++) {
             var a = actions[i]
             var stored = appCore.get_setting("", "remote_keymap." + a.id)
-            var hasCustom = stored !== undefined && stored !== "" && stored !== 0
+            // A never-written key arrives as undefined or null depending on
+            // the Qt version's invalid-QVariant conversion — check both.
+            var hasCustom = stored !== undefined && stored !== null && stored !== "" && stored !== 0
             list.push({
                 id: a.id,
                 label: a.label,
-                value: hasCustom ? ("+ " + inputManager.keyDisplayName(stored)) : "(default only)"
+                value: hasCustom ? ("default + " + inputManager.keyDisplayName(stored)) : "default"
             })
         }
         list.push({ id: "reset", label: "Reset to Defaults", isReset: true })
@@ -54,8 +65,18 @@ FocusScope {
     }
 
     function finishCapture(qtKey) {
-        if (captureIndex >= 0 && captureIndex < actions.length)
+        if (captureIndex >= 0 && captureIndex < actions.length) {
+            // One physical button, one action: InputManager's remap table is
+            // keyed by the button, so a key left bound to two actions would
+            // silently fire only one of them while both rows claim it. Clear
+            // it from any other action before saving.
+            for (var i = 0; i < actions.length; i++) {
+                if (i !== captureIndex
+                        && appCore.get_setting("", "remote_keymap." + actions[i].id) === qtKey)
+                    appCore.save_setting("", "remote_keymap." + actions[i].id, 0)
+            }
             appCore.save_setting("", "remote_keymap." + actions[captureIndex].id, qtKey)
+        }
         capturing = false
         captureIndex = -1
         buildRows()
@@ -79,23 +100,27 @@ FocusScope {
         rowList.forceActiveFocus()
     }
 
-    // Buttons on the auxiliary "Consumer Control" input device (Home, Back,
-    // Menu, colored buttons, zoom, etc. on some remotes) never generate a Qt
-    // key event at all, so the capture overlay's Keys.onPressed can't see
-    // them, this is the other half of that capture, fed by InputManager
-    // reading the device directly. See InputManager::openConsumerControlDevice.
+    // The single capture feed: while capturing, InputManager reports every
+    // real input — keyboard key, Consumer Control button, mouse button —
+    // through this one signal (see setRemapCapture). Back-family keys cancel
+    // instead of binding, so there is always a guaranteed way out.
     Connections {
         target: inputManager
         function onAuxButtonPressed(extendedKeyId) {
-            if (remapRoot.capturing)
+            if (!remapRoot.capturing)
+                return
+            if (extendedKeyId === Qt.Key_Escape || extendedKeyId === Qt.Key_Backspace
+                    || extendedKeyId === Qt.Key_Back)
+                remapRoot.cancelCapture()
+            else
                 remapRoot.finishCapture(extendedKeyId)
         }
     }
 
     // Header
     AppBar {
-        iconSource: "../../assets/images/settings.svg"
-        title: "Remote Controls"
+        iconSource: "../../assets/images/keyboard.svg"
+        title: "Controls"
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: root.sh * 0.125 //60
@@ -178,7 +203,7 @@ FocusScope {
         height: root.sh * 0.0583333 //28
         clip: true
         Text {
-            text: "Adds an extra button for that action, the default key keeps working"
+            text: "Map one additional button for each action\n(the default button will continue to function)"
             color: root.primaryColor
             font.family: root.globalFont
             font.pixelSize: root.sh * 0.0291667 //14
@@ -210,22 +235,17 @@ FocusScope {
         visible: remapRoot.capturing
         focus: remapRoot.capturing
 
-        // Any key other than Back/Escape becomes the new binding; Back always
-        // cancels rather than being bindable, so there's always a guaranteed
-        // way out of this screen. Autorepeat is ignored: the same physical
-        // press that opened this overlay is often still held when OS repeat
-        // kicks in, and without this check that repeat immediately "finishes"
-        // capture with the very key that started it.
+        // Real keys never reach here while capturing — InputManager swallows
+        // them and reports through auxButtonPressed (see the Connections
+        // above). What still arrives is the synthesized default-key events a
+        // gamepad produces: let its Back button cancel, and swallow the rest
+        // so a pad press can't bind its synthesized key or leak into the list
+        // underneath. Autorepeat is ignored: the press that opened this
+        // overlay may still be held when repeat kicks in.
         Keys.onPressed: function(event) {
-            if (event.isAutoRepeat) {
-                event.accepted = true
-                return
-            }
-            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+            if (!event.isAutoRepeat
+                    && (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back))
                 remapRoot.cancelCapture()
-            } else {
-                remapRoot.finishCapture(event.key)
-            }
             event.accepted = true
         }
 
@@ -235,7 +255,7 @@ FocusScope {
 
             Text {
                 text: remapRoot.captureIndex >= 0
-                      ? ("PRESS A BUTTON FOR " + remapRoot.actions[remapRoot.captureIndex].label.toUpperCase())
+                      ? ("PRESS A NEW BUTTON FOR [" + remapRoot.actions[remapRoot.captureIndex].label.toUpperCase() + "]")
                       : ""
                 color: root.accentColor
                 font.family: root.globalFont

--- a/views/RemapControls.qml
+++ b/views/RemapControls.qml
@@ -1,0 +1,254 @@
+import QtQuick
+import Components
+
+// Remote/keyboard button remapping, lets an extra physical key (e.g. a
+// remote's "OK" button sending a code the app doesn't otherwise recognize)
+// also fire one of the six navigation actions, on top of that action's
+// default key. Backed by InputManager's keyRemap table (config.json
+// app.remote_keymap.<action>), which is additive: it never removes an
+// action's default key, so a bad remap can't lock the menus out from a
+// plain keyboard. See src/input/InputManager.cpp for the runtime side.
+FocusScope {
+    id: remapRoot
+
+    signal navigateTo(string path, var params, var listState)
+    signal goBack()
+
+    property var navParams: ({})
+    property var navListState: ({})
+
+    readonly property var actions: [
+        { id: "up",     label: "Up" },
+        { id: "down",   label: "Down" },
+        { id: "left",   label: "Left" },
+        { id: "right",  label: "Right" },
+        { id: "select", label: "Select / OK" },
+        { id: "back",   label: "Back" }
+    ]
+
+    property var rows: []
+    property bool capturing: false
+    property int captureIndex: -1
+
+    function buildRows() {
+        var list = []
+        for (var i = 0; i < actions.length; i++) {
+            var a = actions[i]
+            var stored = appCore.get_setting("", "remote_keymap." + a.id)
+            var hasCustom = stored !== undefined && stored !== "" && stored !== 0
+            list.push({
+                id: a.id,
+                label: a.label,
+                value: hasCustom ? ("+ " + inputManager.keyDisplayName(stored)) : "(default only)"
+            })
+        }
+        list.push({ id: "reset", label: "Reset to Defaults", isReset: true })
+        rows = list
+        if (rowList.currentIndex < 0 || rowList.currentIndex >= rows.length)
+            rowList.currentIndex = 0
+    }
+
+    function startCapture(idx) {
+        captureIndex = idx
+        capturing = true
+    }
+
+    function finishCapture(qtKey) {
+        if (captureIndex >= 0 && captureIndex < actions.length)
+            appCore.save_setting("", "remote_keymap." + actions[captureIndex].id, qtKey)
+        capturing = false
+        captureIndex = -1
+        buildRows()
+        rowList.forceActiveFocus()
+    }
+
+    function cancelCapture() {
+        capturing = false
+        captureIndex = -1
+        rowList.forceActiveFocus()
+    }
+
+    function resetAll() {
+        for (var i = 0; i < actions.length; i++)
+            appCore.save_setting("", "remote_keymap." + actions[i].id, 0)
+        buildRows()
+    }
+
+    Component.onCompleted: {
+        buildRows()
+        rowList.forceActiveFocus()
+    }
+
+    // Buttons on the auxiliary "Consumer Control" input device (Home, Back,
+    // Menu, colored buttons, zoom, etc. on some remotes) never generate a Qt
+    // key event at all, so the capture overlay's Keys.onPressed can't see
+    // them, this is the other half of that capture, fed by InputManager
+    // reading the device directly. See InputManager::openConsumerControlDevice.
+    Connections {
+        target: inputManager
+        function onAuxButtonPressed(extendedKeyId) {
+            if (remapRoot.capturing)
+                remapRoot.finishCapture(extendedKeyId)
+        }
+    }
+
+    // Header
+    AppBar {
+        iconSource: "../../assets/images/settings.svg"
+        title: "Remote Controls"
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125 //60
+        anchors.leftMargin: root.sw * 0.125 //80
+    }
+
+    ListView {
+        id: rowList
+        model: remapRoot.rows
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.25 //120
+        anchors.leftMargin: root.sw * 0.115625 //74
+        width: root.sw * 0.76875 //492
+        height: root.sh * 0.525 //252
+        clip: true
+        focus: !remapRoot.capturing
+
+        Keys.onUpPressed:   currentIndex = Math.max(0, currentIndex - 1)
+        Keys.onDownPressed: currentIndex = Math.min(rows.length - 1, currentIndex + 1)
+        Keys.onReturnPressed: {
+            var row = remapRoot.rows[currentIndex]
+            if (!row) return
+            if (row.isReset) remapRoot.resetAll()
+            else remapRoot.startCapture(currentIndex)
+        }
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                remapRoot.goBack()
+                event.accepted = true
+            }
+        }
+
+        delegate: Item {
+            width: rowList.width
+            height: root.sh * 0.0583333 //28
+
+            Rectangle {
+                anchors.fill: parent
+                color: rowList.currentIndex === index ? root.accentColor : "transparent"
+
+                Text {
+                    text: modelData.label || ""
+                    color: rowList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    anchors.verticalCenter: parent.verticalCenter
+                    topPadding: root.sh * 0.0041667 //2
+                    leftPadding: root.sw * 0.009375 //6
+                    rightPadding: root.sw * 0.009375 //6
+                    bottomPadding: root.sh * 0.00625 //3
+                    font.pixelSize: root.sh * 0.05 //24
+                }
+
+                Text {
+                    visible: !modelData.isReset
+                    text: modelData.value || ""
+                    color: rowList.currentIndex === index ? root.surfaceColor : root.tertiaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.right: parent.right
+                    anchors.rightMargin: root.sw * 0.009375 //6
+                    font.pixelSize: root.sh * 0.0375 //18
+                }
+            }
+        }
+    }
+
+    // --- HELP TEXT ---
+    Rectangle {
+        visible: !remapRoot.capturing
+        property color baseColor: root.primaryColor
+        color: Qt.rgba(baseColor.r, baseColor.g, baseColor.b, 0.2)
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1583333 //76
+        anchors.leftMargin: root.sw * 0.125 //80
+        width: root.sw * 0.75 //480
+        height: root.sh * 0.0583333 //28
+        clip: true
+        Text {
+            text: "Adds an extra button for that action, the default key keeps working"
+            color: root.primaryColor
+            font.family: root.globalFont
+            font.pixelSize: root.sh * 0.0291667 //14
+            wrapMode: Text.WordWrap
+            anchors.fill: parent
+            anchors.margins: root.sw * 0.0125 //6
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+
+    // --- FOOTER ---
+    Text {
+        visible: !remapRoot.capturing
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":SET"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667 //50
+        anchors.leftMargin: root.sw * 0.125 //80
+        font.pixelSize: root.sh * 0.0333333 //16
+    }
+
+    // --- CAPTURE OVERLAY ---
+    Rectangle {
+        anchors.fill: parent
+        color: root.surfaceColor
+        visible: remapRoot.capturing
+        focus: remapRoot.capturing
+
+        // Any key other than Back/Escape becomes the new binding; Back always
+        // cancels rather than being bindable, so there's always a guaranteed
+        // way out of this screen. Autorepeat is ignored: the same physical
+        // press that opened this overlay is often still held when OS repeat
+        // kicks in, and without this check that repeat immediately "finishes"
+        // capture with the very key that started it.
+        Keys.onPressed: function(event) {
+            if (event.isAutoRepeat) {
+                event.accepted = true
+                return
+            }
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                remapRoot.cancelCapture()
+            } else {
+                remapRoot.finishCapture(event.key)
+            }
+            event.accepted = true
+        }
+
+        Column {
+            anchors.centerIn: parent
+            spacing: root.sh * 0.025 //12
+
+            Text {
+                text: remapRoot.captureIndex >= 0
+                      ? ("PRESS A BUTTON FOR " + remapRoot.actions[remapRoot.captureIndex].label.toUpperCase())
+                      : ""
+                color: root.accentColor
+                font.family: root.globalFont
+                font.pixelSize: root.sh * 0.05 //24
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Text {
+                text: root.hints.back + ":CANCEL"
+                color: root.tertiaryColor
+                font.family: root.globalFont
+                font.pixelSize: root.sh * 0.0333333 //16
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+        }
+    }
+}

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -144,17 +144,17 @@ FocusScope {
         items.push({ type: "section", label: "Application" })
         items.push({
             type: "submenu",
-            key: "remote_controls",
-            label: "Remote Controls",
+            key: "remap_controls",
+            label: "Controls",
             moduleId: ""
         })
         items.push({
             type: "submenu",
             key: "software_update",
-            label: "Update 240-MP",
+            label: "Update",
             moduleId: ""
         })
-        items.push({ type: "quit", label: "Quit 240-MP" })
+        items.push({ type: "quit", label: "Quit" })
 
         settingsItems = items
 
@@ -261,7 +261,7 @@ FocusScope {
             if (row && row.type === "submenu") {
                 if (row.key === "software_update")
                     settingsRoot.navigateTo("views/Update.qml", {}, { currentIndex: settingsList.currentIndex })
-                else if (row.key === "remote_controls")
+                else if (row.key === "remap_controls")
                     settingsRoot.navigateTo("views/RemapControls.qml", {}, { currentIndex: settingsList.currentIndex })
                 else
                     settingsRoot.navigateTo("views/ModuleSettings.qml", { moduleId: row.moduleId }, { currentIndex: settingsList.currentIndex })

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -144,6 +144,12 @@ FocusScope {
         items.push({ type: "section", label: "Application" })
         items.push({
             type: "submenu",
+            key: "remote_controls",
+            label: "Remote Controls",
+            moduleId: ""
+        })
+        items.push({
+            type: "submenu",
             key: "software_update",
             label: "Update 240-MP",
             moduleId: ""
@@ -255,6 +261,8 @@ FocusScope {
             if (row && row.type === "submenu") {
                 if (row.key === "software_update")
                     settingsRoot.navigateTo("views/Update.qml", {}, { currentIndex: settingsList.currentIndex })
+                else if (row.key === "remote_controls")
+                    settingsRoot.navigateTo("views/RemapControls.qml", {}, { currentIndex: settingsList.currentIndex })
                 else
                     settingsRoot.navigateTo("views/ModuleSettings.qml", { moduleId: row.moduleId }, { currentIndex: settingsList.currentIndex })
             } else if (row && row.type === "quit") {


### PR DESCRIPTION
## Summary

Adds a "Remote Controls" screen under Settings for remapping an extra physical
button to one of the six navigation actions (up/down/left/right/select/back).
This is additive: it never removes an action's existing default key, it only
adds one more key that also fires that action, so a bad remap can't lock
someone out of the menus.

Covers three input paths, since a lot of cheap USB remotes split themselves
across multiple HID interfaces:
1. Ordinary keyboard keys, via Qt's normal QKeyEvent delivery.
2. "Consumer Control" HID buttons (Home, Back, Menu, colored buttons, zoom,
   etc.) — these show up as a *separate* /dev/input/eventN device from the
   keyboard interface and never reach Qt as key events at all, so this reads
   that device directly and feeds it into the same remap table.
3. Mouse button clicks — some remotes wire their center/OK button as a literal
   left click instead of any kind of key.

Also fixes a real bug in `AppCore::get_setting()`: it wasn't symmetric with
`save_setting()` for dot-notation keys (e.g. `remote_keymap.select`) —
`save_setting` correctly nested those under a sub-object, but `get_setting`
only ever looked for a literal flat key with a dot in it, which never existed,
so any dotted setting silently always read back as invalid. This affects any
future dotted setting, not just this feature.

Files: `src/input/InputManager.h/.cpp`, `views/RemapControls.qml` (new),
`views/Settings.qml`, `src/AppCore.cpp`, `src/main.cpp`

## Testing

- Platform(s) tested: Raspberry Pi 5 (Full KMS)
- Display / output tested: CRT via S-Video

Tested with a physical USB remote exposing Keyboard/Consumer Control/Mouse
interfaces. Verified capture works for all three input types, verified
default bindings still work after remapping, verified reset-to-defaults,
verified a held key's OS autorepeat doesn't self-complete a capture with the
wrong key. Not tested on macOS.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
