### PR TITLE
Fix NFC polling when the module is disabled

### DIFF
--- a/src/modules/nfc_reader/NfcReaderBackend.cpp
+++ b/src/modules/nfc_reader/NfcReaderBackend.cpp
@@ -285,7 +285,9 @@ void NfcReaderBackend::stopPolling() {
     if (m_watchdog)
         m_watchdog->stop();
 
-    abandonWorker(1500);
+    // Settings changes run on the main thread, so release logical ownership
+    // without waiting for a potentially wedged PC/SC call to return.
+    abandonWorker(0);
     m_lastSampleMs = 0;
     m_respawnCount = 0;
 

--- a/src/modules/nfc_reader/NfcReaderBackend.cpp
+++ b/src/modules/nfc_reader/NfcReaderBackend.cpp
@@ -5,6 +5,8 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonValue>
+#include <QMetaType>
 #include <QTimer>
 #include <QDateTime>
 #include <QDebug>
@@ -182,21 +184,25 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
 {
     qDebug("[NfcReader] Initializing NFC reader backend");
 
-    // Resolve the configured tags directory (falls back to the dataRoot/nfc_tags default).
+    // Resolve module settings (the tags directory falls back to dataRoot/nfc_tags).
     m_tagsDir = m_dataRoot + "/" + kTagsDirName;
+    bool configuredEnabled = false;
     QFile f(m_dataRoot + "/config.json");
     if (f.open(QIODevice::ReadOnly)) {
-        const QString dir = QJsonDocument::fromJson(f.readAll()).object()
-            ["modules"].toObject()["com.240mp.nfc_reader"].toObject()
-            ["tags_directory"].toString();
+        const QJsonObject moduleConfig = QJsonDocument::fromJson(f.readAll()).object()
+            ["modules"].toObject()["com.240mp.nfc_reader"].toObject();
+        const QString dir = moduleConfig["tags_directory"].toString();
         if (!dir.isEmpty())
             m_tagsDir = dir;
+
+        const QJsonValue enabled = moduleConfig["enabled"];
+        if (enabled.isBool())
+            configuredEnabled = enabled.toBool();
     }
     qDebug("[NfcReader] Tags dir: %s", qPrintable(tagsDirPath()));
 
     QDir().mkpath(tagsDirPath());
     scanTagsDir();
-    startWorker();
 
     // If the worker wedges inside a PC/SC call, first report the reader as
     // disconnected rather than showing a stale "tap a card" while taps go
@@ -204,6 +210,8 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
     m_watchdog = new QTimer(this);
     m_watchdog->setInterval(2000);
     connect(m_watchdog, &QTimer::timeout, this, [this]() {
+        if (!m_pollingEnabled || !m_workerThread || !m_worker) return;
+
         const qint64 stalledMs = QDateTime::currentMSecsSinceEpoch() - m_lastSampleMs;
         if (stalledMs < kStallDisconnectMs) return;
 
@@ -221,21 +229,80 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
             qWarning("[NfcReader] Poll thread wedged for %llds - restarting it (attempt %d/%d)",
                      static_cast<long long>(stalledMs / 1000), m_respawnCount, kMaxRespawns);
             abandonWorker(100);
+            if (!m_pollingEnabled) return;
             startWorker();
-            m_lastSampleMs = QDateTime::currentMSecsSinceEpoch();
             if (m_respawnCount == kMaxRespawns) {
-                qWarning("[NfcReader] Repeated PC/SC wedges - giving up until app restart");
+                qWarning("[NfcReader] Repeated PC/SC wedges - pausing restarts until polling recovers or NFC is re-enabled");
             }
         }
     });
-    m_watchdog->start();
+
+    if (configuredEnabled) {
+        setPollingEnabled(true);
+    } else {
+        qInfo("[NfcReader] Polling disabled by configuration");
+    }
 }
 
 NfcReaderBackend::~NfcReaderBackend() {
+    m_pollingEnabled = false;
+    if (m_watchdog)
+        m_watchdog->stop();
     abandonWorker(1500);
 }
 
