### PR TITLE
fix(mpv): ambient mode audio device selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(240mp
     src/input/IdleTracker.cpp
     src/update/UpdateManager.cpp
     $<$<BOOL:${APPLE}>:src/macos_utils.mm>
+    $<$<NOT:$<BOOL:${APPLE}>>:src/linux_audio_utils.cpp>
 )
 
 target_compile_definitions(240mp PRIVATE APP_VERSION="${APP_VERSION}")

--- a/src/linux_audio_utils.cpp
+++ b/src/linux_audio_utils.cpp
@@ -1,0 +1,41 @@
+#include "linux_audio_utils.h"
+#include <QFile>
+#include <QDir>
+#include <QRegularExpression>
+
+// ALSA's "default" pcm can resolve to card 0, and on this hardware card 0 is
+// whatever happened to enumerate first, including a USB dongle (e.g. the
+// remote receiver) that exposes a stub audio interface with no real playback
+// path. That sends mpv down a dmix/pipewire fallback chain that dead-ends
+// ("couldn't open play stream") instead of reaching the actual HDMI output.
+// Bypass "default" entirely and target the vc4-hdmi ALSA card directly,
+// preferring whichever HDMI connector DRM reports as connected.
+QString detectAlsaAudioDevice() {
+    QFile cardsFile(QStringLiteral("/proc/asound/cards"));
+    if (!cardsFile.open(QFile::ReadOnly | QFile::Text))
+        return {};
+
+    QStringList vc4Cards; // card names, in card-index order
+    static const QRegularExpression re(QStringLiteral(R"(^\s*\d+\s+\[(\S+)\s*\]:\s*(.+)$)"));
+    for (const QString &line : QString::fromUtf8(cardsFile.readAll()).split('\n')) {
+        const QRegularExpressionMatch m = re.match(line);
+        if (m.hasMatch() && m.captured(2).contains(QLatin1String("vc4-hdmi")))
+            vc4Cards << m.captured(1).trimmed();
+    }
+    if (vc4Cards.isEmpty())
+        return {};
+
+    // Match vc4hdmiN to DRM connector HDMI-A-(N+1) and prefer one reporting
+    // "connected"; falls back to the first HDMI card if none are found connected.
+    for (int i = 0; i < vc4Cards.size(); ++i) {
+        QDir drmDir(QStringLiteral("/sys/class/drm"));
+        for (const QString &entry : drmDir.entryList({QString("card*-HDMI-A-%1").arg(i + 1)}, QDir::Dirs)) {
+            QFile statusFile(drmDir.filePath(entry) + "/status");
+            if (statusFile.open(QFile::ReadOnly | QFile::Text) &&
+                statusFile.readAll().trimmed() == "connected") {
+                return QStringLiteral("alsa/plughw:CARD=%1,DEV=0").arg(vc4Cards[i]);
+            }
+        }
+    }
+    return QStringLiteral("alsa/plughw:CARD=%1,DEV=0").arg(vc4Cards.first());
+}

--- a/src/linux_audio_utils.h
+++ b/src/linux_audio_utils.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <QString>
+
+#ifdef Q_OS_LINUX
+// Picks the ALSA audio-device string mpv should target on this Pi. ALSA's
+// "default" pcm can resolve to whatever card happened to enumerate first
+// (e.g. a USB dongle's stub audio interface), not the real HDMI output, so
+// callers use this instead of leaving mpv on "default". Returns an empty
+// string if no vc4-hdmi card is found (e.g. running on non-RPi hardware),
+// in which case the caller should leave mpv's audio-device alone.
+QString detectAlsaAudioDevice();
+#endif

--- a/src/modules/ambient_mode/AmbientModeBackend.cpp
+++ b/src/modules/ambient_mode/AmbientModeBackend.cpp
@@ -1,9 +1,11 @@
 #include "AmbientModeBackend.h"
+#include "../../linux_audio_utils.h"
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStandardPaths>
+#include <QTimer>
 #include <QDebug>
 
 static const QStringList kVideoExts = {
@@ -72,9 +74,16 @@ QVariantList AmbientModeBackend::getAudioFiles() const
     return scanFiles(kAudioExts);
 }
 
