### PR TITLE
feat(plex): add season/episode number for episodes when displayed in lists

### DIFF
--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -398,9 +398,13 @@ FocusScope {
                 Text {
                     id: rowText
                     text: {
-                        var base = (modelData.type === "episode" && modelData.grandparentTitle)
-                                   ? (modelData.grandparentTitle + ": " + (modelData.title || ""))
-                                   : (modelData.title || "")
+                        if (modelData.type === "episode" && modelData.grandparentTitle) {
+                            var sNum = (modelData.parentIndex != null) ? modelData.parentIndex : "?"
+                            var eNum = (modelData.index != null) ? modelData.index : "?"
+                            return modelData.grandparentTitle + " S" + sNum + "E" + eNum
+                                   + ": " + (modelData.title || "")
+                        }
+                        var base = modelData.title || ""
                         return modelData.editionTitle ? base + " (" + modelData.editionTitle + ")" : base
                     }
                     color: (itemList.currentIndex === index && !letterNavActive)


### PR DESCRIPTION
## Summary

Adds the display of Season & Episode number when an Episode is displayed in a list in the Plex module

## AI involvement

None, but credit to @ToTheXtreme64 for inspiring this addition with their work in 56506a7cd233e3e7da6aa8280a4552e3180191b9 for the Jellyfin Module

## Testing

Tested in the Plex module across continue watching and in a TV Library (playlists, recommended) 

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
