### PR TITLE
feat(mpv): video output levels override

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,18 +217,21 @@ I think of it like this:
 ```
 app constants → 
   app per-playback → 
-    device decode (user-overridable in config) → 
-      ~/.config/mpv/mpv.conf
+    app presentation (user-set in Settings) → 
+      device decode (user-overridable in config) → 
+        ~/.config/mpv/mpv.conf
 ```
 
 | Layer | Examples | Owner | Where |
 |---|---|---|---|
 | **App constants** | `--input-ipc-server`, `--input-conf`, `--osc`, `--script`, `--log-file`, `--no-input-terminal` | App only | command-line |
 | **App per-playback** | `--start`, `--aid`, `--sub-file`, `--http-header-fields` (stream URL, tokens) | App only | command-line |
+| **App presentation** | `--panscan` (Auto Crop), `--video-output-levels` (Video Levels) | User, via a Settings row | command-line |
 | **Device decode** | `--vo` / `--gpu-context` / `--hwdec` | App auto-detects; user may override via `mpv_video_args` | command-line |
 | **User prefs** | `deinterlace`, `cache`, `sub-scale`, profiles | User | `mpv.conf` |
 
-- The first three layers are app-owned and the first two are load-bearing because they wire the IPC control channel, the input/OSC bridge, and (headless) the DRM/VT hand-off. Changing them would break functionality in the app, not just playback, so they are never user-overridable. The 3rd layer (*device decode*) allows a direct user path to override video decode settings if per device tweaks are needed.
+- The first four layers are app-owned and the first two are load-bearing because they wire the IPC control channel, the input/OSC bridge, and (headless) the DRM/VT hand-off. Changing them would break functionality in the app, not just playback, so they are never user-overridable. The last two app layers are the ones the user can steer: *app presentation* through a Settings row (Auto Crop, Video Levels) for the knobs worth reaching without a keyboard, and *device decode* through the `mpv_video_args` override if per device tweaks are needed.
+- A presentation setting left at its default emits **no flag at all** (Video Levels on `Auto`, Auto Crop `Off`), so a `video-output-levels=` line in someone's `mpv.conf` still applies; picking Limited/Full puts it on the command line, where it wins.
 - And all app layers are command-line, so they all win over `mpv.conf`. I do pass no `--no-config`, so mpv will look to read `~/.config/mpv/mpv.conf` on launch, which means users can add anything the app doesn't set explicitly direclty in their MPV config.
 
 ### Custom OSC (Lua)

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -211,17 +211,6 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         }
     }
 
-    // Video Levels: leave mpv's auto-detection alone unless the user has
-    // explicitly overridden it (e.g. content looking washed out/crushed on a
-    // given display regardless of the source file's tagged range).
-    if (m_appCore) {
-        const QString levels = m_appCore->get_setting(QString(), "video_output_levels").toString();
-        if (levels == QLatin1String("Limited"))
-            args << QStringLiteral("--video-output-levels=limited");
-        else if (levels == QLatin1String("Full"))
-            args << QStringLiteral("--video-output-levels=full");
-    }
-
     // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
     // primary plane between two consecutive same-size/format stills, so a photo
     // playlist freezes on the first frame while the clock advances. This script
@@ -335,6 +324,15 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
     // matching the 1080p Playback trade-off. The OSC CROP button still toggles live.
     if (autoCropEnabled() && !cropUnavailable())
         args << QStringLiteral("--panscan=1");
+
+    // Video Levels: the RGB range mpv converts YUV into. Emitted only when the
+    // user has overridden it, so "Auto" leaves both mpv's own default and
+    // anything in their mpv.conf untouched. Sits before appendVideoArgs so an
+    // explicit --video-output-levels inside the mpv_video_args override still
+    // wins (later on the command line).
+    const QString outputLevels = videoOutputLevels();
+    if (!outputLevels.isEmpty())
+        args << QStringLiteral("--video-output-levels=%1").arg(outputLevels);
 
     m_process = new QProcess(this);
     m_process->setProcessChannelMode(QProcess::MergedChannels);
@@ -728,6 +726,21 @@ bool MpvController::autoCropEnabled() const {
         return false;
     const QVariant v = m_appCore->get_setting(QString(), "auto_crop");
     return v.toString().compare(QStringLiteral("On"), Qt::CaseInsensitive) == 0;
+}
+
+QString MpvController::videoOutputLevels() const {
+    // Default "Auto" → no flag at all, leaving mpv's own default (full-range RGB
+    // out) and anything the user set in mpv.conf in place. Stored by Settings as
+    // a string ("Auto"/"Limited"/"Full") via the list_single row, so compare on
+    // the string form.
+    if (!m_appCore)
+        return {};
+    const QString v = m_appCore->get_setting(QString(), "video_output_levels").toString();
+    if (v.compare(QStringLiteral("Limited"), Qt::CaseInsensitive) == 0)
+        return QStringLiteral("limited");
+    if (v.compare(QStringLiteral("Full"), Qt::CaseInsensitive) == 0)
+        return QStringLiteral("full");
+    return {};
 }
 
 bool MpvController::cropUnavailable() const {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -211,6 +211,17 @@ void MpvController::loadAndPlay(const QString &url, float startSeconds,
         }
     }
 