-void AmbientModeBackend::startAudio(const QString &path)
+void AmbientModeBackend::startAudio(const QStringList &paths, bool shuffle)
 {
+    m_audioStopRequested = true; // covers the stopAudio() call below
     stopAudio();
+
+    if (paths.isEmpty())
+        return;
+
+    m_audioPaths   = paths;
+    m_audioShuffle = shuffle;
 
 #ifdef Q_OS_MACOS
     {
@@ -94,19 +103,33 @@ void AmbientModeBackend::startAudio(const QString &path)
     }
 
     QStringList args;
-    args << path
+    args << paths
          << QStringLiteral("--no-video")
-         << QStringLiteral("--loop-playlist=inf")
-         << QStringLiteral("--no-terminal")
+         << QStringLiteral("--loop-playlist=inf");
+    if (shuffle)
+        args << QStringLiteral("--shuffle");
+#ifdef Q_OS_LINUX
+    {
+        const QString audioDevice = detectAlsaAudioDevice();
+        if (!audioDevice.isEmpty())
+            args << QStringLiteral("--audio-device=%1").arg(audioDevice);
+    }
+#endif
+    args << QStringLiteral("--no-terminal")
          << QStringLiteral("--really-quiet");
 
     m_audioProcess = new QProcess(this);
+    connect(m_audioProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, &AmbientModeBackend::onAudioProcessFinished);
     m_audioProcess->start(bin, args);
-    qDebug("[AmbientMode] audio process started: %s", qPrintable(path));
+    m_audioStopRequested = false;
+    qDebug("[AmbientMode] audio process started: %d track(s), shuffle=%d", paths.size(), shuffle);
 }
 
 void AmbientModeBackend::stopAudio()
 {
+    m_audioStopRequested = true;
+    m_audioRespawnCount  = 0;
     if (!m_audioProcess)
         return;
     if (m_audioProcess->state() != QProcess::NotRunning) {
@@ -116,6 +139,30 @@ void AmbientModeBackend::stopAudio()
     m_audioProcess->deleteLater();
     m_audioProcess = nullptr;
     qDebug("[AmbientMode] audio process stopped");
+}
+
+// The companion audio track has no video fallback to lean on, so if its mpv
+// process dies on its own (an ALSA hiccup, a transient device stall), the
+// screen keeps playing but goes silent with nothing to notice or recover.
+// Mirrors NfcReaderBackend's bounded-respawn watchdog for the same class of
+// "external process wedged/died mid-session" failure.
+static constexpr int kMaxAudioRespawns = 5;
+
+void AmbientModeBackend::onAudioProcessFinished()
+{
+    if (m_audioStopRequested || m_audioPaths.isEmpty())
+        return;
+
+    if (m_audioRespawnCount >= kMaxAudioRespawns) {
+        qWarning("[AmbientMode] audio process keeps dying, giving up until next playback session");
+        return;
+    }
+    m_audioRespawnCount++;
+    qWarning("[AmbientMode] audio process exited unexpectedly, restarting (attempt %d/%d)",
+              m_audioRespawnCount, kMaxAudioRespawns);
+    const QStringList paths = m_audioPaths;
+    const bool shuffle = m_audioShuffle;
+    QTimer::singleShot(1000, this, [this, paths, shuffle]() { startAudio(paths, shuffle); });
 }
 
 void AmbientModeBackend::onSettingChanged(const QString &moduleId, const QString &key, const QVariant &value)

--- a/src/modules/ambient_mode/AmbientModeBackend.h
+++ b/src/modules/ambient_mode/AmbientModeBackend.h
@@ -13,11 +13,14 @@ public:
     Q_INVOKABLE QVariantList getAudioFiles() const;
     Q_INVOKABLE QString      mediaRoot() const;
     Q_INVOKABLE void         setMediaRoot(const QString &path);
-    Q_INVOKABLE void         startAudio(const QString &path);
+    Q_INVOKABLE void         startAudio(const QStringList &paths, bool shuffle = false);
     Q_INVOKABLE void         stopAudio();
 
 public slots:
     void onSettingChanged(const QString &moduleId, const QString &key, const QVariant &value);
+
+private slots:
+    void onAudioProcessFinished();
 
 private:
     QVariantList scanFiles(const QStringList &extensions) const;
@@ -25,4 +28,8 @@ private:
     QString   m_dataRoot;
     QString   m_mediaRoot;
     QProcess *m_audioProcess = nullptr;
+    QStringList m_audioPaths;
+    bool        m_audioShuffle = false;
+    bool        m_audioStopRequested = false;
+    int         m_audioRespawnCount = 0;
 };

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -1,5 +1,6 @@
 #include "MpvController.h"
 #include "../AppCore.h"
+#include "../linux_audio_utils.h"
 #include <QDir>
 #include <QFile>
 #include <QProcessEnvironment>
@@ -210,6 +211,16 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
             args << QString("--script=%1").arg(ssScript);
         }
     }
+
+#ifdef Q_OS_LINUX
+    // Skip when muted (e.g. ambient mode's companion audio track is playing
+    // the audio instead), no audio device is opened either way.
+    if (!muteAudio) {
+        const QString audioDevice = detectAlsaAudioDevice();
+        if (!audioDevice.isEmpty())
+            args << QStringLiteral("--audio-device=%1").arg(audioDevice);
+    }
+#endif
 
     // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
     // primary plane between two consecutive same-size/format stills, so a photo


### PR DESCRIPTION
## Summary

Ambient mode's companion audio track (and any unmuted mpv audio) could go
silent because ALSA's "default" pcm device resolves to whatever card
enumerates first — on my Pi 5 that was a USB remote dongle's stub audio
interface, not the real HDMI output, and that path dead-ends in a broken
dmix/pipewire fallback ("couldn't open play stream").

Adds runtime detection of the correct `vc4-hdmi` ALSA card (parsing
`/proc/asound/cards`, preferring whichever HDMI connector `/sys/class/drm`
reports as connected) and passes it explicitly via `--audio-device`, instead
of leaving mpv on "default". Falls back to leaving mpv's audio-device alone
if no vc4-hdmi card is found, so this is a no-op on macOS or non-Pi hardware.

Extracted the detection into `src/linux_audio_utils.h/.cpp` since both
`MpvController` and `AmbientModeBackend` need it — mirrors the existing
`src/macos_utils.h/.mm` pattern for a shared platform helper.

Also adds a bounded auto-restart watchdog for the ambient audio process: it
has no video to fall back on, so if it dies on its own (an ALSA hiccup, a
transient USB/device stall) the screen kept playing silently with nothing to
notice or recover. Mirrors `NfcReaderBackend`'s existing wedge-detection/
respawn pattern for the same class of failure.

Files: `src/linux_audio_utils.h/.cpp` (new), `src/player/MpvController.cpp`,
`src/modules/ambient_mode/AmbientModeBackend.h/.cpp`, `CMakeLists.txt`

## Testing

- Platform(s) tested: Raspberry Pi 5 (Full KMS)
- Display / output tested: CRT via S-Video, audio via HDMI-to-composite converter

Confirmed audio plays through the correct output. Confirmed the watchdog
restarts the audio process after killing it by hand mid-session. Not tested
on macOS (the code path is Linux-only and a no-op elsewhere).

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
