### PR TITLE
feat: Live TV (IPTV) module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(240mp
     src/modules/local_files/LocalFilesBackend.cpp
     src/modules/plex/PlexBackend.cpp
     src/modules/jellyfin/JellyfinBackend.cpp
+    src/modules/iptv/IptvBackend.cpp
     src/modules/ambient_mode/AmbientModeBackend.cpp
     src/modules/youtube/YouTubeBackend.cpp
     src/modules/nfc_reader/NfcReaderBackend.cpp

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 ### Live TV Module (IPTV)
 - Designed for CRT navigation (simple, fast, list browsing)
 - Point it at an M3U playlist (remote URL or local file)
+- Optional XMLTV guide URL for now/next info — current programme, a progress bar per channel, and a now/next info bar on tune-in
 - Channels grouped by category (`group-title`), plus an "All Channels" shelf
 - Streams handed straight to mpv (HLS/TS/UDP) — no auth, transcode, or DRM
 - Change the playlist any time from the "Change Playlist" entry

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 240-MP is a retro VCR style frontend to play content on [Raspberry Pi](https://github.com/anthonycaccese/240-MP/wiki/Hardware-Testing) (preferably hooked up to a CRT TV).
 
-Playback experiences are handled via modules to enable new integrations without requiring major changes to the overall frontend. There are 6 currently included playback modules; [Local Files](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files), [Plex](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex), [Jellyfin](https://github.com/anthonycaccese/240-MP/wiki/Module:-Jellyfin), [YouTube](https://github.com/anthonycaccese/240-MP/wiki/Module:-YouTube), [NFC Reader](https://github.com/anthonycaccese/240-MP/wiki/Module:-NFC-Reader) and a module similar to art/wallpaper modes on modern tvs called [Ambient:Mode](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode).
+Playback experiences are handled via modules to enable new integrations without requiring major changes to the overall frontend. There are 7 currently included playback modules; [Local Files](https://github.com/anthonycaccese/240-MP/wiki/Module:-Local-Files), [Plex](https://github.com/anthonycaccese/240-MP/wiki/Module:-Plex), [Jellyfin](https://github.com/anthonycaccese/240-MP/wiki/Module:-Jellyfin), Live TV (IPTV), [YouTube](https://github.com/anthonycaccese/240-MP/wiki/Module:-YouTube), [NFC Reader](https://github.com/anthonycaccese/240-MP/wiki/Module:-NFC-Reader) and a module similar to art/wallpaper modes on modern tvs called [Ambient:Mode](https://github.com/anthonycaccese/240-MP/wiki/Module:-Ambient-Mode).
 
 It's built to work in conjuction with MPV which will be installed (or updated) as a dependency during the [install](#Install) steps outlined below.  Some modules (like YouTube and NFC Reader) have additional dependencies which are covered on their associated wiki pages under the "To Enable" section.
 
@@ -60,6 +60,14 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 - Full library browsing by letter
 - Show/Season browsing
 - Video quality selection: Direct Playback (Default) or Transcode options
+
+### Live TV Module (IPTV)
+- Designed for CRT navigation (simple, fast, list browsing)
+- Point it at an M3U playlist (remote URL or local file)
+- Channels grouped by category (`group-title`), plus an "All Channels" shelf
+- Streams handed straight to mpv (HLS/TS/UDP) — no auth, transcode, or DRM
+- Change the playlist any time from the "Change Playlist" entry
+
 
 ### YouTube Module ([Wiki](https://github.com/anthonycaccese/240-MP/wiki/Module:-YouTube))
 - Designed for CRT navigation (simple, fast, list browsing)

--- a/modules/iptv/assets/images/logo.svg
+++ b/modules/iptv/assets/images/logo.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Live TV module icon: a retro CRT set with antenna, white monochrome to
+     match the app's icon convention. Original artwork. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g fill="none" stroke="#ffffff" stroke-width="20" stroke-linecap="round" stroke-linejoin="round">
+    <!-- antenna -->
+    <line x1="256" y1="150" x2="176" y2="70"/>
+    <line x1="256" y1="150" x2="336" y2="70"/>
+    <!-- screen bezel -->
+    <rect x="60" y="160" width="300" height="240" rx="24"/>
+    <!-- speaker / controls panel -->
+    <rect x="380" y="160" width="72" height="240" rx="16"/>
+    <line x1="416" y1="210" x2="416" y2="210"/>
+    <line x1="416" y1="270" x2="416" y2="270"/>
+  </g>
+  <g fill="#ffffff">
+    <circle cx="416" cy="215" r="12"/>
+    <circle cx="416" cy="265" r="12"/>
+    <!-- play triangle on the screen -->
+    <path d="M180 230 L180 330 L262 280 Z"/>
+  </g>
+</svg>

--- a/modules/iptv/manifest.json
+++ b/modules/iptv/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "com.240mp.iptv",
+  "name": "Live TV",
+  "icon": "assets/images/logo.svg",
+  "entry_point_qml": "views/Root.qml",
+  "settings": [
+    {
+      "key": "enabled",
+      "label": "Enabled",
+      "type": "toggle",
+      "default": "OFF"
+    }
+  ]
+}

--- a/modules/iptv/views/Channels.qml
+++ b/modules/iptv/views/Channels.qml
@@ -1,0 +1,156 @@
+import QtQuick
+import Components
+
+// Channel list for a group. Selecting a channel hands its stream URL to the
+// live player.
+FocusScope {
+    id: channelsRoot
+
+    property var navParams: ({})
+    property var navListState: navParams.navListState || ({})
+
+    property string group: navParams.group || "__all__"
+    property string title: navParams.title || "CHANNELS"
+
+    signal navigateTo(string path, var params, var listState)
+    signal goBack()
+
+    property var channels: []
+    property bool loading: true
+
+    Connections {
+        target: iptvBackend
+
+        function onChannelsLoaded(items) {
+            channelsRoot.channels = items
+            channelsRoot.loading = false
+            var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
+            channelList.currentIndex = Math.min(restore, Math.max(0, items.length - 1))
+            channelList.positionViewAtIndex(channelList.currentIndex, ListView.Contain)
+        }
+    }
+
+    Component.onCompleted: iptvBackend.load_channels(group)
+
+    focus: true
+
+    AppBar {
+        iconSource: moduleRoot.moduleIcon
+        title: moduleRoot.moduleName
+        subtitle: channelsRoot.title
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125
+        anchors.leftMargin: root.sw * 0.125
+    }
+
+    Text {
+        visible: loading
+        text: "LOADING..."
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.centerIn: parent
+        font.pixelSize: root.sh * 0.05
+    }
+
+    Text {
+        visible: !loading && channels.length === 0
+        text: "NO CHANNELS"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.centerIn: parent
+        font.pixelSize: root.sh * 0.05
+    }
+
+    ListView {
+        id: channelList
+        model: channels
+        visible: !loading && channels.length > 0
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.25
+        anchors.leftMargin: root.sw * 0.115625
+        width: root.sw * 0.76875
+        height: root.sh * 0.525
+        clip: true
+        focus: true
+
+        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
+        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+
+        Keys.onReturnPressed: {
+            var ch = channels[currentIndex]
+            if (!ch || !ch.url) return
+            channelsRoot.navigateTo("Player.qml", {
+                streamUrl: ch.url,
+                title: ch.name
+            }, { currentIndex: channelList.currentIndex })
+        }
+
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                channelsRoot.goBack()
+                event.accepted = true
+            }
+        }
+
+        delegate: Item {
+            width: channelList.width
+            height: root.sh * 0.0583333
+
+            Item {
+                id: textClip
+                width: Math.min(rowText.implicitWidth, channelList.width)
+                height: parent.height
+                clip: true
+
+                Rectangle {
+                    color: root.accentColor
+                    anchors.fill: rowText
+                    visible: channelList.currentIndex === index
+                }
+
+                Text {
+                    id: rowText
+                    text: modelData.name || modelData.url || ""
+                    color: channelList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    anchors.verticalCenter: parent.verticalCenter
+                    x: 0
+                    topPadding: root.sh * 0.0041667
+                    leftPadding: root.sw * 0.009375
+                    rightPadding: root.sw * 0.009375
+                    bottomPadding: root.sh * 0.00625
+                    font.pixelSize: root.sh * 0.05
+                }
+
+                SequentialAnimation {
+                    running: (channelList.currentIndex === index) &&
+                             (rowText.implicitWidth > textClip.width)
+                    loops: Animation.Infinite
+                    onRunningChanged: if (!running) rowText.x = 0
+                    PauseAnimation { duration: 1500 }
+                    NumberAnimation {
+                        target: rowText; property: "x"
+                        to: textClip.width - rowText.implicitWidth
+                        duration: Math.abs(to) * 20
+                    }
+                    PauseAnimation { duration: 2000 }
+                    PropertyAction { target: rowText; property: "x"; value: 0 }
+                }
+            }
+        }
+    }
+
+    Text {
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":WATCH"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667
+        anchors.leftMargin: root.sw * 0.125
+        font.pixelSize: root.sh * 0.0333333
+    }
+}

--- a/modules/iptv/views/Channels.qml
+++ b/modules/iptv/views/Channels.qml
@@ -98,8 +98,18 @@ FocusScope {
         focus: true
         spacing: root.sh * 0.0083333
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            channelList.positionViewAtIndex(channelList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            channelList.positionViewAtIndex(channelList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             var ch = channels[currentIndex]

--- a/modules/iptv/views/Channels.qml
+++ b/modules/iptv/views/Channels.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import Components
 
-// Channel list for a group. Selecting a channel hands its stream URL to the
-// live player.
+// Channel list for a group, with now/next guide info (when an XMLTV EPG is
+// configured). Selecting a channel hands its stream URL to the live player.
 FocusScope {
     id: channelsRoot
 
@@ -18,6 +18,25 @@ FocusScope {
     property var channels: []
     property bool loading: true
 
+    // Wall-clock in epoch-ms, ticked so the "now" progress bars advance while the
+    // list is on screen.
+    property double nowMs: 0
+
+    Timer {
+        interval: 30000
+        repeat: true
+        running: true
+        onTriggered: channelsRoot.nowMs = Date.now()
+    }
+
+    function progressFor(item) {
+        var start = item.nowStartMs || 0
+        var stop = item.nowStopMs || 0
+        if (stop <= start) return -1
+        var f = (channelsRoot.nowMs - start) / (stop - start)
+        return Math.max(0, Math.min(1, f))
+    }
+
     Connections {
         target: iptvBackend
 
@@ -30,7 +49,10 @@ FocusScope {
         }
     }
 
-    Component.onCompleted: iptvBackend.load_channels(group)
+    Component.onCompleted: {
+        nowMs = Date.now()
+        iptvBackend.load_channels(group)
+    }
 
     focus: true
 
@@ -71,9 +93,10 @@ FocusScope {
         anchors.topMargin: root.sh * 0.25
         anchors.leftMargin: root.sw * 0.115625
         width: root.sw * 0.76875
-        height: root.sh * 0.525
+        height: root.sh * 0.55
         clip: true
         focus: true
+        spacing: root.sh * 0.0083333
 
         Keys.onUpPressed: if (currentIndex > 0) currentIndex--
         Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
@@ -83,7 +106,9 @@ FocusScope {
             if (!ch || !ch.url) return
             channelsRoot.navigateTo("Player.qml", {
                 streamUrl: ch.url,
-                title: ch.name
+                title: ch.name,
+                nowTitle: ch.nowTitle || "",
+                nextTitle: ch.nextTitle || ""
             }, { currentIndex: channelList.currentIndex })
         }
 
@@ -95,49 +120,61 @@ FocusScope {
         }
 
         delegate: Item {
+            id: chRow
             width: channelList.width
-            height: root.sh * 0.0583333
+            height: nowLine.visible ? root.sh * 0.09 : root.sh * 0.0583333
+            property bool selected: channelList.currentIndex === index
 
-            Item {
-                id: textClip
-                width: Math.min(rowText.implicitWidth, channelList.width)
-                height: parent.height
-                clip: true
+            Rectangle {
+                anchors.fill: parent
+                color: root.accentColor
+                visible: chRow.selected
+            }
 
-                Rectangle {
-                    color: root.accentColor
-                    anchors.fill: rowText
-                    visible: channelList.currentIndex === index
+            Column {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: root.sw * 0.009375
+                anchors.rightMargin: root.sw * 0.009375
+                spacing: root.sh * 0.004
+
+                Text {
+                    text: modelData.name || modelData.url || ""
+                    color: chRow.selected ? root.surfaceColor : root.primaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    font.pixelSize: root.sh * 0.0416667
+                    elide: Text.ElideRight
+                    width: parent.width
                 }
 
                 Text {
-                    id: rowText
-                    text: modelData.name || modelData.url || ""
-                    color: channelList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                    id: nowLine
+                    visible: (modelData.nowTitle || modelData.nextTitle || "") !== ""
+                    text: modelData.nowTitle
+                          ? "NOW · " + modelData.nowTitle
+                          : (modelData.nextTitle ? "NEXT · " + modelData.nextTitle : "")
+                    color: chRow.selected ? root.surfaceColor : root.tertiaryColor
                     font.family: root.globalFont
                     font.capitalization: Font.AllUppercase
-                    anchors.verticalCenter: parent.verticalCenter
-                    x: 0
-                    topPadding: root.sh * 0.0041667
-                    leftPadding: root.sw * 0.009375
-                    rightPadding: root.sw * 0.009375
-                    bottomPadding: root.sh * 0.00625
-                    font.pixelSize: root.sh * 0.05
+                    font.pixelSize: root.sh * 0.0270833
+                    elide: Text.ElideRight
+                    width: parent.width
                 }
 
-                SequentialAnimation {
-                    running: (channelList.currentIndex === index) &&
-                             (rowText.implicitWidth > textClip.width)
-                    loops: Animation.Infinite
-                    onRunningChanged: if (!running) rowText.x = 0
-                    PauseAnimation { duration: 1500 }
-                    NumberAnimation {
-                        target: rowText; property: "x"
-                        to: textClip.width - rowText.implicitWidth
-                        duration: Math.abs(to) * 20
+                // Progress through the current programme.
+                Rectangle {
+                    visible: channelsRoot.progressFor(modelData) >= 0
+                    width: parent.width
+                    height: root.sh * 0.005
+                    color: chRow.selected ? Qt.rgba(1,1,1,0.35) : root.surfaceColor
+
+                    Rectangle {
+                        height: parent.height
+                        width: parent.width * Math.max(0, channelsRoot.progressFor(modelData))
+                        color: chRow.selected ? root.surfaceColor : root.accentColor
                     }
-                    PauseAnimation { duration: 2000 }
-                    PropertyAction { target: rowText; property: "x"; value: 0 }
                 }
             }
         }

--- a/modules/iptv/views/Groups.qml
+++ b/modules/iptv/views/Groups.qml
@@ -95,8 +95,18 @@ FocusScope {
         clip: true
         focus: true
 
-        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
-        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+        Keys.onUpPressed: {
+            if (count === 0) return
+            if (currentIndex > 0) currentIndex--
+            else currentIndex = count - 1
+            groupList.positionViewAtIndex(groupList.currentIndex, ListView.Contain)
+        }
+        Keys.onDownPressed: {
+            if (count === 0) return
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            groupList.positionViewAtIndex(groupList.currentIndex, ListView.Contain)
+        }
 
         Keys.onReturnPressed: {
             var g = groupsRoot.rows[currentIndex]

--- a/modules/iptv/views/Groups.qml
+++ b/modules/iptv/views/Groups.qml
@@ -1,0 +1,182 @@
+import QtQuick
+import Components
+
+// Channel groups (categories) from the M3U's group-title tags, plus an
+// "ALL CHANNELS" shelf (prepended by the backend) and a "CHANGE PLAYLIST" entry.
+FocusScope {
+    id: groupsRoot
+
+    property var navParams: ({})
+    property var navListState: navParams.navListState || ({})
+
+    signal navigateTo(string path, var params, var listState)
+    signal goBack()
+
+    property var groups: []
+    property bool loading: true
+    property string errorMsg: ""
+
+    // Sentinel row appended after the real groups.
+    readonly property var changeEntry: ({ title: "CHANGE PLAYLIST", key: "__change__" })
+
+    property var rows: groups.concat([changeEntry])
+
+    Connections {
+        target: iptvBackend
+
+        function onGroupsLoaded(items) {
+            groupsRoot.groups = items
+            groupsRoot.loading = false
+            var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
+            groupList.currentIndex = Math.min(restore, groupsRoot.rows.length - 1)
+            groupList.positionViewAtIndex(groupList.currentIndex, ListView.Contain)
+        }
+
+        function onLoadingChanged(isLoading) {
+            if (isLoading) groupsRoot.loading = true
+        }
+
+        function onPlaylistError(msg) {
+            groupsRoot.loading = false
+            groupsRoot.errorMsg = msg
+        }
+    }
+
+    Component.onCompleted: iptvBackend.load_groups(false)
+
+    focus: true
+
+    AppBar {
+        iconSource: moduleRoot.moduleIcon
+        title: moduleRoot.moduleName
+        subtitle: "Channels"
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125
+        anchors.leftMargin: root.sw * 0.125
+    }
+
+    Text {
+        visible: loading
+        text: "LOADING..."
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.centerIn: parent
+        font.pixelSize: root.sh * 0.05
+    }
+
+    // Error is non-blocking: the list still shows the "CHANGE PLAYLIST" row so a
+    // bad URL can be corrected without leaving the module.
+    Text {
+        visible: !loading && errorMsg !== ""
+        text: errorMsg
+        color: root.accentColor
+        font.family: root.globalFont
+        font.capitalization: Font.AllUppercase
+        horizontalAlignment: Text.AlignHCenter
+        anchors.bottom: groupsFooter.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottomMargin: root.sh * 0.0333333
+        width: root.sw * 0.6
+        wrapMode: Text.WordWrap
+        font.pixelSize: root.sh * 0.0333333
+    }
+
+    ListView {
+        id: groupList
+        model: groupsRoot.rows
+        visible: !loading
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.25
+        anchors.leftMargin: root.sw * 0.115625
+        width: root.sw * 0.76875
+        height: root.sh * 0.525
+        clip: true
+        focus: true
+
+        Keys.onUpPressed: if (currentIndex > 0) currentIndex--
+        Keys.onDownPressed: if (currentIndex < count - 1) currentIndex++
+
+        Keys.onReturnPressed: {
+            var g = groupsRoot.rows[currentIndex]
+            if (!g) return
+            if (g.key === "__change__") {
+                groupsRoot.navigateTo("Setup.qml", {}, { currentIndex: groupList.currentIndex })
+                return
+            }
+            groupsRoot.navigateTo("Channels.qml", {
+                group: g.key,
+                title: g.title
+            }, { currentIndex: groupList.currentIndex })
+        }
+
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+                groupsRoot.goBack()
+                event.accepted = true
+            }
+        }
+
+        delegate: Item {
+            width: groupList.width
+            height: root.sh * 0.0583333
+
+            Item {
+                id: textClip
+                width: Math.min(rowText.implicitWidth, groupList.width)
+                height: parent.height
+                clip: true
+
+                Rectangle {
+                    color: root.accentColor
+                    anchors.fill: rowText
+                    visible: groupList.currentIndex === index
+                }
+
+                Text {
+                    id: rowText
+                    text: (modelData.title || "") +
+                          (modelData.count !== undefined ? "  (" + modelData.count + ")" : "")
+                    color: groupList.currentIndex === index ? root.surfaceColor : root.primaryColor
+                    font.family: root.globalFont
+                    font.capitalization: Font.AllUppercase
+                    anchors.verticalCenter: parent.verticalCenter
+                    x: 0
+                    topPadding: root.sh * 0.0041667
+                    leftPadding: root.sw * 0.009375
+                    rightPadding: root.sw * 0.009375
+                    bottomPadding: root.sh * 0.00625
+                    font.pixelSize: root.sh * 0.05
+                }
+
+                SequentialAnimation {
+                    running: (groupList.currentIndex === index) &&
+                             (rowText.implicitWidth > textClip.width)
+                    loops: Animation.Infinite
+                    onRunningChanged: if (!running) rowText.x = 0
+                    PauseAnimation { duration: 1500 }
+                    NumberAnimation {
+                        target: rowText; property: "x"
+                        to: textClip.width - rowText.implicitWidth
+                        duration: Math.abs(to) * 20
+                    }
+                    PauseAnimation { duration: 2000 }
+                    PropertyAction { target: rowText; property: "x"; value: 0 }
+                }
+            }
+        }
+    }
+
+    Text {
+        id: groupsFooter
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":SELECT"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667
+        anchors.leftMargin: root.sw * 0.125
+        font.pixelSize: root.sh * 0.0333333
+    }
+}

--- a/modules/iptv/views/Player.qml
+++ b/modules/iptv/views/Player.qml
@@ -1,0 +1,88 @@
+import QtQuick
+
+// Live playback: hand the stream URL straight to mpv. No resume, seek, or
+// progress reporting — this is a live feed, not VOD.
+FocusScope {
+    id: playerRoot
+
+    property var navParams: ({})
+
+    signal goBack()
+
+    property string streamUrl: navParams.streamUrl || ""
+    property string channelTitle: navParams.title || ""
+    property bool playbackStarted: false
+
+    focus: true
+
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+            mpvController.sendKey("ESC")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Backspace) {
+            mpvController.sendKey("BS")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Space) {
+            mpvController.sendKey("SPACE")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Up) {
+            mpvController.sendKey("UP")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Down) {
+            mpvController.sendKey("DOWN")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Left) {
+            mpvController.sendKey("LEFT")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Right) {
+            mpvController.sendKey("RIGHT")
+            event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            mpvController.sendKey("ENTER")
+            event.accepted = true
+        }
+    }
+
+    // Defer the launch one tick so the LOADING frame paints before mpv takes
+    // over the screen (mirrors the other modules' players).
+    Timer {
+        id: startTimer
+        interval: 16
+        repeat: false
+        onTriggered: {
+            // audioTrack -1 (mpv default), subTrack -2 (subs off) — live streams
+            // rarely carry selectable tracks; everything else uses defaults.
+            mpvController.loadAndPlay(playerRoot.streamUrl, 0.0, -1, -2)
+        }
+    }
+
+    Connections {
+        target: mpvController
+
+        function onPositionChanged(ms) {
+            if (ms > 0) playerRoot.playbackStarted = true
+        }
+
+        function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            playerRoot.goBack()
+        }
+    }
+
+    Component.onCompleted: {
+        if (streamUrl !== "") startTimer.restart()
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "black"
+
+        Text {
+            text: "TUNING IN..."
+            color: "white"
+            font.family: root.globalFont
+            anchors.centerIn: parent
+            font.pixelSize: root.sh * 0.05
+            visible: playerRoot.streamUrl !== "" && !playerRoot.playbackStarted
+        }
+    }
+}

--- a/modules/iptv/views/Player.qml
+++ b/modules/iptv/views/Player.qml
@@ -11,7 +11,11 @@ FocusScope {
 
     property string streamUrl: navParams.streamUrl || ""
     property string channelTitle: navParams.title || ""
+    property string nowTitle: navParams.nowTitle || ""
+    property string nextTitle: navParams.nextTitle || ""
     property bool playbackStarted: false
+    // Info bar is shown on tune-in and for a few seconds after playback starts.
+    property bool infoVisible: true
 
     focus: true
 
@@ -56,11 +60,22 @@ FocusScope {
         }
     }
 
+    // Hide the info bar a few seconds after playback actually starts.
+    Timer {
+        id: infoTimer
+        interval: 5000
+        repeat: false
+        onTriggered: playerRoot.infoVisible = false
+    }
+
     Connections {
         target: mpvController
 
         function onPositionChanged(ms) {
-            if (ms > 0) playerRoot.playbackStarted = true
+            if (ms > 0 && !playerRoot.playbackStarted) {
+                playerRoot.playbackStarted = true
+                infoTimer.restart()
+            }
         }
 
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
@@ -75,6 +90,9 @@ FocusScope {
     Rectangle {
         anchors.fill: parent
         color: "black"
+        // Only covers the screen before mpv takes over; once playback starts mpv
+        // paints over this, and only the info bar (a separate overlay) shows.
+        visible: !playerRoot.playbackStarted
 
         Text {
             text: "TUNING IN..."
@@ -82,7 +100,60 @@ FocusScope {
             font.family: root.globalFont
             anchors.centerIn: parent
             font.pixelSize: root.sh * 0.05
-            visible: playerRoot.streamUrl !== "" && !playerRoot.playbackStarted
+            visible: playerRoot.streamUrl !== ""
+        }
+    }
+
+    // Channel / now-next info bar — shown on tune-in and briefly after start.
+    Rectangle {
+        id: infoBar
+        visible: playerRoot.infoVisible && playerRoot.channelTitle !== ""
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: infoColumn.implicitHeight + root.sh * 0.05
+        color: Qt.rgba(0, 0, 0, 0.6)
+
+        Column {
+            id: infoColumn
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.leftMargin: root.sw * 0.05
+            anchors.right: parent.right
+            anchors.rightMargin: root.sw * 0.05
+            spacing: root.sh * 0.008
+
+            Text {
+                text: playerRoot.channelTitle
+                color: "white"
+                font.family: root.globalFont
+                font.capitalization: Font.AllUppercase
+                font.pixelSize: root.sh * 0.045
+                elide: Text.ElideRight
+                width: parent.width
+            }
+
+            Text {
+                visible: playerRoot.nowTitle !== ""
+                text: "NOW · " + playerRoot.nowTitle
+                color: root.accentColor
+                font.family: root.globalFont
+                font.capitalization: Font.AllUppercase
+                font.pixelSize: root.sh * 0.03
+                elide: Text.ElideRight
+                width: parent.width
+            }
+
+            Text {
+                visible: playerRoot.nextTitle !== ""
+                text: "NEXT · " + playerRoot.nextTitle
+                color: "#cccccc"
+                font.family: root.globalFont
+                font.capitalization: Font.AllUppercase
+                font.pixelSize: root.sh * 0.03
+                elide: Text.ElideRight
+                width: parent.width
+            }
         }
     }
 }

--- a/modules/iptv/views/Root.qml
+++ b/modules/iptv/views/Root.qml
@@ -1,0 +1,74 @@
+import QtQuick
+
+FocusScope {
+    id: moduleRoot
+
+    // Exit signal — emitted to leave the module entirely
+    signal goBack()
+
+    property var navParams: ({})
+
+    // The module's manifest id — the single place it appears in this module's QML.
+    property string moduleId: "com.240mp.iptv"
+    property var _moduleInfo: appCore ? appCore.get_module_info(moduleId) : ({})
+    property string moduleName: _moduleInfo.name || ""
+    property string moduleIcon: _moduleInfo.icon || ""
+
+    // Internal navigation state
+    property var navStack: []
+    property var currentParams: ({})
+
+    function navigateTo(viewPath, params, fromState) {
+        var resolved = Qt.resolvedUrl(viewPath)
+        navStack.push({ source: internalLoader.source, params: currentParams, listState: fromState || {} })
+        currentParams = params || {}
+        internalLoader.setSource(resolved, { "navParams": params || {} })
+    }
+
+    function replaceWith(viewPath, params) {
+        var resolved = Qt.resolvedUrl(viewPath)
+        currentParams = params || {}
+        navStack = []
+        internalLoader.setSource(resolved, { "navParams": params || {} })
+    }
+
+    function navigateBack() {
+        if (navStack.length === 0) {
+            moduleRoot.goBack()
+            return
+        }
+        var prev = navStack.pop()
+        if (!prev.source || prev.source.toString() === "") {
+            moduleRoot.goBack()
+            return
+        }
+        var restored = Object.assign({}, prev.params)
+        restored.navListState = prev.listState || {}
+        currentParams = restored
+        internalLoader.setSource(prev.source, { "navParams": restored })
+    }
+
+    Loader {
+        id: internalLoader
+        anchors.fill: parent
+        focus: true
+        onLoaded: { if (item) item.forceActiveFocus() }
+
+        Connections {
+            target: internalLoader.item
+            ignoreUnknownSignals: true
+            function onNavigateTo(path, params, listState) { moduleRoot.navigateTo(path, params, listState) }
+            function onReplaceWith(path, params) { moduleRoot.replaceWith(path, params) }
+            function onGoBack() { moduleRoot.navigateBack() }
+        }
+    }
+
+    Component.onCompleted: {
+        // Straight to the channel groups when a playlist is configured; otherwise
+        // prompt for one first.
+        if (iptvBackend.has_source())
+            replaceWith("Groups.qml", {})
+        else
+            replaceWith("Setup.qml", {})
+    }
+}

--- a/modules/iptv/views/Setup.qml
+++ b/modules/iptv/views/Setup.qml
@@ -1,0 +1,161 @@
+import QtQuick
+import Components
+
+// Playlist setup: enter an M3U URL (or a local file path). Saved to
+// modules.<id>.m3u_url; the backend fetches + parses it on load.
+FocusScope {
+    focus: true
+    id: setupRoot
+
+    property var navParams: ({})
+
+    signal navigateTo(string path, var params, var listState)
+    signal replaceWith(string path, var params)
+    signal goBack()
+
+    property string m3uUrl: appCore.get_setting(moduleRoot.moduleId, "m3u_url") || ""
+    property bool waiting: false
+    property string errorMsg: ""
+
+    Connections {
+        target: iptvBackend
+
+        function onGroupsLoaded(groups) {
+            // Playlist parsed successfully — remember it and enter the guide.
+            setupRoot.waiting = false
+            appCore.save_setting(moduleRoot.moduleId, "m3u_url", setupRoot.m3uUrl)
+            setupRoot.replaceWith("Groups.qml", {})
+        }
+
+        function onPlaylistError(msg) {
+            setupRoot.waiting = false
+            setupRoot.errorMsg = msg
+        }
+    }
+
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Shift || event.key === Qt.Key_Control ||
+            event.key === Qt.Key_Alt   || event.key === Qt.Key_Meta ||
+            event.key === Qt.Key_AltGr) {
+            return
+        }
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+            goBack()
+            event.accepted = true
+            return
+        }
+        if (waiting) {
+            event.accepted = true
+            return
+        }
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            setupRoot.submit()
+            event.accepted = true
+        }
+    }
+
+    function submit() {
+        if (waiting) return
+        if (m3uUrl === "") {
+            errorMsg = "Enter an M3U playlist URL or file path"
+            return
+        }
+        waiting = true
+        errorMsg = ""
+        // Persist first so the backend reads the new source, then load.
+        appCore.save_setting(moduleRoot.moduleId, "m3u_url", m3uUrl)
+        iptvBackend.load_groups(true)
+    }
+
+    // Header
+    AppBar {
+        iconSource: moduleRoot.moduleIcon
+        title: moduleRoot.moduleName
+        subtitle: "Add a Playlist"
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125
+        anchors.leftMargin: root.sw * 0.125
+    }
+
+    // Body
+    Column {
+        anchors.centerIn: parent
+        spacing: root.sh * 0.0333333
+
+        Column {
+            spacing: root.sh * 0.0166667
+            width: root.sw * 0.6
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Text {
+                text: "M3U Playlist URL"
+                color: root.secondaryColor
+                font.family: root.globalFont
+                font.capitalization: Font.AllUppercase
+                font.pixelSize: root.sh * 0.0291667
+            }
+
+            Rectangle {
+                width: parent.width
+                height: root.sh * 0.075
+                color: root.surfaceColor
+                border.color: root.accentColor
+                border.width: root.sh * 0.003125
+
+                TextInput {
+                    id: urlInput
+                    anchors.fill: parent
+                    anchors.margins: root.sh * 0.0166667
+                    text: setupRoot.m3uUrl
+                    color: root.primaryColor
+                    font.family: root.globalFont
+                    font.pixelSize: root.sh * 0.0375
+                    clip: true
+                    focus: true
+
+                    onTextChanged: { setupRoot.m3uUrl = text }
+
+                    Keys.onPressed: function(event) {
+                        event.accepted = false
+                    }
+                }
+            }
+        }
+
+        Text {
+            visible: waiting
+            text: "LOADING PLAYLIST..."
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            font.capitalization: Font.AllUppercase
+            anchors.horizontalCenter: parent.horizontalCenter
+            font.pixelSize: root.sh * 0.0333333
+        }
+
+        Text {
+            visible: errorMsg !== ""
+            text: errorMsg
+            color: root.accentColor
+            font.family: root.globalFont
+            font.capitalization: Font.AllUppercase
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: root.sw * 0.6
+            wrapMode: Text.WordWrap
+            font.pixelSize: root.sh * 0.0333333
+        }
+    }
+
+    // Footer
+    Text {
+        text: root.hints.back + ":BACK " + root.hints.select + ":LOAD"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667
+        anchors.leftMargin: root.sw * 0.125
+        font.pixelSize: root.sh * 0.0333333
+    }
+}

--- a/modules/iptv/views/Setup.qml
+++ b/modules/iptv/views/Setup.qml
@@ -1,8 +1,8 @@
 import QtQuick
 import Components
 
-// Playlist setup: enter an M3U URL (or a local file path). Saved to
-// modules.<id>.m3u_url; the backend fetches + parses it on load.
+// Playlist setup: an M3U URL (or local file path) plus an optional XMLTV EPG
+// URL for the now/next guide. Saved to modules.<id>.m3u_url / .epg_url.
 FocusScope {
     focus: true
     id: setupRoot
@@ -14,16 +14,20 @@ FocusScope {
     signal goBack()
 
     property string m3uUrl: appCore.get_setting(moduleRoot.moduleId, "m3u_url") || ""
+    property string epgUrl: appCore.get_setting(moduleRoot.moduleId, "epg_url") || ""
     property bool waiting: false
     property string errorMsg: ""
+
+    // Focus index: 0=M3U URL, 1=EPG URL, 2=Load
+    property int focusIndex: 0
 
     Connections {
         target: iptvBackend
 
         function onGroupsLoaded(groups) {
-            // Playlist parsed successfully — remember it and enter the guide.
             setupRoot.waiting = false
             appCore.save_setting(moduleRoot.moduleId, "m3u_url", setupRoot.m3uUrl)
+            appCore.save_setting(moduleRoot.moduleId, "epg_url", setupRoot.epgUrl)
             setupRoot.replaceWith("Groups.qml", {})
         }
 
@@ -48,7 +52,13 @@ FocusScope {
             event.accepted = true
             return
         }
-        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+        if (event.key === Qt.Key_Up) {
+            if (focusIndex > 0) focusIndex--
+            event.accepted = true
+        } else if (event.key === Qt.Key_Down) {
+            if (focusIndex < 2) focusIndex++
+            event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             setupRoot.submit()
             event.accepted = true
         }
@@ -64,6 +74,7 @@ FocusScope {
         errorMsg = ""
         // Persist first so the backend reads the new source, then load.
         appCore.save_setting(moduleRoot.moduleId, "m3u_url", m3uUrl)
+        appCore.save_setting(moduleRoot.moduleId, "epg_url", epgUrl)
         iptvBackend.load_groups(true)
     }
 
@@ -83,13 +94,19 @@ FocusScope {
         anchors.centerIn: parent
         spacing: root.sh * 0.0333333
 
-        Column {
+        // Reusable labelled field (keys forwarded up to setupRoot.Keys).
+        component Field: Column {
+            property alias label: fieldLabel.text
+            property alias text: fieldInput.text
+            property int index: 0
+            signal edited(string value)
+
             spacing: root.sh * 0.0166667
             width: root.sw * 0.6
             anchors.horizontalCenter: parent.horizontalCenter
 
             Text {
-                text: "M3U Playlist URL"
+                id: fieldLabel
                 color: root.secondaryColor
                 font.family: root.globalFont
                 font.capitalization: Font.AllUppercase
@@ -100,26 +117,55 @@ FocusScope {
                 width: parent.width
                 height: root.sh * 0.075
                 color: root.surfaceColor
-                border.color: root.accentColor
+                border.color: setupRoot.focusIndex === index ? root.accentColor : root.tertiaryColor
                 border.width: root.sh * 0.003125
 
                 TextInput {
-                    id: urlInput
+                    id: fieldInput
                     anchors.fill: parent
                     anchors.margins: root.sh * 0.0166667
-                    text: setupRoot.m3uUrl
                     color: root.primaryColor
                     font.family: root.globalFont
                     font.pixelSize: root.sh * 0.0375
                     clip: true
-                    focus: true
+                    focus: setupRoot.focusIndex === index
 
-                    onTextChanged: { setupRoot.m3uUrl = text }
-
-                    Keys.onPressed: function(event) {
-                        event.accepted = false
-                    }
+                    onTextChanged: edited(text)
+                    Keys.onPressed: function(event) { event.accepted = false }
                 }
+            }
+        }
+
+        Field {
+            label: "M3U Playlist URL"
+            index: 0
+            text: setupRoot.m3uUrl
+            onEdited: function(value) { setupRoot.m3uUrl = value }
+        }
+
+        Field {
+            label: "XMLTV Guide URL (optional)"
+            index: 1
+            text: setupRoot.epgUrl
+            onEdited: function(value) { setupRoot.epgUrl = value }
+        }
+
+        // Load button
+        Rectangle {
+            width: root.sw * 0.234375
+            height: root.sh * 0.0583333
+            color: focusIndex === 2 ? root.accentColor : root.surfaceColor
+            border.color: focusIndex === 2 ? root.accentColor : root.tertiaryColor
+            border.width: root.sh * 0.003125
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Text {
+                anchors.centerIn: parent
+                text: "Load"
+                color: focusIndex === 2 ? root.surfaceColor : root.primaryColor
+                font.family: root.globalFont
+                font.capitalization: Font.AllUppercase
+                font.pixelSize: root.sh * 0.0375
             }
         }
 
@@ -149,7 +195,7 @@ FocusScope {
 
     // Footer
     Text {
-        text: root.hints.back + ":BACK " + root.hints.select + ":LOAD"
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":NAVIGATE " + root.hints.select + ":LOAD"
         color: root.tertiaryColor
         font.family: root.globalFont
         anchors.bottom: parent.bottom

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "modules/local_files/LocalFilesBackend.h"
 #include "modules/plex/PlexBackend.h"
 #include "modules/jellyfin/JellyfinBackend.h"
+#include "modules/iptv/IptvBackend.h"
 #include "modules/ambient_mode/AmbientModeBackend.h"
 #include "modules/nfc_reader/NfcReaderBackend.h"
 #include "modules/youtube/YouTubeBackend.h"
@@ -84,6 +85,7 @@ int main(int argc, char *argv[]) {
     LocalFilesBackend   localFiles(appRoot, dataRoot);
     PlexBackend         plexBackend(appRoot, dataRoot);
     JellyfinBackend     jellyfinBackend(appRoot, dataRoot);
+    IptvBackend         iptvBackend(appRoot, dataRoot);
     AmbientModeBackend  ambientMode(dataRoot);
     NfcReaderBackend    nfcReader(appRoot, dataRoot);
     YouTubeBackend      youtubeBackend(appRoot, dataRoot);
@@ -104,6 +106,7 @@ int main(int argc, char *argv[]) {
     appCore.registerModule("com.240mp.local_files",  "localFilesBackend",  &localFiles,  ctx);
     appCore.registerModule("com.240mp.plex",         "plexBackend",        &plexBackend, ctx);
     appCore.registerModule("com.240mp.jellyfin",     "jellyfinBackend",    &jellyfinBackend, ctx);
+    appCore.registerModule("com.240mp.iptv",         "iptvBackend",        &iptvBackend, ctx);
     appCore.registerModule("com.240mp.ambient_mode", "ambientModeBackend", &ambientMode, ctx);
     appCore.registerModule("com.240mp.nfc_reader",   "nfcReaderBackend",   &nfcReader,   ctx);
     appCore.registerModule("com.240mp.youtube",      "youtubeBackend",     &youtubeBackend, ctx);

--- a/src/modules/iptv/IptvBackend.cpp
+++ b/src/modules/iptv/IptvBackend.cpp
@@ -1,0 +1,214 @@
+#include "IptvBackend.h"
+
+#include <QFile>
+#include <QJsonDocument>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QRegularExpression>
+#include <QUrl>
+#include <QVariantList>
+#include <QVariantMap>
+#include <QHash>
+#include <QDebug>
+
+static const QString kModuleId = QStringLiteral("com.240mp.iptv");
+
+IptvBackend::IptvBackend(const QString &appRoot, const QString &dataRoot, QObject *parent)
+    : QObject(parent)
+    , m_appRoot(appRoot)
+    , m_dataRoot(dataRoot)
+    , m_nam(new QNetworkAccessManager(this))
+{
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+QJsonObject IptvBackend::loadConfig() const {
+    QFile f(m_dataRoot + "/config.json");
+    if (f.open(QIODevice::ReadOnly)) {
+        QJsonParseError err;
+        QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
+        if (err.error == QJsonParseError::NoError && doc.isObject())
+            return doc.object();
+    }
+    return {};
+}
+
+QJsonObject IptvBackend::moduleConfig() const {
+    return loadConfig()["modules"].toObject()[kModuleId].toObject();
+}
+
+QString IptvBackend::sourceUrl() const {
+    return moduleConfig()["m3u_url"].toString().trimmed();
+}
+
+bool IptvBackend::has_source() const {
+    return !sourceUrl().isEmpty();
+}
+
+QString IptvBackend::get_source() const {
+    return sourceUrl();
+}
+
+// ---------------------------------------------------------------------------
+// Load + parse
+// ---------------------------------------------------------------------------
+
+void IptvBackend::load_groups(bool force) {
+    if (m_loaded && !force) {
+        emitGroups();
+        return;
+    }
+    fetchAndParse([this]() { emitGroups(); });
+}
+
+void IptvBackend::load_channels(const QString &group) {
+    if (m_loaded) {
+        emitChannels(group);
+        return;
+    }
+    // Playlist not parsed yet (e.g. Channels opened before Groups): fetch first,
+    // then emit the requested group's channels.
+    fetchAndParse([this, group]() { emitChannels(group); });
+}
+
+void IptvBackend::emitChannels(const QString &group) {
+    const bool all = group.isEmpty() || group == QLatin1String("__all__");
+    QVariantList result;
+    for (const Channel &c : m_channels) {
+        if (all || c.group == group) {
+            result.append(QVariantMap{
+                {"name",  c.name},
+                {"url",   c.url},
+                {"logo",  c.logo},
+                {"group", c.group},
+            });
+        }
+    }
+    emit channelsLoaded(result);
+}
+
+void IptvBackend::fetchAndParse(std::function<void()> onDone) {
+    const QString src = sourceUrl();
+    if (src.isEmpty()) {
+        emit playlistError("NO PLAYLIST CONFIGURED");
+        return;
+    }
+
+    emit loadingChanged(true);
+
+    const bool isUrl = src.startsWith(QLatin1String("http://"), Qt::CaseInsensitive)
+                    || src.startsWith(QLatin1String("https://"), Qt::CaseInsensitive);
+
+    if (!isUrl) {
+        // Local file path.
+        QFile f(src);
+        if (!f.open(QIODevice::ReadOnly)) {
+            emit loadingChanged(false);
+            emit playlistError("CANNOT OPEN PLAYLIST FILE");
+            return;
+        }
+        parseM3U(f.readAll());
+        emit loadingChanged(false);
+        if (onDone) onDone();
+        return;
+    }
+
+    QNetworkRequest req{QUrl(src)};
+    req.setRawHeader("Accept", "*/*");
+    auto *reply = m_nam->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, onDone]() {
+        reply->deleteLater();
+        emit loadingChanged(false);
+        if (reply->error() != QNetworkReply::NoError) {
+            emit playlistError("PLAYLIST DOWNLOAD FAILED: " + reply->errorString());
+            return;
+        }
+        parseM3U(reply->readAll());
+        if (onDone) onDone();
+    });
+}
+
+void IptvBackend::parseM3U(const QByteArray &data) {
+    m_channels.clear();
+    m_loaded = true;
+
+    static const QRegularExpression reLogo(
+        QStringLiteral("tvg-logo=\"([^\"]*)\""));
+    static const QRegularExpression reGroup(
+        QStringLiteral("group-title=\"([^\"]*)\""));
+    static const QRegularExpression reTvgId(
+        QStringLiteral("tvg-id=\"([^\"]*)\""));
+
+    const QString text = QString::fromUtf8(data);
+    const QStringList lines = text.split(QRegularExpression("\r\n|\n|\r"));
+
+    Channel pending;
+    bool havePending = false;
+
+    for (const QString &raw : lines) {
+        const QString line = raw.trimmed();
+        if (line.isEmpty())
+            continue;
+
+        if (line.startsWith(QLatin1String("#EXTINF"))) {
+            pending = Channel{};
+            havePending = true;
+
+            auto mLogo = reLogo.match(line);
+            if (mLogo.hasMatch()) pending.logo = mLogo.captured(1);
+            auto mGroup = reGroup.match(line);
+            if (mGroup.hasMatch()) pending.group = mGroup.captured(1);
+            auto mId = reTvgId.match(line);
+            if (mId.hasMatch()) pending.tvgId = mId.captured(1);
+
+            // Display name is everything after the last comma on the EXTINF line.
+            const int comma = line.lastIndexOf(QLatin1Char(','));
+            if (comma >= 0)
+                pending.name = line.mid(comma + 1).trimmed();
+        } else if (line.startsWith(QLatin1Char('#'))) {
+            // Other directives (#EXTGRP, #EXTVLCOPT, etc.) — ignore for Phase 1.
+            continue;
+        } else if (havePending) {
+            // First non-comment line after an #EXTINF is the stream URL.
+            pending.url = line;
+            if (pending.name.isEmpty())
+                pending.name = line;
+            m_channels.append(pending);
+            havePending = false;
+        }
+    }
+
+    qDebug("[Iptv] Parsed %d channels", int(m_channels.size()));
+}
+
+void IptvBackend::emitGroups() {
+    // Preserve first-appearance order; count channels per group.
+    QVariantList groups;
+    QVector<QString> order;
+    QHash<QString, int> counts;
+    for (const Channel &c : m_channels) {
+        if (!counts.contains(c.group))
+            order.append(c.group);
+        counts[c.group]++;
+    }
+
+    // Always offer an "all channels" shelf first.
+    groups.append(QVariantMap{
+        {"title", QStringLiteral("ALL CHANNELS")},
+        {"key",   QStringLiteral("__all__")},
+        {"count", m_channels.size()},
+    });
+
+    for (const QString &g : order) {
+        groups.append(QVariantMap{
+            {"title", g.isEmpty() ? QStringLiteral("UNGROUPED") : g.toUpper()},
+            {"key",   g},
+            {"count", counts.value(g)},
+        });
+    }
+
+    emit groupsLoaded(groups);
+}

--- a/src/modules/iptv/IptvBackend.cpp
+++ b/src/modules/iptv/IptvBackend.cpp
@@ -11,6 +11,7 @@
 #include <QHash>
 #include <QXmlStreamReader>
 #include <QDateTime>
+#include <QTimeZone>
 #include <QDebug>
 #include <algorithm>
 
@@ -331,7 +332,7 @@ static qint64 parseXmltvTime(const QString &raw) {
         return 0;
     // The 14-digit stamp is wall-clock time in the trailing offset; interpret it
     // as UTC first, then subtract the offset to get true UTC.
-    dt.setTimeSpec(Qt::UTC);
+    dt.setTimeZone(QTimeZone::UTC);
 
     int offsetSec = 0;
     const QString rest = s.mid(14).trimmed(); // e.g. "+0000" / "-0500"

--- a/src/modules/iptv/IptvBackend.cpp
+++ b/src/modules/iptv/IptvBackend.cpp
@@ -9,7 +9,10 @@
 #include <QVariantList>
 #include <QVariantMap>
 #include <QHash>
+#include <QXmlStreamReader>
+#include <QDateTime>
 #include <QDebug>
+#include <algorithm>
 
 static const QString kModuleId = QStringLiteral("com.240mp.iptv");
 
@@ -44,12 +47,20 @@ QString IptvBackend::sourceUrl() const {
     return moduleConfig()["m3u_url"].toString().trimmed();
 }
 
+QString IptvBackend::epgUrl() const {
+    return moduleConfig()["epg_url"].toString().trimmed();
+}
+
 bool IptvBackend::has_source() const {
     return !sourceUrl().isEmpty();
 }
 
 QString IptvBackend::get_source() const {
     return sourceUrl();
+}
+
+QString IptvBackend::get_epg_source() const {
+    return epgUrl();
 }
 
 // ---------------------------------------------------------------------------
@@ -76,18 +87,65 @@ void IptvBackend::load_channels(const QString &group) {
 
 void IptvBackend::emitChannels(const QString &group) {
     const bool all = group.isEmpty() || group == QLatin1String("__all__");
+    const qint64 nowMs = QDateTime::currentDateTimeUtc().toMSecsSinceEpoch();
     QVariantList result;
     for (const Channel &c : m_channels) {
         if (all || c.group == group) {
-            result.append(QVariantMap{
+            QVariantMap m{
                 {"name",  c.name},
                 {"url",   c.url},
                 {"logo",  c.logo},
                 {"group", c.group},
-            });
+                {"tvgId", c.tvgId},
+            };
+            // Merge in now/next guide info (empty fields when no EPG match).
+            const QVariantMap nn = nowNextFor(c.tvgId, nowMs);
+            for (auto it = nn.constBegin(); it != nn.constEnd(); ++it)
+                m.insert(it.key(), it.value());
+            result.append(m);
         }
     }
     emit channelsLoaded(result);
+}
+
+// Returns {nowTitle, nowStartMs, nowStopMs, nextTitle, nextStartMs} for the
+// channel's guide at nowMs. Missing fields stay empty/0 when there's no match.
+QVariantMap IptvBackend::nowNextFor(const QString &tvgId, qint64 nowMs) const {
+    QVariantMap out{
+        {"nowTitle",    QString()},
+        {"nowStartMs",  QVariant::fromValue<qint64>(0)},
+        {"nowStopMs",   QVariant::fromValue<qint64>(0)},
+        {"nextTitle",   QString()},
+        {"nextStartMs", QVariant::fromValue<qint64>(0)},
+    };
+    if (tvgId.isEmpty())
+        return out;
+    auto it = m_epg.constFind(tvgId);
+    if (it == m_epg.constEnd())
+        return out;
+
+    const QVector<Programme> &progs = it.value();
+    // Sorted ascending by start; find the airing programme and the one after.
+    for (int i = 0; i < progs.size(); ++i) {
+        const Programme &p = progs[i];
+        if (nowMs >= p.startMs && nowMs < p.stopMs) {
+            out["nowTitle"]   = p.title;
+            out["nowStartMs"] = QVariant::fromValue<qint64>(p.startMs);
+            out["nowStopMs"]  = QVariant::fromValue<qint64>(p.stopMs);
+            if (i + 1 < progs.size()) {
+                out["nextTitle"]   = progs[i + 1].title;
+                out["nextStartMs"] = QVariant::fromValue<qint64>(progs[i + 1].startMs);
+            }
+            return out;
+        }
+        if (p.startMs > nowMs) {
+            // Gap before the next programme — report it as "next" only.
+            out["nextTitle"]   = p.title;
+            out["nextStartMs"] = QVariant::fromValue<qint64>(p.startMs);
+            return out;
+        }
+    }
+    return out;
 }
 
 void IptvBackend::fetchAndParse(std::function<void()> onDone) {
@@ -98,6 +156,7 @@ void IptvBackend::fetchAndParse(std::function<void()> onDone) {
     }
 
     emit loadingChanged(true);
+    m_epgLoaded = false; // a (re)load of the playlist also refreshes the guide
 
     const bool isUrl = src.startsWith(QLatin1String("http://"), Qt::CaseInsensitive)
                     || src.startsWith(QLatin1String("https://"), Qt::CaseInsensitive);
@@ -111,8 +170,11 @@ void IptvBackend::fetchAndParse(std::function<void()> onDone) {
             return;
         }
         parseM3U(f.readAll());
-        emit loadingChanged(false);
-        if (onDone) onDone();
+        // Load the guide (if any) before signalling completion.
+        fetchEpg([this, onDone]() {
+            emit loadingChanged(false);
+            if (onDone) onDone();
+        });
         return;
     }
 
@@ -121,12 +183,52 @@ void IptvBackend::fetchAndParse(std::function<void()> onDone) {
     auto *reply = m_nam->get(req);
     connect(reply, &QNetworkReply::finished, this, [this, reply, onDone]() {
         reply->deleteLater();
-        emit loadingChanged(false);
         if (reply->error() != QNetworkReply::NoError) {
+            emit loadingChanged(false);
             emit playlistError("PLAYLIST DOWNLOAD FAILED: " + reply->errorString());
             return;
         }
         parseM3U(reply->readAll());
+        fetchEpg([this, onDone]() {
+            emit loadingChanged(false);
+            if (onDone) onDone();
+        });
+    });
+}
+
+void IptvBackend::fetchEpg(std::function<void()> onDone) {
+    // Guide is optional and only loaded once per session. A missing or broken
+    // EPG never blocks channel browsing — it just means no now/next info.
+    const QString url = epgUrl();
+    if (url.isEmpty() || m_epgLoaded) {
+        if (onDone) onDone();
+        return;
+    }
+
+    const bool isUrl = url.startsWith(QLatin1String("http://"), Qt::CaseInsensitive)
+                    || url.startsWith(QLatin1String("https://"), Qt::CaseInsensitive);
+
+    if (!isUrl) {
+        QFile f(url);
+        if (f.open(QIODevice::ReadOnly))
+            parseXmltv(f.readAll());
+        else
+            qWarning("[Iptv] Cannot open EPG file: %s", qPrintable(url));
+        m_epgLoaded = true;
+        if (onDone) onDone();
+        return;
+    }
+
+    QNetworkRequest req{QUrl(url)};
+    req.setRawHeader("Accept", "*/*");
+    auto *reply = m_nam->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, onDone]() {
+        reply->deleteLater();
+        if (reply->error() == QNetworkReply::NoError)
+            parseXmltv(reply->readAll());
+        else
+            qWarning("[Iptv] EPG download failed: %s", qPrintable(reply->errorString()));
+        m_epgLoaded = true; // don't retry this session even on failure
         if (onDone) onDone();
     });
 }
@@ -211,4 +313,74 @@ void IptvBackend::emitGroups() {
     }
 
     emit groupsLoaded(groups);
+}
+
+// ---------------------------------------------------------------------------
+// XMLTV guide
+// ---------------------------------------------------------------------------
+
+// Parse an XMLTV timestamp ("YYYYMMDDHHMMSS +ZZZZ", offset optional) to epoch
+// milliseconds. Returns 0 on failure.
+static qint64 parseXmltvTime(const QString &raw) {
+    const QString s = raw.trimmed();
+    if (s.size() < 14)
+        return 0;
+
+    QDateTime dt = QDateTime::fromString(s.left(14), QStringLiteral("yyyyMMddHHmmss"));
+    if (!dt.isValid())
+        return 0;
+    // The 14-digit stamp is wall-clock time in the trailing offset; interpret it
+    // as UTC first, then subtract the offset to get true UTC.
+    dt.setTimeSpec(Qt::UTC);
+
+    int offsetSec = 0;
+    const QString rest = s.mid(14).trimmed(); // e.g. "+0000" / "-0500"
+    if (rest.size() >= 5 && (rest[0] == QLatin1Char('+') || rest[0] == QLatin1Char('-'))) {
+        const int hh = rest.mid(1, 2).toInt();
+        const int mm = rest.mid(3, 2).toInt();
+        offsetSec = (hh * 3600 + mm * 60) * (rest[0] == QLatin1Char('-') ? -1 : 1);
+    }
+    return dt.addSecs(-offsetSec).toMSecsSinceEpoch();
+}
+
+void IptvBackend::parseXmltv(const QByteArray &data) {
+    m_epg.clear();
+
+    QXmlStreamReader xml(data);
+    while (!xml.atEnd() && !xml.hasError()) {
+        if (xml.readNext() != QXmlStreamReader::StartElement)
+            continue;
+        if (xml.name() != QLatin1String("programme"))
+            continue;
+
+        const QString channel = xml.attributes().value(QLatin1String("channel")).toString();
+        const qint64 startMs = parseXmltvTime(xml.attributes().value(QLatin1String("start")).toString());
+        const qint64 stopMs  = parseXmltvTime(xml.attributes().value(QLatin1String("stop")).toString());
+        QString title;
+
+        // Read child elements until the matching </programme>.
+        while (!(xml.tokenType() == QXmlStreamReader::EndElement
+                 && xml.name() == QLatin1String("programme"))) {
+            if (xml.readNext() == QXmlStreamReader::StartElement
+                && xml.name() == QLatin1String("title") && title.isEmpty()) {
+                title = xml.readElementText();
+            }
+            if (xml.atEnd())
+                break;
+        }
+
+        if (channel.isEmpty() || startMs == 0)
+            continue;
+        m_epg[channel].append(Programme{startMs, stopMs, title});
+    }
+
+    // Sort each channel's programmes by start time so now/next lookups are a
+    // single ordered scan.
+    int total = 0;
+    for (auto it = m_epg.begin(); it != m_epg.end(); ++it) {
+        std::sort(it.value().begin(), it.value().end(),
+                  [](const Programme &a, const Programme &b) { return a.startMs < b.startMs; });
+        total += it.value().size();
+    }
+    qDebug("[Iptv] Parsed EPG: %d channels, %d programmes", int(m_epg.size()), total);
 }

--- a/src/modules/iptv/IptvBackend.h
+++ b/src/modules/iptv/IptvBackend.h
@@ -3,6 +3,7 @@
 #include <QVariant>
 #include <QString>
 #include <QVector>
+#include <QHash>
 #include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <functional>
@@ -16,9 +17,11 @@ class IptvBackend : public QObject {
 public:
     explicit IptvBackend(const QString &appRoot, const QString &dataRoot, QObject *parent = nullptr);
 
-    // Source (the configured M3U URL / path lives in modules.<id>.m3u_url).
+    // Source (the configured M3U URL / path lives in modules.<id>.m3u_url;
+    // the optional XMLTV guide URL lives in modules.<id>.epg_url).
     Q_INVOKABLE bool has_source() const;
     Q_INVOKABLE QString get_source() const;
+    Q_INVOKABLE QString get_epg_source() const;
 
     // Fetch + parse (once), then emit groupsLoaded. Cheap to call repeatedly —
     // it only re-fetches when nothing is cached or force is true.
@@ -43,17 +46,32 @@ private:
         QString tvgId;
     };
 
+    struct Programme {
+        qint64 startMs = 0;
+        qint64 stopMs = 0;
+        QString title;
+    };
+
     QString m_appRoot;
     QString m_dataRoot;
     QNetworkAccessManager *m_nam;
     QVector<Channel> m_channels;
+    // XMLTV programmes keyed by channel id (matched against each channel's
+    // tvg-id), each list sorted ascending by start time.
+    QHash<QString, QVector<Programme>> m_epg;
     bool m_loaded = false;
+    bool m_epgLoaded = false;
 
     QString sourceUrl() const;
+    QString epgUrl() const;
     void fetchAndParse(std::function<void()> onDone);
+    void fetchEpg(std::function<void()> onDone);
     void parseM3U(const QByteArray &data);
+    void parseXmltv(const QByteArray &data);
     void emitGroups();
     void emitChannels(const QString &group);
+    // now/next for a channel id at the given epoch-ms time.
+    QVariantMap nowNextFor(const QString &tvgId, qint64 nowMs) const;
 
     QJsonObject loadConfig() const;
     QJsonObject moduleConfig() const;

--- a/src/modules/iptv/IptvBackend.h
+++ b/src/modules/iptv/IptvBackend.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <QObject>
+#include <QVariant>
+#include <QString>
+#include <QVector>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <functional>
+
+// Live TV / IPTV backend. Reads a user-supplied M3U playlist (a remote URL or a
+// local file), parses its #EXTINF channel entries, and exposes them grouped by
+// category. Streams are handed to mpv untouched (HLS/TS/UDP) — there is no auth,
+// transcode, or progress reporting for live playback.
+class IptvBackend : public QObject {
+    Q_OBJECT
+public:
+    explicit IptvBackend(const QString &appRoot, const QString &dataRoot, QObject *parent = nullptr);
+
+    // Source (the configured M3U URL / path lives in modules.<id>.m3u_url).
+    Q_INVOKABLE bool has_source() const;
+    Q_INVOKABLE QString get_source() const;
+
+    // Fetch + parse (once), then emit groupsLoaded. Cheap to call repeatedly —
+    // it only re-fetches when nothing is cached or force is true.
+    Q_INVOKABLE void load_groups(bool force = false);
+    // Emit channelsLoaded for a group ("" or "__all__" = every channel).
+    Q_INVOKABLE void load_channels(const QString &group);
+
+signals:
+    // [{ title, key, count }] — key is the raw group name ("" for ungrouped).
+    void groupsLoaded(const QVariant &groups);
+    // [{ name, url, logo, group }]
+    void channelsLoaded(const QVariant &channels);
+    void playlistError(const QString &message);
+    void loadingChanged(bool loading);
+
+private:
+    struct Channel {
+        QString name;
+        QString url;
+        QString logo;
+        QString group;
+        QString tvgId;
+    };
+
+    QString m_appRoot;
+    QString m_dataRoot;
+    QNetworkAccessManager *m_nam;
+    QVector<Channel> m_channels;
+    bool m_loaded = false;
+
+    QString sourceUrl() const;
+    void fetchAndParse(std::function<void()> onDone);
+    void parseM3U(const QByteArray &data);
+    void emitGroups();
+    void emitChannels(const QString &group);
+
+    QJsonObject loadConfig() const;
+    QJsonObject moduleConfig() const;
+};


### PR DESCRIPTION
## Summary

Adds a self-contained **Live TV (IPTV)** module (`modules/iptv/` plus `src/modules/iptv/`, one `registerModule` call). Channel-surfing for the VCR concept: point it at an M3U playlist and browse/watch. Ships disabled by default.

- **Playlist**: an M3U from a remote URL or a local file. Channels are grouped by `group-title`, with an "ALL CHANNELS" shelf first and a "CHANGE PLAYLIST" entry so a bad URL can be fixed without leaving the module.
- **Guide (optional)**: an XMLTV URL gives a now/next line and a progress bar per channel, matched to channels by `tvg-id`.
- **Playback**: streams are handed straight to mpv untouched (HLS/TS/UDP). No auth, transcode, or DRM, in keeping with browse-and-hand-off.
- **List wraparound**: the channel and group lists follow the app-wide pattern from #174 (added here since these views are new).

Relates to #153.

## AI involvement

Per CONTRIBUTING.md: the initial implementation was AI-generated (Claude Code), then built and tested locally by me against a real playlist and guide. The wraparound was added and the module re-verified in this pass.

## Testing (macOS ARM)

Verified against a live Melbourne free-to-air feed from Matt Huisman's free over-the-air service (a good, legal test source if you want to try it yourself):

- Playlist: `https://i.mjh.nz/au/Melbourne/raw-tv.m3u8` (167 channels)
- Guide: `https://i.mjh.nz/au/Melbourne/epg.xml`

Checked M3U parse and grouping, the channel list, playback (streams hand to mpv), and the EPG (126 channels matched, ~15.8k programmes) with the now/next lines confirmed against actual broadcast times. The guide URL serves a 302 redirect, which Qt's network stack follows, so the guide still loads. `i.mjh.nz` has equivalents for other AU/NZ regions and a few other countries if you want a different region. Not yet run on a Pi/CRT.

## Checklist

- [x] Works with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Sized with `root.sh` / `root.sw` (no hardcoded pixels), CRT overscan in mind
- [x] No tracking/analytics; only writes settings (playlist/guide URLs) to the local data dir
- [x] Follows ARCHITECTURE.md patterns and CONTRIBUTING.md principles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
