### PR TITLE
feat(app core, jellyfin, local files, youtube): add list wraparound

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -395,6 +395,22 @@ FocusScope {
             positionViewAtIndex(currentIndex, ListView.Contain)
         }
 
+        // Up/Down with wraparound. The positionViewAtIndex call is required:
+        // changing currentIndex alone does not scroll a clipped ListView, so
+        // without it a wrap moves the selection off-screen.
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+        }
+
         Keys.onReturnPressed: {
             navigateTo("Detail.qml", { item: model[currentIndex] }, { currentIndex: currentIndex })
         }
@@ -438,7 +454,8 @@ FocusScope {
 **View rules:**
 - Always declare `property var navParams: ({})` — the router passes params via `Loader.setSource`.
 - List views also declare `property var navListState: navParams.navListState || ({})` and restore position in `Component.onCompleted`.
-- `navigateTo` always takes 3 args: `(path, params, listState)` — pass `{ currentIndex: listView.currentIndex }` as listState when pushing to a detail view.
+- `navigateTo` always takes 3 args: `(path, params, listState)` — pass `{ currentIndex: listView.currentIndex }` as listState when pushing to a detail view. Detail views with multiple focus rows (play button / list) also pass `focusRow` in listState and restore it in their data-loaded handler, so backing in lands on the row the user left.
+- Up/Down navigation wraps: past the last item returns to the first and vice versa, always followed by `positionViewAtIndex(..., ListView.Contain)` (see the handlers in Items.qml above). Views with an A–Z letter panel additionally keep `letterList.currentIndex` in sync on every move and wrap the panel itself — `modules/jellyfin/views/Items.qml` is the reference.
 - Leaf views only need `signal goBack()` — no `navigateTo`.
 - Use `root.sh` / `root.sw` for all margins and sizes — never hardcoded pixels. This keeps layouts responsive across CRT (240p/480i, watch overscan) and HDMI/LCD.
 - Access shared state via `moduleRoot.moduleName`, `moduleRoot.moduleIcon`.

--- a/modules/jellyfin/views/Boxset.qml
+++ b/modules/jellyfin/views/Boxset.qml
@@ -183,8 +183,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            categoryList.positionViewAtIndex(categoryList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            categoryList.positionViewAtIndex(categoryList.currentIndex, ListView.Contain)
+        }
         Keys.onReturnPressed: boxsetRoot.selectCategory()
 
         delegate: Item {

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -148,6 +148,12 @@ FocusScope {
     Keys.onUpPressed: {
         if (isLaunching) return
         if (focusRow > 0) focusRow--
+        else if (detail) {
+            var maxRow = 0
+            if (detail.audioStreams && detail.audioStreams.length > 0) maxRow = 1
+            if (detail.subtitleStreams && detail.subtitleStreams.length > 0) maxRow = 2
+            focusRow = maxRow
+        }
     }
     Keys.onDownPressed: {
         if (isLaunching) return
@@ -156,6 +162,7 @@ FocusScope {
             if (detail.audioStreams && detail.audioStreams.length > 0) maxRow = 1
             if (detail.subtitleStreams && detail.subtitleStreams.length > 0) maxRow = 2
             if (focusRow < maxRow) focusRow++
+            else focusRow = 0
         }
     }
     // Debounce: batch rapid arrow-key changes into a single backend save

--- a/modules/jellyfin/views/ItemSeason.qml
+++ b/modules/jellyfin/views/ItemSeason.qml
@@ -67,17 +67,28 @@ FocusScope {
     }
 
     Keys.onUpPressed: {
-        if (focusRow === 1) {
-            if (episodeList.currentIndex > 0) episodeList.currentIndex--
-            else focusRow = 0
+        if (focusRow === 0) {
+            episodeList.currentIndex = episodes.length-1
+            focusRow = 1
+        } else {
+            if (episodes.length === 0) return
+            if (focusRow === 1) {
+                if (episodeList.currentIndex > 0) episodeList.currentIndex--
+                else focusRow = 0
+            }
         }
+        episodeList.positionViewAtIndex(episodeList.currentIndex, ListView.Contain)
     }
     Keys.onDownPressed: {
         if (focusRow === 0) {
+            episodeList.currentIndex = 0
             if (episodes.length > 0) focusRow = 1
         } else {
+            if (episodes.length === 0) return
             if (episodeList.currentIndex < episodes.length - 1) episodeList.currentIndex++
+            else episodeList.currentIndex = focusRow = 0
         }
+        episodeList.positionViewAtIndex(episodeList.currentIndex, ListView.Contain)
     }
     Keys.onReturnPressed: {
         if (focusRow === 0) {

--- a/modules/jellyfin/views/ItemSeason.qml
+++ b/modules/jellyfin/views/ItemSeason.qml
@@ -32,6 +32,7 @@ FocusScope {
             if (loadedItems.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 episodeList.currentIndex = Math.min(restore, loadedItems.length - 1)
+                if (navListState.focusRow === 1) focusRow = 1
                 episodeList.positionViewAtIndex(episodeList.currentIndex, ListView.Contain)
             }
         }
@@ -99,7 +100,7 @@ FocusScope {
             seasonRoot.navigateTo("Item.qml", {
                 item: ep,
                 libraryName: libraryName
-            }, { currentIndex: episodeList.currentIndex })
+            }, { currentIndex: episodeList.currentIndex, focusRow: 1 })
         }
     }
     Keys.onPressed: function(event) {

--- a/modules/jellyfin/views/ItemShow.qml
+++ b/modules/jellyfin/views/ItemShow.qml
@@ -35,6 +35,7 @@ FocusScope {
             if (loadedItems.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                 seasonList.currentIndex = Math.min(restore, loadedItems.length - 1)
+                if (navListState.focusRow === 1) focusRow = 1
                 seasonList.positionViewAtIndex(seasonList.currentIndex, ListView.Contain)
             }
         }
@@ -119,7 +120,7 @@ FocusScope {
                 seriesId: item.itemId,
                 showTitle: item.title,
                 libraryName: libraryName
-            }, { currentIndex: seasonList.currentIndex })
+            }, { currentIndex: seasonList.currentIndex, focusRow: 1 })
         }
     }
     Keys.onPressed: function(event) {

--- a/modules/jellyfin/views/ItemShow.qml
+++ b/modules/jellyfin/views/ItemShow.qml
@@ -83,17 +83,28 @@ FocusScope {
     focus: true
 
     Keys.onUpPressed: {
-        if (focusRow === 1) {
-            if (seasonList.currentIndex > 0) seasonList.currentIndex--
-            else focusRow = 0
+        if (focusRow === 0) {
+            seasonList.currentIndex = seasons.length-1
+            focusRow = 1
+        } else {
+            if (seasons.length === 0) return
+            if (focusRow === 1) {
+                if (seasonList.currentIndex > 0) seasonList.currentIndex--
+                else focusRow = 0
+            } 
         }
+        seasonList.positionViewAtIndex(seasonList.currentIndex, ListView.Contain)
     }
     Keys.onDownPressed: {
         if (focusRow === 0) {
+            seasonList.currentIndex = 0
             if (seasons.length > 0) focusRow = 1
         } else {
+            if (seasons.length === 0) return
             if (seasonList.currentIndex < seasons.length - 1) seasonList.currentIndex++
+            else seasonList.currentIndex = focusRow = 0
         }
+        seasonList.positionViewAtIndex(seasonList.currentIndex, ListView.Contain)
     }
     Keys.onReturnPressed: {
         if (focusRow === 0) {

--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -226,9 +226,40 @@ FocusScope {
         height: root.sh * 0.525 //252
         clip: true
         focus: true
-
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) {
+                currentIndex-- 
+                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
+                for (var i = 0; i < letterIndex.length; i++) {
+                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+                }
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+            else {
+                currentIndex = count-1
+                itemList.positionViewAtIndex(currentIndex, ListView.Contain)
+                letterList.currentIndex = letterIndex.length-1
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) {
+                currentIndex++
+                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
+                for (var i = 0; i < letterIndex.length; i++) {
+                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+                }
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+            else {
+                currentIndex = 0
+                itemList.positionViewAtIndex(currentIndex, ListView.Contain)
+                letterList.currentIndex = 0
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+        }
         Keys.onReturnPressed: itemListRoot.selectItem()
         Keys.onPressed: function(event) {
             // Right hands focus to the letter panel, synced to the current letter.
@@ -313,18 +344,29 @@ FocusScope {
         focus: false
 
         Keys.onUpPressed: {
+            if (count === 0) return
             if (currentIndex > 0) {
-                currentIndex--
-                itemList.currentIndex = letterIndex[currentIndex].firstIndex
-                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
+                currentIndex-- 
             }
+            else {
+                currentIndex = count - 1
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Beginning)
+            }
+            itemList.currentIndex = letterIndex[currentIndex].firstIndex
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
+            
         }
         Keys.onDownPressed: {
+            if (count === 0) return
             if (currentIndex < count - 1) {
                 currentIndex++
-                itemList.currentIndex = letterIndex[currentIndex].firstIndex
-                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
             }
+            else {
+                currentIndex = 0
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Beginning)
+            }
+            itemList.currentIndex = letterIndex[currentIndex].firstIndex
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
         }
         Keys.onReturnPressed: { letterNavActive = false; itemList.forceActiveFocus() }
         Keys.onLeftPressed:   { letterNavActive = false; itemList.forceActiveFocus() }

--- a/modules/jellyfin/views/Libraries.qml
+++ b/modules/jellyfin/views/Libraries.qml
@@ -80,8 +80,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            libraryList.positionViewAtIndex(libraryList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            libraryList.positionViewAtIndex(libraryList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             var lib = libraries[currentIndex]

--- a/modules/local_files/views/Items.qml
+++ b/modules/local_files/views/Items.qml
@@ -145,6 +145,19 @@ FocusScope {
                 }
             }
         }
+
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            fileList.positionViewAtIndex(fileList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            fileList.positionViewAtIndex(fileList.currentIndex, ListView.Contain)
+        }
     }
 
     Component.onCompleted: {
@@ -157,6 +170,8 @@ FocusScope {
         }
         fileList.forceActiveFocus()
     }
+
+    
 
     // Footer
     Text {

--- a/modules/plex/views/Extras.qml
+++ b/modules/plex/views/Extras.qml
@@ -107,12 +107,16 @@ FocusScope {
     focus: true
 
     Keys.onUpPressed: {
-        if (launchingExtra) return
+        if (launchingExtra || extras.length === 0) return
         if (itemList.currentIndex > 0) itemList.currentIndex--
+        else itemList.currentIndex = extras.length - 1
+        itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
     }
     Keys.onDownPressed: {
-        if (launchingExtra) return
+        if (launchingExtra || extras.length === 0) return
         if (itemList.currentIndex < extras.length - 1) itemList.currentIndex++
+        else itemList.currentIndex = 0
+        itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
     }
     Keys.onReturnPressed: {
         if (launchingExtra) return

--- a/modules/plex/views/Item.qml
+++ b/modules/plex/views/Item.qml
@@ -5,6 +5,7 @@ FocusScope {
     id: detailRoot
 
     property var navParams: ({})
+    property var navListState: navParams.navListState || ({})
 
     signal navigateTo(string path, var params, var listState)
     signal goBack()
@@ -42,8 +43,8 @@ FocusScope {
         var rows = activeRows()
         var i = rows.indexOf(focusRow)
         if (i === -1) { focusRow = 0; return }
-        var next = i + dir
-        if (next >= 0 && next < rows.length) focusRow = rows[next]
+        var next = (i + dir + rows.length) % rows.length
+        focusRow = rows[next]
     }
 
     // True from when PLAY is pressed until we navigate to the Player (or error
@@ -135,6 +136,7 @@ FocusScope {
 
         function onExtrasLoaded(items) {
             detailRoot.extras = items
+            if (navListState.focusRow === 1 && items.length > 0) focusRow = 1
         }
 
         function onErrorOccurred(msg) {
@@ -185,7 +187,7 @@ FocusScope {
                 ratingKey: item.ratingKey,
                 itemTitle: displayName,
                 libraryName: libraryName
-            }, {})
+            }, { focusRow: 1 })
             return
         }
         if (focusRow === 0 && detail) {

--- a/modules/plex/views/ItemSeason.qml
+++ b/modules/plex/views/ItemSeason.qml
@@ -5,6 +5,7 @@ FocusScope {
     id: seasonRoot
 
     property var navParams: ({})
+    property var navListState: navParams.navListState || ({})
 
     signal navigateTo(string path, var params, var listState)
     signal goBack()
@@ -30,12 +31,16 @@ FocusScope {
             seasonRoot.isLoading = false
             seasonRoot.episodes = loadedItems
             if (loadedItems.length > 0) {
-                episodeList.currentIndex = 0
+                var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
+                episodeList.currentIndex = Math.min(restore, loadedItems.length - 1)
+                if (navListState.focusRow === 2) focusRow = 2
+                episodeList.positionViewAtIndex(episodeList.currentIndex, ListView.Contain)
             }
         }
 
         function onExtrasLoaded(items) {
             seasonRoot.extras = items
+            if (navListState.focusRow === 1 && items.length > 0) focusRow = 1
         }
 
         function onErrorOccurred(msg) {
@@ -71,18 +76,39 @@ FocusScope {
             }
         } else if (focusRow === 1) {
             focusRow = 0
+        } else {
+            if (episodes.length > 0) {
+                episodeList.currentIndex = episodes.length - 1
+                focusRow = 2
+            } else if (hasExtras) {
+                focusRow = 1
+            }
         }
+        episodeList.positionViewAtIndex(episodeList.currentIndex, ListView.Contain)
     }
     Keys.onDownPressed: {
         if (focusRow === 0) {
             if (hasExtras) focusRow = 1
-            else if (episodes.length > 0) focusRow = 2
+            else if (episodes.length > 0) {
+                episodeList.currentIndex = 0
+                focusRow = 2
+            }
         } else if (focusRow === 1) {
-            if (episodes.length > 0) focusRow = 2
+            if (episodes.length > 0) {
+                episodeList.currentIndex = 0
+                focusRow = 2
+            } else {
+                focusRow = 0
+            }
         } else {
-            if (episodeList.currentIndex < episodes.length - 1)
+            if (episodeList.currentIndex < episodes.length - 1) {
                 episodeList.currentIndex++
+            } else {
+                episodeList.currentIndex = 0
+                focusRow = 0
+            }
         }
+        episodeList.positionViewAtIndex(episodeList.currentIndex, ListView.Contain)
     }
     Keys.onReturnPressed: {
         if (focusRow === 0) {
@@ -94,14 +120,14 @@ FocusScope {
                 ratingKey: item.ratingKey,
                 itemTitle: showTitle + (label ? " - " + label : ""),
                 libraryName: libraryName
-            }, {})
+            }, { focusRow: 1 })
         } else {
             var ep = episodes[episodeList.currentIndex]
             if (!ep) return
             seasonRoot.navigateTo("Item.qml", {
                 item: ep,
                 libraryName: libraryName
-            }, { currentIndex: episodeList.currentIndex })
+            }, { currentIndex: episodeList.currentIndex, focusRow: 2 })
         }
     }
     Keys.onPressed: function(event) {

--- a/modules/plex/views/ItemShow.qml
+++ b/modules/plex/views/ItemShow.qml
@@ -5,6 +5,7 @@ FocusScope {
     id: showRoot
 
     property var navParams: ({})
+    property var navListState: navParams.navListState || ({})
 
     signal navigateTo(string path, var params, var listState)
     signal goBack()
@@ -36,12 +37,18 @@ FocusScope {
             } else {
                 showRoot.isLoading = false
                 showRoot.seasons = loadedItems
-                if (loadedItems.length > 0) seasonList.currentIndex = 0
+                if (loadedItems.length > 0) {
+                    var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
+                    seasonList.currentIndex = Math.min(restore, loadedItems.length - 1)
+                    if (navListState.focusRow === 2) focusRow = 2
+                    seasonList.positionViewAtIndex(seasonList.currentIndex, ListView.Contain)
+                }
             }
         }
 
         function onExtrasLoaded(items) {
             showRoot.extras = items
+            if (navListState.focusRow === 1 && items.length > 0) focusRow = 1
         }
 
         function onInProgressEpisodeLoaded(episodeItem) {
@@ -112,18 +119,39 @@ FocusScope {
             }
         } else if (focusRow === 1) {
             focusRow = 0
+        } else {
+            if (seasons.length > 0) {
+                seasonList.currentIndex = seasons.length - 1
+                focusRow = 2
+            } else if (hasExtras) {
+                focusRow = 1
+            }
         }
+        seasonList.positionViewAtIndex(seasonList.currentIndex, ListView.Contain)
     }
     Keys.onDownPressed: {
         if (focusRow === 0) {
             if (hasExtras) focusRow = 1
-            else if (seasons.length > 0) focusRow = 2
+            else if (seasons.length > 0) {
+                seasonList.currentIndex = 0
+                focusRow = 2
+            }
         } else if (focusRow === 1) {
-            if (seasons.length > 0) focusRow = 2
+            if (seasons.length > 0) {
+                seasonList.currentIndex = 0
+                focusRow = 2
+            } else {
+                focusRow = 0
+            }
         } else {
-            if (seasonList.currentIndex < seasons.length - 1)
+            if (seasonList.currentIndex < seasons.length - 1) {
                 seasonList.currentIndex++
+            } else {
+                seasonList.currentIndex = 0
+                focusRow = 0
+            }
         }
+        seasonList.positionViewAtIndex(seasonList.currentIndex, ListView.Contain)
     }
     Keys.onReturnPressed: {
         if (focusRow === 0) {
@@ -136,7 +164,7 @@ FocusScope {
                 ratingKey: item.ratingKey,
                 itemTitle: item.title,
                 libraryName: libraryName
-            }, {})
+            }, { focusRow: 1 })
         } else {
             var season = seasons[seasonList.currentIndex]
             if (!season) return
@@ -144,7 +172,7 @@ FocusScope {
                 item: season,
                 showTitle: item.title,
                 libraryName: libraryName
-            }, { currentIndex: seasonList.currentIndex })
+            }, { currentIndex: seasonList.currentIndex, focusRow: 2 })
         }
     }
     Keys.onPressed: function(event) {

--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -329,8 +329,40 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) {
+                currentIndex--
+                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
+                for (var i = 0; i < letterIndex.length; i++) {
+                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+                }
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+            else {
+                currentIndex = count - 1
+                itemList.positionViewAtIndex(currentIndex, ListView.Contain)
+                letterList.currentIndex = letterIndex.length - 1
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) {
+                currentIndex++
+                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
+                for (var i = 0; i < letterIndex.length; i++) {
+                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+                }
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+            else {
+                currentIndex = 0
+                itemList.positionViewAtIndex(currentIndex, ListView.Contain)
+                letterList.currentIndex = 0
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+        }
         Keys.onReturnPressed: itemListRoot.selectItem()
         Keys.onPressed: function(event) {
             if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
@@ -417,18 +449,28 @@ FocusScope {
         focus: false
 
         Keys.onUpPressed: {
+            if (count === 0) return
             if (currentIndex > 0) {
                 currentIndex--
-                itemList.currentIndex = letterIndex[currentIndex].firstIndex
-                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
             }
+            else {
+                currentIndex = count - 1
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Beginning)
+            }
+            itemList.currentIndex = letterIndex[currentIndex].firstIndex
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
         }
         Keys.onDownPressed: {
+            if (count === 0) return
             if (currentIndex < count - 1) {
                 currentIndex++
-                itemList.currentIndex = letterIndex[currentIndex].firstIndex
-                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
             }
+            else {
+                currentIndex = 0
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Beginning)
+            }
+            itemList.currentIndex = letterIndex[currentIndex].firstIndex
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
         }
         Keys.onReturnPressed: {
             letterNavActive = false

--- a/modules/plex/views/Libraries.qml
+++ b/modules/plex/views/Libraries.qml
@@ -90,8 +90,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            libraryList.positionViewAtIndex(libraryList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            libraryList.positionViewAtIndex(libraryList.currentIndex, ListView.Contain)
+        }
         Keys.onLeftPressed: browseRoot.openServerSwitch()
         Keys.onRightPressed: browseRoot.openServerSwitch()
 

--- a/modules/plex/views/Library.qml
+++ b/modules/plex/views/Library.qml
@@ -86,8 +86,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            menuList.positionViewAtIndex(menuList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            menuList.positionViewAtIndex(menuList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             var item = menuItems[currentIndex]

--- a/modules/plex/views/LiveChannels.qml
+++ b/modules/plex/views/LiveChannels.qml
@@ -83,8 +83,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            channelList.positionViewAtIndex(channelList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            channelList.positionViewAtIndex(channelList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             if (channels.length === 0) return

--- a/modules/plex/views/ServerSelect.qml
+++ b/modules/plex/views/ServerSelect.qml
@@ -81,8 +81,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            serverList.positionViewAtIndex(serverList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            serverList.positionViewAtIndex(serverList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             var server = servers[currentIndex]

--- a/modules/plex/views/UserSelect.qml
+++ b/modules/plex/views/UserSelect.qml
@@ -79,8 +79,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            userList.positionViewAtIndex(userList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            userList.positionViewAtIndex(userList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             var user = users[currentIndex]

--- a/modules/youtube/views/Channels.qml
+++ b/modules/youtube/views/Channels.qml
@@ -139,13 +139,37 @@ FocusScope {
 
         Keys.onUpPressed: {
             if (count === 0) return
-            if (currentIndex > 0) currentIndex--
-            else currentIndex = count - 1
+            if (currentIndex > 0) {
+                currentIndex--
+                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
+                for (var i = 0; i < letterIndex.length; i++) {
+                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+                }
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+            else {
+                currentIndex = count - 1
+                itemList.positionViewAtIndex(currentIndex, ListView.Contain)
+                letterList.currentIndex = letterIndex.length - 1
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
         }
         Keys.onDownPressed: {
             if (count === 0) return
-            if (currentIndex < count - 1) currentIndex++
-            else currentIndex = 0
+            if (currentIndex < count - 1) {
+                currentIndex++
+                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
+                for (var i = 0; i < letterIndex.length; i++) {
+                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+                }
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
+            else {
+                currentIndex = 0
+                itemList.positionViewAtIndex(currentIndex, ListView.Contain)
+                letterList.currentIndex = 0
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+            }
         }
         Keys.onReturnPressed: {
             var item = items[itemList.currentIndex]
@@ -237,18 +261,28 @@ FocusScope {
         focus: false
 
         Keys.onUpPressed: {
+            if (count === 0) return
             if (currentIndex > 0) {
                 currentIndex--
-                itemList.currentIndex = letterIndex[currentIndex].firstIndex
-                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
             }
+            else {
+                currentIndex = count - 1
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Beginning)
+            }
+            itemList.currentIndex = letterIndex[currentIndex].firstIndex
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
         }
         Keys.onDownPressed: {
+            if (count === 0) return
             if (currentIndex < count - 1) {
                 currentIndex++
-                itemList.currentIndex = letterIndex[currentIndex].firstIndex
-                itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
             }
+            else {
+                currentIndex = 0
+                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Beginning)
+            }
+            itemList.currentIndex = letterIndex[currentIndex].firstIndex
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Beginning)
         }
         Keys.onReturnPressed: {
             letterNavActive = false

--- a/modules/youtube/views/Channels.qml
+++ b/modules/youtube/views/Channels.qml
@@ -137,8 +137,16 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+        }
         Keys.onReturnPressed: {
             var item = items[itemList.currentIndex]
             if (!item)

--- a/modules/youtube/views/Items.qml
+++ b/modules/youtube/views/Items.qml
@@ -148,6 +148,16 @@ FocusScope {
             else if (selected === "History")
                 navigateTo("Subscriptions.qml", { mode: "history" }, state)
         }
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+        }
     }
 
     // Footer

--- a/modules/youtube/views/Playlists.qml
+++ b/modules/youtube/views/Playlists.qml
@@ -105,8 +105,16 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+        }
         Keys.onReturnPressed: {
             var item = items[itemList.currentIndex]
             if (!item)

--- a/modules/youtube/views/Subscriptions.qml
+++ b/modules/youtube/views/Subscriptions.qml
@@ -272,7 +272,8 @@ FocusScope {
         }
         Keys.onUpPressed: {
             if (wlOverlayVisible) {
-                wlChoiceIndex = 0
+                if(wlChoiceIndex === 0) wlChoiceIndex = 1
+                else wlChoiceIndex = 0
                 event.accepted = true
                 return
             }
@@ -283,7 +284,8 @@ FocusScope {
         }
         Keys.onDownPressed: {
             if (wlOverlayVisible) {
-                wlChoiceIndex = 1
+                if(wlChoiceIndex === 0) wlChoiceIndex = 1
+                else wlChoiceIndex = 0
                 event.accepted = true
                 return
             }
@@ -295,10 +297,12 @@ FocusScope {
         Keys.onPressed: function(event) {
             if (wlOverlayVisible) {
                 if (event.key === Qt.Key_Up) {
-                    wlChoiceIndex = 0
+                    if(wlChoiceIndex === 0) wlChoiceIndex = 1
+                    else wlChoiceIndex = 0
                     event.accepted = true
                 } else if (event.key === Qt.Key_Down) {
-                    wlChoiceIndex = 1
+                    if(wlChoiceIndex === 0) wlChoiceIndex = 1
+                    else wlChoiceIndex = 0
                     event.accepted = true
                 } else if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
                     wlOverlayVisible = false

--- a/modules/youtube/views/Subscriptions.qml
+++ b/modules/youtube/views/Subscriptions.qml
@@ -270,6 +270,28 @@ FocusScope {
                 return
             navigateTo("Player.qml", { item: selected }, { currentIndex: itemList.currentIndex })
         }
+        Keys.onUpPressed: {
+            if (wlOverlayVisible) {
+                wlChoiceIndex = 0
+                event.accepted = true
+                return
+            }
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (wlOverlayVisible) {
+                wlChoiceIndex = 1
+                event.accepted = true
+                return
+            }
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+        }
         Keys.onPressed: function(event) {
             if (wlOverlayVisible) {
                 if (event.key === Qt.Key_Up) {

--- a/views/DirectoryBrowser.qml
+++ b/views/DirectoryBrowser.qml
@@ -82,10 +82,16 @@ FocusScope {
         focus: true
 
         Keys.onUpPressed: {
+            if (count === 0) return
             if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            dirList.positionViewAtIndex(dirList.currentIndex, ListView.Contain)
         }
         Keys.onDownPressed: {
+            if (count === 0) return
             if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            dirList.positionViewAtIndex(dirList.currentIndex, ListView.Contain)
         }
         Keys.onReturnPressed: {
             var entry = browserRoot.listModel[currentIndex]

--- a/views/ModuleList.qml
+++ b/views/ModuleList.qml
@@ -134,6 +134,21 @@ FocusScope {
                 }
             }
         }
+
+        Keys.onUpPressed: {
+            if (currentIndex > 0) {
+                currentIndex--
+            } else {
+                currentIndex = menuList.model.length-1
+            }
+        }
+        Keys.onDownPressed: {
+            if (currentIndex < menuList.model.length-1) {
+                currentIndex++
+            } else {
+                currentIndex = 0
+            }
+        }
         
         Keys.onReturnPressed: {
             var selectedModulePath = menuList.model[menuList.currentIndex].entry_point

--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -195,10 +195,19 @@ FocusScope {
         focus: true
 
         Keys.onUpPressed: {
-            if (currentIndex > 0) currentIndex--
+            if (currentIndex > 0) currentIndex-- 
+            else {
+                for (var i = schemaItems.length - 1; i >= 0; i--) {
+                    if (schemaItems[i].type !== "section") { currentIndex = i; break }
+                }
+            }
+            schemaItems.positionViewAtIndex(currentIndex, ListView.Contain)
+
         }
         Keys.onDownPressed: {
             if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            schemaItems.positionViewAtIndex(currentIndex, ListView.Contain)
         }
 
         Keys.onLeftPressed: {

--- a/views/MultiSelectSettings.qml
+++ b/views/MultiSelectSettings.qml
@@ -81,10 +81,16 @@ FocusScope {
         focus: true
 
         Keys.onUpPressed: {
+            if (count === 0) return
             if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            optionsList.positionViewAtIndex(optionsList.currentIndex, ListView.Contain)
         }
         Keys.onDownPressed: {
+            if (count === 0) return
             if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            optionsList.positionViewAtIndex(optionsList.currentIndex, ListView.Contain)
         }
 
         Keys.onLeftPressed: {

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -207,11 +207,28 @@ FocusScope {
 
         Keys.onUpPressed: {
             var prev = settingsRoot.firstSelectableBefore(currentIndex)
-            if (prev !== currentIndex) currentIndex = prev
+            if (prev !== currentIndex) {
+                currentIndex = prev
+            } else {
+                // wrap to last selectable
+                for (var i = settingsItems.length - 1; i >= 0; i--) {
+                    if (settingsItems[i].type !== "section") { currentIndex = i; break }
+                }
+            }
+            settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
         }
         Keys.onDownPressed: {
             var next = settingsRoot.firstSelectableAfter(currentIndex)
-            if (next !== currentIndex) currentIndex = next
+            if (next !== currentIndex) {
+                currentIndex = next
+                settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
+            } else {
+                // wrap to first selectable
+                for (var j = 0; j < settingsItems.length; j++) {
+                    if (settingsItems[j].type !== "section") { currentIndex = j; break }
+                }
+                settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
+            }
         }
 
         Keys.onLeftPressed: {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Added list wraparound to all menus I could find related to the app core, settings, jellyfin, local files, and youtube. So when you press up at the top of a list it brings you to the bottom and when you press down at the bottom of a list it brings you to the top. 
## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->

Not used at all

## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->

I tested on MacOS with my Jellyfin server, some test files, and the example subscription and playlist files. 

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)

Definitely needs some more testing, but seems to be working great with what I have tested. I am unable to work on the other modules so those were left alone for now. The other pull request I opened related to the letter nav on collections will definitely need some tweaks to work with this pull request. A much needed QOL change. 
