### PR TITLE
feat(jellyfin): enable letter nav on collections

### DIFF
--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -21,7 +21,7 @@ FocusScope {
     property bool isLoading: false
     property string errorMessage: ""
 
-    // A–Z letter-jump panel - only for the alphabetized full-library list
+    // A–Z letter-jump panel — only for the alphabetized full-library list
     // ("browse"); resume/up_next are not alpha-sorted.
     property bool showLetterNav: mode === "browse" || mode === "folder" || itemListRoot.mode === "boxset"
     property bool letterNavActive: false

--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -21,9 +21,8 @@ FocusScope {
     property bool isLoading: false
     property string errorMessage: ""
 
-    // A–Z letter-jump panel — only for the alphabetized full-library list
-    // ("browse"); resume/up_next are not alpha-sorted.
-    property bool showLetterNav: mode === "browse" || mode === "folder"
+    // A–Z letter-jump panel — works for all list modes
+    property bool showLetterNav: items.length > 0
     property bool letterNavActive: false
     property var letterIndex: []
 
@@ -91,6 +90,8 @@ FocusScope {
             if (itemListRoot.mode !== "boxset") return
             itemListRoot.isLoading = false
             itemListRoot.items = loadedItems
+            if (itemListRoot.showLetterNav)
+                itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
             if (loadedItems.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 itemList.currentIndex = Math.min(restore, loadedItems.length - 1)
@@ -102,6 +103,8 @@ FocusScope {
             if (itemListRoot.mode !== "resume") return
             itemListRoot.isLoading = false
             itemListRoot.items = loadedItems
+            if (itemListRoot.showLetterNav)
+                itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
             if (loadedItems.length > 0) {
                 itemList.currentIndex = 0
                 itemList.positionViewAtIndex(0, ListView.Contain)
@@ -112,6 +115,8 @@ FocusScope {
             if (itemListRoot.mode !== "up_next") return
             itemListRoot.isLoading = false
             itemListRoot.items = loadedItems
+            if (itemListRoot.showLetterNav)
+                itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
             if (loadedItems.length > 0) {
                 itemList.currentIndex = 0
                 itemList.positionViewAtIndex(0, ListView.Contain)
@@ -131,6 +136,8 @@ FocusScope {
             isLoading = false
             errorMessage = ""
             items = navParams.items || []
+            if (showLetterNav)
+                letterIndex = buildLetterIndex(items)
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 itemList.currentIndex = Math.min(restore, items.length - 1)

--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -21,8 +21,9 @@ FocusScope {
     property bool isLoading: false
     property string errorMessage: ""
 
-    // A–Z letter-jump panel — works for all list modes
-    property bool showLetterNav: items.length > 0
+    // A–Z letter-jump panel - only for the alphabetized full-library list
+    // ("browse"); resume/up_next are not alpha-sorted.
+    property bool showLetterNav: mode === "browse" || mode === "folder" || itemListRoot.mode === "boxset"
     property bool letterNavActive: false
     property var letterIndex: []
 
@@ -103,8 +104,6 @@ FocusScope {
             if (itemListRoot.mode !== "resume") return
             itemListRoot.isLoading = false
             itemListRoot.items = loadedItems
-            if (itemListRoot.showLetterNav)
-                itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
             if (loadedItems.length > 0) {
                 itemList.currentIndex = 0
                 itemList.positionViewAtIndex(0, ListView.Contain)
@@ -115,8 +114,6 @@ FocusScope {
             if (itemListRoot.mode !== "up_next") return
             itemListRoot.isLoading = false
             itemListRoot.items = loadedItems
-            if (itemListRoot.showLetterNav)
-                itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
             if (loadedItems.length > 0) {
                 itemList.currentIndex = 0
                 itemList.positionViewAtIndex(0, ListView.Contain)
@@ -136,8 +133,6 @@ FocusScope {
             isLoading = false
             errorMessage = ""
             items = navParams.items || []
-            if (showLetterNav)
-                letterIndex = buildLetterIndex(items)
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 itemList.currentIndex = Math.min(restore, items.length - 1)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
In the Jellyfin module, enables the letter nav to skip to a letter in the collections view 
<img width="1800" height="1169" alt="clipboard_2026-07-17_17-18" src="https://github.com/user-attachments/assets/6dd9d43b-d08f-4043-9886-608d6d0e3f3d" />

## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Used to check my work 
## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->
Tested on MacOS with my Jellyfin server and works for me.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)

Draft because of max open pull requests