### PR TITLE
feat(jellyfin): season and episode number in next up/continue watching

### DIFF
--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -262,9 +262,12 @@ FocusScope {
                 Text {
                     id: rowText
                     text: {
-                        var base = (modelData.type === "episode" && modelData.grandparentTitle)
-                                   ? (modelData.grandparentTitle + ": " + (modelData.title || ""))
-                                   : (modelData.title || "")
+                        if (modelData.type === "episode" && modelData.grandparentTitle) {
+                            var sNum = (modelData.parentIndex != null) ? modelData.parentIndex : "?"
+                            var eNum = (modelData.index || modelData.index === 0) ? modelData.index : "?"
+                            return modelData.grandparentTitle + " S" + sNum + "E" + eNum + ": " + (modelData.title || "")
+                        }
+                        var base = modelData.title || ""
                         return modelData.year ? base + " (" + String(modelData.year) + ")" : base
                     }
                     color: (itemList.currentIndex === index && !letterNavActive)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Adds season and episode number to next up and continue watching in the Jellyfin module. 
<img width="1800" height="1169" alt="clipboard_2026-07-17_17-07" src="https://github.com/user-attachments/assets/857cb397-0062-4755-b01d-140c3430e21c" />
## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Used to double check my work

## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->
Tested on MacOS with my Jellyfin server and works for me. 

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
