### PR TITLE
feat(jellyfin): change subtitle track during transcode

### DIFF
--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -313,11 +313,7 @@ FocusScope {
                 }
             }
         }
-        if (jellyfinBackend && typeof jellyfinBackend.set_last_track_langs === "function") {
-            jellyfinBackend.set_last_track_langs(aLang, sLang, aLangIdx, sLangIdx)
-        } else {
-            console.log("[Item] Skipping set_last_track_langs: backend method not available")
-        }
+        jellyfinBackend.set_last_track_langs(aLang, sLang, aLangIdx, sLangIdx)
     }
 
     function applyLanguagePreferences(d) {

--- a/modules/jellyfin/views/Item.qml
+++ b/modules/jellyfin/views/Item.qml
@@ -313,7 +313,11 @@ FocusScope {
                 }
             }
         }
-        jellyfinBackend.set_last_track_langs(aLang, sLang, aLangIdx, sLangIdx)
+        if (jellyfinBackend && typeof jellyfinBackend.set_last_track_langs === "function") {
+            jellyfinBackend.set_last_track_langs(aLang, sLang, aLangIdx, sLangIdx)
+        } else {
+            console.log("[Item] Skipping set_last_track_langs: backend method not available")
+        }
     }
 
     function applyLanguagePreferences(d) {

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -382,12 +382,22 @@ FocusScope {
     function doStartPlayback(offsetMs) {
         var jfToken = jellyfinBackend.get_access_token()
         if (isTranscoding) {
-            // HLS manifest bakes in the selected audio, and the chosen subtitle is
-            // burned into the video — so there's no soft sub track for mpv to pick
-            // (subTrack -2 = --sid=no, a no-op when nothing soft exists).
+            // Find the human-readable name of the selected subtitle track
+            var subName = "Off"
+            if (subtitleIdx >= 0 && subtitleStreams && subtitleStreams[subtitleIdx]) {
+                var s = subtitleStreams[subtitleIdx]
+                subName = s.displayTitle || s.title || s.language || "Unknown"
+            }
+            
+            // Replace spaces with underscores for command-line safety
+            subName = subName.replace(/ /g, "_")
+            
+            // Inject it as a custom script option
+            var extra = ["--script-opts=transcode_sub=" + subName]
+
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
                                        -1, -2, [], [], false, -1, 0.0, "",
-                                       false, "", false, [], 0.0, false, [], jfToken)
+                                       false, "", false, [], 0.0, false, extra, jfToken)
         } else {
             // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
             // --aid; subtitles come from buildSubArgs (sidecars + --sid).
@@ -530,6 +540,25 @@ FocusScope {
                 // end naturally. Nulling it before the seek completes causes a
                 // position update at the old location to re-detect the same
                 // segment as "new" and re-trigger the prompt.
+            } else if (streamUrl.indexOf(".m3u8") >= 0 && subtitleStreams && subtitleStreams.length > 0) {
+                subtitleIdx++
+                if (subtitleIdx >= subtitleStreams.length) subtitleIdx = -1
+
+                selectedSubtitleId = subtitleIdx >= 0 ? subtitleStreams[subtitleIdx].id : ""
+
+                // Save the current timestamp so we can resume smoothly
+                lastKnownPositionMs = mpvController.position
+                pendingRetryTranscode = true
+                stoppedReported = false
+
+                var aIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
+                var sIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
+                
+                // Explicitly stop mpv before requesting the new stream
+                mpvController.stop()
+                
+                // Request a new transcode from the server with the new SubtitleStreamIndex
+                jellyfinBackend.get_playback_url(itemId, mediaSourceId, aIdx, sIdx, true)
             }
         }
 

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -31,6 +31,9 @@ FocusScope {
     property bool   pendingNextEpisode: false
     // Set when a direct-play attempt fails and we re-request forcing a transcode.
     property bool   pendingRetryTranscode: false
+    // Set when the user changed the subtitle mid-transcode: mpv is quitting so we
+    // can re-request the stream with a different burned-in track (not a real stop).
+    property bool   pendingSubtitleSwitch: false
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
     // Full stream metadata used to disambiguate when several streams share a language.
@@ -382,18 +385,24 @@ FocusScope {
     function doStartPlayback(offsetMs) {
         var jfToken = jellyfinBackend.get_access_token()
         if (isTranscoding) {
-            // Find the human-readable name of the selected subtitle track
+            // The HLS manifest bakes in the selected audio, and the chosen subtitle
+            // is burned into the video — so there's no soft sub track for mpv to
+            // pick (subTrack -2 = --sid=no) or to cycle. Instead the OSC gets:
+            //   sub-cycle     — show a SUBTITLE button that asks us to switch
+            //                   (handled in onSubtitleCycleRequested → new transcode)
+            //   transcode-sub — the burned-in track's name, for the info line
+            // Both go through --script-opts-append: a plain --script-opts= would
+            // replace the list MpvController already built (screensaver, hide-crop…).
             var subName = "Off"
-            if (subtitleIdx >= 0 && subtitleStreams && subtitleStreams[subtitleIdx]) {
+            if (subtitleIdx >= 0 && subtitleStreams[subtitleIdx]) {
                 var s = subtitleStreams[subtitleIdx]
                 subName = s.displayTitle || s.title || s.language || "Unknown"
             }
-            
-            // Replace spaces with underscores for command-line safety
-            subName = subName.replace(/ /g, "_")
-            
-            // Inject it as a custom script option
-            var extra = ["--script-opts=transcode_sub=" + subName]
+            // script-opts is a comma-separated key=value list, so the value can
+            // carry neither a comma nor an "="; spaces round-trip as underscores.
+            subName = subName.replace(/ /g, "_").replace(/[,=]/g, "")
+            var extra = ["--script-opts-append=transcode-sub=" + subName,
+                         "--script-opts-append=sub-cycle=" + (subtitleStreams.length > 0 ? "1" : "0")]
 
             mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
                                        -1, -2, [], [], false, -1, 0.0, "",
@@ -540,29 +549,45 @@ FocusScope {
                 // end naturally. Nulling it before the seek completes causes a
                 // position update at the old location to re-detect the same
                 // segment as "new" and re-trigger the prompt.
-            } else if (streamUrl.indexOf(".m3u8") >= 0 && subtitleStreams && subtitleStreams.length > 0) {
-                subtitleIdx++
-                if (subtitleIdx >= subtitleStreams.length) subtitleIdx = -1
-
-                selectedSubtitleId = subtitleIdx >= 0 ? subtitleStreams[subtitleIdx].id : ""
-
-                // Save the current timestamp so we can resume smoothly
-                lastKnownPositionMs = mpvController.position
-                pendingRetryTranscode = true
-                stoppedReported = false
-
-                var aIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
-                var sIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
-                
-                // Explicitly stop mpv before requesting the new stream
-                mpvController.stop()
-                
-                // Request a new transcode from the server with the new SubtitleStreamIndex
-                jellyfinBackend.get_playback_url(itemId, mediaSourceId, aIdx, sIdx, true)
             }
         }
 
+        // OSC SUBTITLE button during a transcode. The sub is burned into the
+        // video, so switching means a new transcode: quit mpv, then do the work
+        // in onPlaybackEnded once it has actually exited — starting the request
+        // here would race mpv's exit, and that exit would run the normal
+        // "user stopped" path and navigate out of the player.
+        function onSubtitleCycleRequested() {
+            if (!isTranscoding || subtitleStreams.length === 0) return
+            playerRoot.lastKnownPositionMs = mpvController.position
+            playerRoot.pendingSubtitleSwitch = true
+            mpvController.stop()
+        }
+
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            if (pendingSubtitleSwitch) {
+                // mpv exited because we asked it to (onSubtitleCycleRequested), not
+                // because the user stopped. Close out the old transcode session so
+                // the server tears the encode down, advance to the next subtitle,
+                // and re-request — onStreamUrlReady's pendingRetryTranscode branch
+                // resumes at lastKnownPositionMs. Deliberately no goBack().
+                pendingSubtitleSwitch = false
+                reportStopped(finalPositionMs, finalDurationMs)
+                stoppedReported = false
+
+                subtitleIdx++
+                if (subtitleIdx >= subtitleStreams.length) subtitleIdx = -1
+                selectedSubtitleId = subtitleIdx >= 0 ? subtitleStreams[subtitleIdx].id : ""
+                // Keep the autoplay carry-over hints in step with the new choice so
+                // the next episode inherits it.
+                captureCarryLanguages()
+
+                pendingRetryTranscode = true
+                var newAIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
+                var newSIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
+                jellyfinBackend.get_playback_url(itemId, mediaSourceId, newAIdx, newSIdx, true)
+                return
+            }
             if (reason === "failed") {
                 if (!isTranscoding) {
                     // Direct play failed (e.g. a codec mpv couldn't handle, or a

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -52,18 +52,14 @@ local function get_audio_str()
 end
 
 local function get_sub_str()
-    -- 1. Check for QML-injected transcode subtitle name first
-    local transcode_sub = mp.get_opt("transcode_sub")
+    -- Burned-in transcode sub: there is no mpv track to read, so the app passes
+    -- the selected track's name (spaces as underscores) for display.
+    local transcode_sub = mp.get_opt("transcode-sub")
     if transcode_sub and transcode_sub ~= "" then
-        if transcode_sub == "Off" then
-            return "(NONE)"
-        else
-            -- Convert underscores back to spaces and match the UI's uppercase style
-            return transcode_sub:gsub("_", " "):upper()
-        end
+        if transcode_sub == "Off" then return "(NONE)" end
+        return (transcode_sub:gsub("_", " ")):upper()
     end
 
-    -- 2. Standard mpv track logic for direct play
     local id = mp.get_property_number("current-tracks/sub/id", 0)
     if id == 0 then return "(NONE)" end
     -- External sidecar with an app-provided friendly name (e.g. Jellyfin): use it
@@ -82,34 +78,32 @@ local function get_sub_str()
     return table.concat(parts, " ")
 end
 
+-- Set by the app when the subtitle is burned into the stream and only the module
+-- can change it (Jellyfin transcode): mpv has no sub track to cycle, so the
+-- SUBTITLE button asks the module to re-request the stream instead.
+local sub_cycle = mp.get_opt("sub-cycle") == "1"
+
 local btn_actions = {
     function() mp.command("no-osd cycle audio") end,
     function()
-        local path = mp.get_property("path", "")
-        if path and path:find("%.m3u8") then
-            -- Hijack the exact signal the C++ wrapper allows through
-            mp.commandv("script-message", "skip-segment")
+        if sub_cycle then
+            mp.commandv("script-message", "cycle-sub")
         else
             mp.command("no-osd cycle sub")
         end
     end,
     function() mp.command("no-osd cycle-values panscan 0 1") end,
-    function() mp.command("quit") end
+    function() mp.command("quit") end,
+    function() mp.command("playlist-prev") end,
+    function() mp.command("playlist-next") end,
 }
 
 local function has_subtitle_tracks()
-    -- Always show the button for transcoded HLS streams
-    local path = mp.get_property("path", "")
-    if path and path:find("%.m3u8") then
-        return true
-    end
-    
-    -- Fall back to checking standard tracks for direct play
-    local count = mp.get_property_number("track-list/count", 0)
-    for i = 0, count - 1 do
-        if mp.get_property("track-list/"..i.."/type") == "sub" then
-            return true
-        end
+    -- Burned-in transcode subs never appear in the track list.
+    if sub_cycle then return true end
+    local tracks = mp.get_property_native("track-list", {})
+    for _, t in ipairs(tracks) do
+        if t.type == "sub" then return true end
     end
     return false
 end

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -52,6 +52,18 @@ local function get_audio_str()
 end
 
 local function get_sub_str()
+    -- 1. Check for QML-injected transcode subtitle name first
+    local transcode_sub = mp.get_opt("transcode_sub")
+    if transcode_sub and transcode_sub ~= "" then
+        if transcode_sub == "Off" then
+            return "(NONE)"
+        else
+            -- Convert underscores back to spaces and match the UI's uppercase style
+            return transcode_sub:gsub("_", " "):upper()
+        end
+    end
+
+    -- 2. Standard mpv track logic for direct play
     local id = mp.get_property_number("current-tracks/sub/id", 0)
     if id == 0 then return "(NONE)" end
     -- External sidecar with an app-provided friendly name (e.g. Jellyfin): use it
@@ -72,17 +84,32 @@ end
 
 local btn_actions = {
     function() mp.command("no-osd cycle audio") end,
-    function() mp.command("no-osd cycle sub") end,
+    function()
+        local path = mp.get_property("path", "")
+        if path and path:find("%.m3u8") then
+            -- Hijack the exact signal the C++ wrapper allows through
+            mp.commandv("script-message", "skip-segment")
+        else
+            mp.command("no-osd cycle sub")
+        end
+    end,
     function() mp.command("no-osd cycle-values panscan 0 1") end,
-    function() mp.command("quit") end,
-    function() mp.command("playlist-prev") end,
-    function() mp.command("playlist-next") end,
+    function() mp.command("quit") end
 }
 
 local function has_subtitle_tracks()
-    local tracks = mp.get_property_native("track-list", {})
-    for _, t in ipairs(tracks) do
-        if t.type == "sub" then return true end
+    -- Always show the button for transcoded HLS streams
+    local path = mp.get_property("path", "")
+    if path and path:find("%.m3u8") then
+        return true
+    end
+    
+    -- Fall back to checking standard tracks for direct play
+    local count = mp.get_property_number("track-list/count", 0)
+    for i = 0, count - 1 do
+        if mp.get_property("track-list/"..i.."/type") == "sub" then
+            return true
+        end
     end
     return false
 end

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -1035,22 +1035,36 @@ void JellyfinBackend::get_playback_url(const QString &itemId, const QString &med
         // Direct play serves the original file whole and mpv renders embedded
         // subtitles itself. Advertise Embed (not Encode) so the server doesn't
         // force a transcode just to burn in / convert the selected subtitle.
-        auto addEmbed = [&](const char *fmt) {
+        auto addProfile = [&](const char *fmt, const char *method) {
             QJsonObject s;
             s["Format"] = QString::fromLatin1(fmt);
-            s["Method"] = QStringLiteral("Embed");
+            s["Method"] = QString::fromLatin1(method);
             subtitleProfiles.append(s);
         };
-        addEmbed("subrip");
-        addEmbed("srt");
-        addEmbed("ass");
-        addEmbed("ssa");
-        addEmbed("vtt");
-        addEmbed("webvtt");
-        addEmbed("mov_text");
-        addEmbed("pgssub");
-        addEmbed("dvbsub");
-        addEmbed("dvdsub");
+        // Text formats can also arrive as a sidecar file sitting next to the video
+        // ("… - External" tracks). Those can't be embedded into a static stream, so
+        // advertising Embed alone made the server deny direct play entirely
+        // (SubtitleCodecNotSupported) and fall back to a burn-in transcode. External
+        // tells it to keep direct play and serve the sub separately — which is what
+        // the app already does with them: every text sub is fetched from
+        // /Videos/{id}/{src}/Subtitles/{idx}/Stream.{ext} and passed to mpv as a
+        // --sub-file (see the subUrl built in formatItem + buildSubArgs in Player.qml).
+        auto addText = [&](const char *fmt) {
+            addProfile(fmt, "External");
+            addProfile(fmt, "Embed");
+        };
+        addText("subrip");
+        addText("srt");
+        addText("ass");
+        addText("ssa");
+        addText("vtt");
+        addText("webvtt");
+        addText("mov_text");
+        // Image subs have no text sidecar for mpv to load, so they can only come
+        // from the embedded stream (selected with --sid).
+        addProfile("pgssub", "Embed");
+        addProfile("dvbsub", "Embed");
+        addProfile("dvdsub", "Embed");
     } else {
         // Transcode: burn the selected subtitle into the video (like the Plex
         // module). Soft HLS subtitle renditions are unreliable in mpv — they

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -500,6 +500,8 @@ void MpvController::onIpcReadyRead() {
                     const QString msg = args[0].toString();
                     if (msg == "skip-segment")
                         emit skipRequested();
+                    else if (msg == "cycle-sub")
+                        emit subtitleCycleRequested();
                 }
             }
             continue;

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -82,6 +82,10 @@ signals:
     void playbackEnded(int finalPositionMs, int finalDurationMs, const QString &reason);
 
     void skipRequested();
+    // The OSC's SUBTITLE button when the sub is burned into the stream and mpv
+    // has nothing to cycle (see `sub-cycle` in scripts/mpv-osc.lua). The module
+    // owns the change — typically stop, re-request the stream, relaunch.
+    void subtitleCycleRequested();
 
 private slots:
     void onProcessFinished();


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Allow changing subtitle track during playback in the Jellyfin module during transcoding. 
## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Used to check my work

## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->

Tested on MacOS and works perfect from what I have tested. 

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)

Probably needs some further testing to make sure I didn't break anything. Also having a menu to switch subtitle and audio tracks instead of just cycling through them might be a good idea. 