+void NfcReaderBackend::setPollingEnabled(bool enabled) {
+    if (m_pollingEnabled == enabled) return;
+
+    m_pollingEnabled = enabled;
+    if (enabled)
+        startPolling();
+    else
+        stopPolling();
+}
+
+void NfcReaderBackend::startPolling() {
+    if (!m_pollingEnabled) return;
+
+    if (!available()) {
+        if (m_watchdog)
+            m_watchdog->stop();
+        qInfo("[NfcReader] Polling enabled but PC/SC support is unavailable");
+        return;
+    }
+
+    if (m_workerThread || m_worker) return;
+
+    m_respawnCount = 0;
+    startWorker();
+    if (!m_workerThread || !m_worker) return;
+
+    m_watchdog->start();
+    qInfo("[NfcReader] Polling started");
+}
+
+void NfcReaderBackend::stopPolling() {
+    if (m_watchdog)
+        m_watchdog->stop();
+
+    abandonWorker(1500);
+    m_lastSampleMs = 0;
+    m_respawnCount = 0;
+
+    if (m_readerConnected) {
+        m_readerConnected = false;
+        emit readerConnectedChanged();
+    }
+    m_lastUid.clear();
+    m_playbackActive = false;
+    setCardState("none");
+
+    qInfo("[NfcReader] Polling disabled");
+}
+
 void NfcReaderBackend::startWorker() {
+    if (!m_pollingEnabled || !available() || m_workerThread || m_worker) return;
+
     m_lastSampleMs = QDateTime::currentMSecsSinceEpoch();
     m_workerThread = new QThread(this);
     m_worker = new NfcPollWorker;
@@ -256,7 +323,7 @@ void NfcReaderBackend::abandonWorker(int waitMs) {
     } else {
         // The thread is stuck in an uninterruptible PC/SC call: it can't be
         // terminated (mach_msg is not a cancellation point) and destroying a
-        // running QThread aborts the process. Unparent and leak it instead;
+        // running QThread aborts the process. Unparent it instead;
         // if the call ever returns, the thread exits (quit() was already
         // requested) and deletes itself.
         m_workerThread->setParent(nullptr);
@@ -279,8 +346,14 @@ void NfcReaderBackend::setTagsDir(const QString &path) {
 }
 
 void NfcReaderBackend::onSettingChanged(const QString &moduleId, const QString &key, const QVariant &value) {
-    if (moduleId == QLatin1String("com.240mp.nfc_reader") && key == QLatin1String("tags_directory"))
+    if (moduleId != QLatin1String("com.240mp.nfc_reader")) return;
+
+    if (key == QLatin1String("enabled")) {
+        const bool enabled = value.metaType().id() == QMetaType::Bool && value.toBool();
+        setPollingEnabled(enabled);
+    } else if (key == QLatin1String("tags_directory")) {
         setTagsDir(value.toString());
+    }
 }
 
 // One .txt file per card: the filename (minus .txt) is the display title, the
@@ -533,6 +606,8 @@ QString NfcReaderBackend::resolveVideoPath(const QString &path) const {
 }
 
 void NfcReaderBackend::onSampled(bool readerConnected, const QString &uid) {
+    if (!m_pollingEnabled || sender() != m_worker) return;
+
     m_lastSampleMs = QDateTime::currentMSecsSinceEpoch();
     m_respawnCount = 0;
 

--- a/src/modules/nfc_reader/NfcReaderBackend.cpp
+++ b/src/modules/nfc_reader/NfcReaderBackend.cpp
@@ -28,6 +28,9 @@ static constexpr qint64 kStallDisconnectMs = 3000;
 static constexpr qint64 kStallRespawnMs = 10000;
 static constexpr int kMaxRespawns = 5;
 static const char *kTagsDirName = "nfc_tags";
+// Must track the "enabled" toggle's default in modules/nfc_reader/manifest.json,
+// which is what AppCore falls back to when config.json has no value yet.
+static constexpr bool kManifestEnabledDefault = false;
 
 // ---------------------------------------------------------------------------
 // NfcPollWorker — lives on its own QThread; owns all PC/SC state and calls.
@@ -186,7 +189,12 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
 
     // Resolve module settings (the tags directory falls back to dataRoot/nfc_tags).
     m_tagsDir = m_dataRoot + "/" + kTagsDirName;
-    bool configuredEnabled = false;
+    // Whether polling runs must match whether AppCore shows the module at all,
+    // so this mirrors AppCore::isModuleEnabled: an unwritten setting means the
+    // manifest default (OFF for this module), and a present-but-not-bool value
+    // means enabled — otherwise a hand-edited config could list the module in
+    // the menu while the reader silently never polls.
+    bool configuredEnabled = kManifestEnabledDefault;
     QFile f(m_dataRoot + "/config.json");
     if (f.open(QIODevice::ReadOnly)) {
         const QJsonObject moduleConfig = QJsonDocument::fromJson(f.readAll()).object()
@@ -195,9 +203,8 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
         if (!dir.isEmpty())
             m_tagsDir = dir;
 
-        const QJsonValue enabled = moduleConfig["enabled"];
-        if (enabled.isBool())
-            configuredEnabled = enabled.toBool();
+        if (moduleConfig.contains("enabled"))
+            configuredEnabled = moduleConfig["enabled"].toBool(true);
     }
     qDebug("[NfcReader] Tags dir: %s", qPrintable(tagsDirPath()));
 
@@ -246,8 +253,7 @@ NfcReaderBackend::NfcReaderBackend(const QString &appRoot, const QString &dataRo
 
 NfcReaderBackend::~NfcReaderBackend() {
     m_pollingEnabled = false;
-    if (m_watchdog)
-        m_watchdog->stop();
+    m_watchdog->stop();
     abandonWorker(1500);
 }
 
@@ -265,8 +271,7 @@ void NfcReaderBackend::startPolling() {
     if (!m_pollingEnabled) return;
 
     if (!available()) {
-        if (m_watchdog)
-            m_watchdog->stop();
+        m_watchdog->stop();
         qInfo("[NfcReader] Polling enabled but PC/SC support is unavailable");
         return;
     }
@@ -282,8 +287,7 @@ void NfcReaderBackend::startPolling() {
 }
 
 void NfcReaderBackend::stopPolling() {
-    if (m_watchdog)
-        m_watchdog->stop();
+    m_watchdog->stop();
 
     // Settings changes run on the main thread, so release logical ownership
     // without waiting for a potentially wedged PC/SC call to return.
@@ -311,6 +315,11 @@ void NfcReaderBackend::startWorker() {
     m_worker->moveToThread(m_workerThread);
     connect(m_workerThread, &QThread::started, m_worker, &NfcPollWorker::start);
     connect(m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
+    // Set up here, not in abandonWorker(): a thread that exits between quit()
+    // and a connect() made afterwards has already emitted finished(), which
+    // would strand the QThread object. Harmless on the delete-after-wait path
+    // below — ~QObject drops the object's own pending deferred-delete event.
+    connect(m_workerThread, &QThread::finished, m_workerThread, &QObject::deleteLater);
     connect(m_worker, &NfcPollWorker::sampled, this, &NfcReaderBackend::onSampled);
     m_workerThread->start();
 }
@@ -323,13 +332,14 @@ void NfcReaderBackend::abandonWorker(int waitMs) {
     if (m_workerThread->wait(waitMs)) {
         delete m_workerThread;
     } else {
-        // The thread is stuck in an uninterruptible PC/SC call: it can't be
-        // terminated (mach_msg is not a cancellation point) and destroying a
-        // running QThread aborts the process. Unparent it instead;
+        // Either the caller did not want to block (waitMs 0, from a settings
+        // change) or the thread is stuck in an uninterruptible PC/SC call: it
+        // can't be terminated (mach_msg is not a cancellation point) and
+        // destroying a running QThread aborts the process. Unparent it instead;
         // if the call ever returns, the thread exits (quit() was already
-        // requested) and deletes itself.
+        // requested) and the deleteLater wired up in startWorker() reaps both
+        // it and its worker.
         m_workerThread->setParent(nullptr);
-        connect(m_workerThread, &QThread::finished, m_workerThread, &QObject::deleteLater);
     }
     m_workerThread = nullptr;
     m_worker = nullptr;
@@ -351,7 +361,9 @@ void NfcReaderBackend::onSettingChanged(const QString &moduleId, const QString &
     if (moduleId != QLatin1String("com.240mp.nfc_reader")) return;
 
     if (key == QLatin1String("enabled")) {
-        const bool enabled = value.metaType().id() == QMetaType::Bool && value.toBool();
+        // Same rule as the constructor / AppCore::isModuleEnabled: only an
+        // explicit false turns polling off.
+        const bool enabled = value.metaType().id() != QMetaType::Bool || value.toBool();
         setPollingEnabled(enabled);
     } else if (key == QLatin1String("tags_directory")) {
         setTagsDir(value.toString());

--- a/src/modules/nfc_reader/NfcReaderBackend.h
+++ b/src/modules/nfc_reader/NfcReaderBackend.h
@@ -45,10 +45,9 @@ public:
     Q_INVOKABLE void reloadMapping();
     Q_INVOKABLE void resetAfterPlayback();
 
-    // The module's Root.qml raises/lowers this on load/unload. Polling runs
-    // for the whole app lifetime (the watchdog needs it), but card events must
-    // not do anything — no state changes, no playback — unless the user is
-    // inside the NFC module.
+    // The module's Root.qml raises/lowers this on load/unload. The configured
+    // enabled setting owns polling lifetime; active view state only decides
+    // whether card events may change state or request playback.
     Q_INVOKABLE void setModuleActive(bool active);
 
     Q_INVOKABLE QVariantMap getSavedPosition(const QString &videoPath);
@@ -94,6 +93,7 @@ private:
     QString m_dataRoot;
     QString m_tagsDir;
     QHash<QString, MappingEntry> m_mapping;
+    bool m_pollingEnabled = false;
     QThread *m_workerThread = nullptr;
     NfcPollWorker *m_worker = nullptr;
     QTimer *m_watchdog = nullptr;
@@ -116,6 +116,9 @@ private:
     void scanTagsDir();
     bool parseTagFile(const QString &filePath, QString &uidOut, QString &pathOut) const;
     void writeStubFile(const QString &normalizedUid);
+    void setPollingEnabled(bool enabled);
+    void startPolling();
+    void stopPolling();
     void startWorker();
     void abandonWorker(int waitMs);
     void setCardState(const QString &state, const QString &uid = {}, const QString &title = {});


### PR DESCRIPTION
## Summary

The NFC backend starts its PC/SC worker and watchdog at application startup
even when the NFC Reader module is disabled.

This patch uses the existing NFC `enabled` setting to control polling. Polling
now stays off when the module is disabled, starts when it is enabled, stops
when it is disabled, and ignores samples from an old or disabled worker.

The change is limited to the NFC backend. It does not change the settings
schema, QML interface, mappings, or playback behavior.

## AI involvement

AI tools assisted with investigating the issue, drafting the C++ changes, and
running the Raspberry Pi build and runtime checks. I reviewed the final
two-file diff and the test results and limitations described below.

## Testing

- Platform(s) tested: Raspberry Pi 3 Model B Plus Rev 1.4, Debian 13 arm64
- Display / output tested: Not tested; this is a backend-only change
- Native Raspberry Pi build passed with PC/SC support enabled
- With NFC disabled, the application reported polling disabled and showed no
  polling-start, reader, stall, or restart activity during the runtime check

I do not have an NFC reader. Before merge, a reviewer with an ACR122-compatible
reader and known mapped tag should verify:

- [ ] The reader is detected
- [ ] Enabling NFC starts polling and a known tag starts playback
- [ ] Disabling NFC stops polling and subsequent tag activity is ignored
- [ ] Repeated enable/disable cycles and enabled/disabled restarts work
- [ ] Existing tag mappings and settings continue to work

## Checklist

- [ ] Changes work with remote-only navigation (not tested; no UI contract
      changed)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw`
      properties (not applicable; no QML or layout changes)
- [x] Did not add tracking or analytics; only wrote settings to the local data
      directory if the change required storage (no persistence changes)
- [x] Follows the patterns in
      [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md)
      and the principles in
      [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
