### PR TITLE
feat(core): wraparound in remap controls

### DIFF
--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -197,12 +197,9 @@ FocusScope {
         Keys.onUpPressed: {
             if (currentIndex > 0) currentIndex-- 
             else {
-                for (var i = schemaItems.length - 1; i >= 0; i--) {
-                    if (schemaItems[i].type !== "section") { currentIndex = i; break }
-                }
+                currentIndex = schemaItems.length-1
             }
             schemaItems.positionViewAtIndex(currentIndex, ListView.Contain)
-
         }
         Keys.onDownPressed: {
             if (currentIndex < count - 1) currentIndex++

--- a/views/RemapControls.qml
+++ b/views/RemapControls.qml
@@ -142,12 +142,9 @@ FocusScope {
         Keys.onUpPressed: {
             if (currentIndex > 0) currentIndex-- 
             else {
-                for (var i = rows.length - 1; i >= 0; i--) {
-                    if (rows[i].type !== "section") { currentIndex = i; break }
-                }
+                currentIndex = rows.length-1
             }
             rowList.positionViewAtIndex(currentIndex, ListView.Contain)
-
         }
         Keys.onDownPressed: {
             if (currentIndex < count - 1) currentIndex++

--- a/views/RemapControls.qml
+++ b/views/RemapControls.qml
@@ -139,8 +139,21 @@ FocusScope {
         clip: true
         focus: !remapRoot.capturing
 
-        Keys.onUpPressed:   currentIndex = Math.max(0, currentIndex - 1)
-        Keys.onDownPressed: currentIndex = Math.min(rows.length - 1, currentIndex + 1)
+        Keys.onUpPressed: {
+            if (currentIndex > 0) currentIndex-- 
+            else {
+                for (var i = rows.length - 1; i >= 0; i--) {
+                    if (rows[i].type !== "section") { currentIndex = i; break }
+                }
+            }
+            rowList.positionViewAtIndex(currentIndex, ListView.Contain)
+
+        }
+        Keys.onDownPressed: {
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            rowList.positionViewAtIndex(currentIndex, ListView.Contain)
+        }
         Keys.onReturnPressed: {
             var row = remapRoot.rows[currentIndex]
             if (!row) return

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -212,29 +212,22 @@ FocusScope {
         focus: true
 
         Keys.onUpPressed: {
-            var prev = settingsRoot.firstSelectableBefore(currentIndex)
-            if (prev !== currentIndex) {
-                currentIndex = prev
-            } else {
-                // wrap to last selectable
-                for (var i = settingsItems.length - 1; i >= 0; i--) {
-                    if (settingsItems[i].type !== "section") { currentIndex = i; break }
-                }
+            if (currentIndex > 0) currentIndex-- 
+            else {
+                currentIndex = settingsItems.length-1
+            }
+            while (settingsItems[currentIndex].type == "section") {
+                currentIndex--
             }
             settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
         }
         Keys.onDownPressed: {
-            var next = settingsRoot.firstSelectableAfter(currentIndex)
-            if (next !== currentIndex) {
-                currentIndex = next
-                settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
-            } else {
-                // wrap to first selectable
-                for (var j = 0; j < settingsItems.length; j++) {
-                    if (settingsItems[j].type !== "section") { currentIndex = j; break }
-                }
-                settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
+            if (currentIndex < count - 1) currentIndex++
+            else currentIndex = 0
+            while (settingsItems[currentIndex].type == "section") {
+                currentIndex++
             }
+            settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
         }
 
         Keys.onLeftPressed: {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Adds list wraparound in the remap controls menu, also future proofs for a longer list of controls. 
Separately simplifies the settings wraparound logic. 
## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Not used
## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->

Tested on MacOS works perfect for me

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