+    // Video Levels: leave mpv's auto-detection alone unless the user has
+    // explicitly overridden it (e.g. content looking washed out/crushed on a
+    // given display regardless of the source file's tagged range).
+    if (m_appCore) {
+        const QString levels = m_appCore->get_setting(QString(), "video_output_levels").toString();
+        if (levels == QLatin1String("Limited"))
+            args << QStringLiteral("--video-output-levels=limited");
+        else if (levels == QLatin1String("Full"))
+            args << QStringLiteral("--video-output-levels=full");
+    }
+
     // Still-image playback only: mpv's KMS output (--vo=drm) won't repaint the
     // primary plane between two consecutive same-size/format stills, so a photo
     // playlist freezes on the first frame while the clock advances. This script

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -109,6 +109,9 @@ private:
     // playback ON): --panscan blanks the video there. Gates auto-crop and tells
     // the OSC scripts to hide their CROP button.
     bool cropUnavailable() const;
+    // App-level "video_output_levels" setting (default "Auto"). Returns the mpv
+    // value for --video-output-levels ("limited"/"full"), or empty on Auto/unset.
+    QString videoOutputLevels() const;
     int  getActiveVt() const;
     int  findFreeVt() const;
     int  findQtDrmFd() const;

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -124,6 +124,19 @@ FocusScope {
             moduleId: ""
         })
 
+        // Video Levels: overrides mpv's auto-detected output range. Auto trusts
+        // the source's tagged range; force Limited/Full if content looks washed
+        // out or crushed on your display regardless of what the file is tagged.
+        items.push({
+            type: "list_single",
+            key: "video_output_levels",
+            label: "Video Levels",
+            options: ["Auto", "Limited", "Full"],
+            value: appSettings["video_output_levels"] || "Auto",
+            description: "Override output color range if video looks washed out or crushed\n[AUTO] Trust the source file's tagged range",
+            moduleId: ""
+        })
+
         // MODULES section — only show modules with has_settings
         var hasModuleSettings = false
         for (var i = 0; i < installedModules.length; i++) {

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -112,6 +112,23 @@ FocusScope {
             moduleId: ""
         })
 
+        // Video Output Range, the RGB range mpv converts YUV into. mpv's default
+        // is full range; a display expecting studio (limited) levels renders that
+        // as crushed blacks and blown whites, and the reverse reads as washed-out
+        // gray. Takes effect on the next video.
+        // The key keeps mpv's own name for the option; the label uses the wording
+        // TVs and GPU drivers use for the same control (HDMI RGB range, DRM
+        // "Broadcast RGB"), since that's what the setting is matching.
+        items.push({
+            type: "list_single",
+            key: "video_output_levels",
+            label: "Video Levels",
+            options: ["Auto", "Limited", "Full"],
+            value: appSettings["video_output_levels"] || "Auto",
+            description: "Match the color range your display expects\n[LIMITED] If blacks crush  [FULL] If blacks look gray",
+            moduleId: ""
+        })
+
         // SCREEN SAVER section — single control: OFF disables, a number sets the
         // timeout for both menu idle and playback pause (handled inside mpv).
         items.push({
@@ -121,19 +138,6 @@ FocusScope {
             options: ["OFF", "30", "60", "120"],
             value: appSettings["screensaver_timeout"] || "OFF",
             description: "Prevent CRT burn-in after seconds of inactivity or pause",
-            moduleId: ""
-        })
-
-        // Video Levels: overrides mpv's auto-detected output range. Auto trusts
-        // the source's tagged range; force Limited/Full if content looks washed
-        // out or crushed on your display regardless of what the file is tagged.
-        items.push({
-            type: "list_single",
-            key: "video_output_levels",
-            label: "Video Levels",
-            options: ["Auto", "Limited", "Full"],
-            value: appSettings["video_output_levels"] || "Auto",
-            description: "Override output color range if video looks washed out or crushed\n[AUTO] Trust the source file's tagged range",
             moduleId: ""
         })
 


### PR DESCRIPTION
## Summary

Adds a "Video Levels" setting (Auto/Limited/Full) that overrides mpv's
auto-detected output color range. Auto trusts the source file's tagged
range, same as today; Limited/Full let you force it if content looks washed
out or crushed on a given display regardless of what the file is tagged as.

Files: `views/Settings.qml`, `src/player/MpvController.cpp`

P.S. I'm sorry for the 5 PRs I just felt it was better to do each feature as a single PR :)

## Testing

- Platform(s) tested: Raspberry Pi 5 (Full KMS)
- Display / output tested: CRT via S-Video

Confirmed each of the three options changes mpv's output range as expected.
Not tested on macOS.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
