### PR TITLE
feat(jellyfin): change audio track during transcode

### DIFF
--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -33,7 +33,8 @@ FocusScope {
     property bool   pendingRetryTranscode: false
     // Set when the user changed the subtitle mid-transcode: mpv is quitting so we
     // can re-request the stream with a different burned-in track (not a real stop).
-    property bool   pendingSubtitleSwitch: false
+    property bool pendingSubtitleSwitch: false
+    property bool pendingAudioSwitch: false
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
     // Full stream metadata used to disambiguate when several streams share a language.
@@ -383,9 +384,9 @@ FocusScope {
     }
 
     function doStartPlayback(offsetMs) {
-        var jfToken = jellyfinBackend.get_access_token()
-        if (isTranscoding) {
-            // The HLS manifest bakes in the selected audio, and the chosen subtitle
+    var jfToken = jellyfinBackend.get_access_token()
+    if (isTranscoding) {
+        // The HLS manifest bakes in the selected audio, and the chosen subtitle
             // is burned into the video — so there's no soft sub track for mpv to
             // pick (subTrack -2 = --sid=no) or to cycle. Instead the OSC gets:
             //   sub-cycle     — show a SUBTITLE button that asks us to switch
@@ -393,30 +394,40 @@ FocusScope {
             //   transcode-sub — the burned-in track's name, for the info line
             // Both go through --script-opts-append: a plain --script-opts= would
             // replace the list MpvController already built (screensaver, hide-crop…).
-            var subName = "Off"
-            if (subtitleIdx >= 0 && subtitleStreams[subtitleIdx]) {
-                var s = subtitleStreams[subtitleIdx]
-                subName = s.displayTitle || s.title || s.language || "Unknown"
-            }
-            // script-opts is a comma-separated key=value list, so the value can
-            // carry neither a comma nor an "="; spaces round-trip as underscores.
-            subName = subName.replace(/ /g, "_").replace(/[,=]/g, "")
-            var extra = ["--script-opts-append=transcode-sub=" + subName,
-                         "--script-opts-append=sub-cycle=" + (subtitleStreams.length > 0 ? "1" : "0")]
-
-            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                       -1, -2, [], [], false, -1, 0.0, "",
-                                       false, "", false, [], 0.0, false, extra, jfToken)
-        } else {
-            // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
-            // --aid; subtitles come from buildSubArgs (sidecars + --sid).
-            var audioTrack = audioStreams.length > 0 ? audioIdx + 1 : 0
-            var sub = buildSubArgs()
-            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                       audioTrack, sub.track, sub.urls, [], false, -1, 0.0, "",
-                                       false, "", false, sub.titles, 0.0, false, [], jfToken)
+        var subName = "Off"
+        if (subtitleIdx >= 0 && subtitleStreams[subtitleIdx]) {
+            var s = subtitleStreams[subtitleIdx]
+            subName = s.displayTitle || s.title || s.language || "Unknown"
         }
+        subName = subName.replace(/ /g, "_").replace(/[,=]/g, "")
+
+        var audioName = "Off"
+        if (audioIdx >= 0 && audioStreams[audioIdx]) {
+            var a = audioStreams[audioIdx]
+            audioName = a.displayTitle || a.title || a.language || "Unknown"
+        }
+        audioName = audioName.replace(/ /g, "_").replace(/[,=]/g, "")
+
+        var extra = [
+            "--script-opts-append=transcode-sub=" + subName,
+            "--script-opts-append=sub-cycle=" + (subtitleStreams.length > 0 ? "1" : "0"),
+            "--script-opts-append=transcode-audio=" + audioName,
+            "--script-opts-append=audio-cycle=1"
+        ]
+
+        mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
+                                   -1, -2, [], [], false, -1, 0.0, "",
+                                   (audioIdx === -1), "", false, [], 0.0, false, extra, jfToken)
+    } else {
+        // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
+        // --aid; subtitles come from buildSubArgs (sidecars + --sid).
+        var audioTrack = audioStreams.length > 0 ? audioIdx + 1 : 0
+        var sub = buildSubArgs()
+        mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
+        audioTrack, sub.track, sub.urls, [], false, -1, 0.0, "",
+        (audioIdx === -1), "", false, sub.titles, 0.0, false, [], jfToken)
     }
+}
 
     function formatTime(ms) {
         var s = Math.floor(ms / 1000)
@@ -564,7 +575,32 @@ FocusScope {
             mpvController.stop()
         }
 
+        function onAudioCycleRequested() {
+            if (!isTranscoding || audioStreams.length === 0) return
+            playerRoot.lastKnownPositionMs = mpvController.position
+            playerRoot.pendingAudioSwitch = true
+            mpvController.stop()
+        }
+
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
+            if (pendingAudioSwitch) {
+            pendingAudioSwitch = false
+            reportStopped(finalPositionMs, finalDurationMs)
+            stoppedReported = false
+
+            // Cycle to the next audio track
+            audioIdx++
+            if (audioIdx >= audioStreams.length) audioIdx = -1
+            selectedAudioId = audioIdx >= 0 ? audioStreams[audioIdx].id : ""
+            captureCarryLanguages()
+
+            // Re-request the stream URL from Jellyfin with the new audio index
+            pendingRetryTranscode = true
+            var newAIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
+            var newSIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
+            jellyfinBackend.get_playback_url(itemId, mediaSourceId, newAIdx, newSIdx, true)
+            return
+        }
             if (pendingSubtitleSwitch) {
                 // mpv exited because we asked it to (onSubtitleCycleRequested), not
                 // because the user stopped. Close out the old transcode session so

--- a/modules/jellyfin/views/Player.qml
+++ b/modules/jellyfin/views/Player.qml
@@ -31,10 +31,10 @@ FocusScope {
     property bool   pendingNextEpisode: false
     // Set when a direct-play attempt fails and we re-request forcing a transcode.
     property bool   pendingRetryTranscode: false
-    // Set when the user changed the subtitle mid-transcode: mpv is quitting so we
-    // can re-request the stream with a different burned-in track (not a real stop).
-    property bool pendingSubtitleSwitch: false
-    property bool pendingAudioSwitch: false
+    // Set when the user changed a track mid-transcode: mpv is quitting so we can
+    // re-request the stream with a different audio track / burned-in subtitle
+    // (not a real stop). "audio", "sub", or "" for none.
+    property string pendingTrackSwitch: ""
     property string carryAudioLang:     ""
     property string carrySubLang:       "__off__"
     // Full stream metadata used to disambiguate when several streams share a language.
@@ -384,50 +384,59 @@ FocusScope {
     }
 
     function doStartPlayback(offsetMs) {
-    var jfToken = jellyfinBackend.get_access_token()
-    if (isTranscoding) {
-        // The HLS manifest bakes in the selected audio, and the chosen subtitle
-            // is burned into the video — so there's no soft sub track for mpv to
-            // pick (subTrack -2 = --sid=no) or to cycle. Instead the OSC gets:
-            //   sub-cycle     — show a SUBTITLE button that asks us to switch
-            //                   (handled in onSubtitleCycleRequested → new transcode)
-            //   transcode-sub — the burned-in track's name, for the info line
-            // Both go through --script-opts-append: a plain --script-opts= would
+        var jfToken = jellyfinBackend.get_access_token()
+        if (isTranscoding) {
+            // The HLS manifest bakes in the selected audio, and the chosen subtitle
+            // is burned into the video — so there's no soft track for mpv to pick
+            // (subTrack -2 = --sid=no) or to cycle, for either audio or subs.
+            // Instead the OSC gets:
+            //   sub-cycle       — show a SUBTITLE button that asks us to switch
+            //                     (handled in onSubtitleCycleRequested → new transcode)
+            //   transcode-sub   — the burned-in track's name, for the info line
+            //   audio-cycle     — same deal for the AUDIO button
+            //                     (onAudioCycleRequested → new transcode)
+            //   transcode-audio — the baked-in audio track's name, for the info line
+            // All go through --script-opts-append: a plain --script-opts= would
             // replace the list MpvController already built (screensaver, hide-crop…).
-        var subName = "Off"
-        if (subtitleIdx >= 0 && subtitleStreams[subtitleIdx]) {
-            var s = subtitleStreams[subtitleIdx]
-            subName = s.displayTitle || s.title || s.language || "Unknown"
+            //
+            // script-opts is a comma-separated key=value list, so neither value can
+            // carry a comma or an "="; spaces round-trip as underscores.
+            var subName = "Off"
+            if (subtitleIdx >= 0 && subtitleStreams[subtitleIdx]) {
+                var s = subtitleStreams[subtitleIdx]
+                subName = s.displayTitle || s.title || s.language || "Unknown"
+            }
+            subName = subName.replace(/ /g, "_").replace(/[,=]/g, "")
+
+            // "Off" only when the item has no audio at all — the cycle itself never
+            // lands there (see onPlaybackEnded).
+            var audioName = "Off"
+            if (audioIdx >= 0 && audioStreams[audioIdx]) {
+                var a = audioStreams[audioIdx]
+                audioName = a.displayTitle || a.title || a.language || "Unknown"
+            }
+            audioName = audioName.replace(/ /g, "_").replace(/[,=]/g, "")
+
+            var extra = [
+                "--script-opts-append=transcode-sub=" + subName,
+                "--script-opts-append=sub-cycle=" + (subtitleStreams.length > 0 ? "1" : "0"),
+                "--script-opts-append=transcode-audio=" + audioName,
+                "--script-opts-append=audio-cycle=" + (audioStreams.length > 0 ? "1" : "0")
+            ]
+
+            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
+                                       -1, -2, [], [], false, -1, 0.0, "",
+                                       false, "", false, [], 0.0, false, extra, jfToken)
+        } else {
+            // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
+            // --aid; subtitles come from buildSubArgs (sidecars + --sid).
+            var audioTrack = audioStreams.length > 0 ? audioIdx + 1 : 0
+            var sub = buildSubArgs()
+            mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
+                                       audioTrack, sub.track, sub.urls, [], false, -1, 0.0, "",
+                                       false, "", false, sub.titles, 0.0, false, [], jfToken)
         }
-        subName = subName.replace(/ /g, "_").replace(/[,=]/g, "")
-
-        var audioName = "Off"
-        if (audioIdx >= 0 && audioStreams[audioIdx]) {
-            var a = audioStreams[audioIdx]
-            audioName = a.displayTitle || a.title || a.language || "Unknown"
-        }
-        audioName = audioName.replace(/ /g, "_").replace(/[,=]/g, "")
-
-        var extra = [
-            "--script-opts-append=transcode-sub=" + subName,
-            "--script-opts-append=sub-cycle=" + (subtitleStreams.length > 0 ? "1" : "0"),
-            "--script-opts-append=transcode-audio=" + audioName,
-            "--script-opts-append=audio-cycle=1"
-        ]
-
-        mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-                                   -1, -2, [], [], false, -1, 0.0, "",
-                                   (audioIdx === -1), "", false, [], 0.0, false, extra, jfToken)
-    } else {
-        // Direct play: file served whole. audioIdx is 0-based → mpv's 1-based
-        // --aid; subtitles come from buildSubArgs (sidecars + --sid).
-        var audioTrack = audioStreams.length > 0 ? audioIdx + 1 : 0
-        var sub = buildSubArgs()
-        mpvController.loadAndPlay(streamUrl, offsetMs / 1000.0,
-        audioTrack, sub.track, sub.urls, [], false, -1, 0.0, "",
-        (audioIdx === -1), "", false, sub.titles, 0.0, false, [], jfToken)
     }
-}
 
     function formatTime(ms) {
         var s = Math.floor(ms / 1000)
@@ -571,49 +580,43 @@ FocusScope {
         function onSubtitleCycleRequested() {
             if (!isTranscoding || subtitleStreams.length === 0) return
             playerRoot.lastKnownPositionMs = mpvController.position
-            playerRoot.pendingSubtitleSwitch = true
+            playerRoot.pendingTrackSwitch = "sub"
             mpvController.stop()
         }
 
+        // OSC AUDIO button during a transcode. The audio is baked into the HLS
+        // manifest, so switching means a new transcode — same deferred-until-exit
+        // contract as onSubtitleCycleRequested above.
         function onAudioCycleRequested() {
             if (!isTranscoding || audioStreams.length === 0) return
             playerRoot.lastKnownPositionMs = mpvController.position
-            playerRoot.pendingAudioSwitch = true
+            playerRoot.pendingTrackSwitch = "audio"
             mpvController.stop()
         }
 
         function onPlaybackEnded(finalPositionMs, finalDurationMs, reason) {
-            if (pendingAudioSwitch) {
-            pendingAudioSwitch = false
-            reportStopped(finalPositionMs, finalDurationMs)
-            stoppedReported = false
-
-            // Cycle to the next audio track
-            audioIdx++
-            if (audioIdx >= audioStreams.length) audioIdx = -1
-            selectedAudioId = audioIdx >= 0 ? audioStreams[audioIdx].id : ""
-            captureCarryLanguages()
-
-            // Re-request the stream URL from Jellyfin with the new audio index
-            pendingRetryTranscode = true
-            var newAIdx = selectedAudioId ? parseInt(selectedAudioId) : -1
-            var newSIdx = selectedSubtitleId ? parseInt(selectedSubtitleId) : -1
-            jellyfinBackend.get_playback_url(itemId, mediaSourceId, newAIdx, newSIdx, true)
-            return
-        }
-            if (pendingSubtitleSwitch) {
-                // mpv exited because we asked it to (onSubtitleCycleRequested), not
-                // because the user stopped. Close out the old transcode session so
-                // the server tears the encode down, advance to the next subtitle,
-                // and re-request — onStreamUrlReady's pendingRetryTranscode branch
-                // resumes at lastKnownPositionMs. Deliberately no goBack().
-                pendingSubtitleSwitch = false
+            if (pendingTrackSwitch !== "") {
+                // mpv exited because we asked it to (onAudio/onSubtitleCycleRequested),
+                // not because the user stopped. Close out the old transcode session so
+                // the server tears the encode down, advance to the next track, and
+                // re-request — onStreamUrlReady's pendingRetryTranscode branch resumes
+                // at lastKnownPositionMs. Deliberately no goBack().
+                var which = pendingTrackSwitch
+                pendingTrackSwitch = ""
                 reportStopped(finalPositionMs, finalDurationMs)
                 stoppedReported = false
 
-                subtitleIdx++
-                if (subtitleIdx >= subtitleStreams.length) subtitleIdx = -1
-                selectedSubtitleId = subtitleIdx >= 0 ? subtitleStreams[subtitleIdx].id : ""
+                if (which === "audio") {
+                    // No "off" stop in the audio cycle: silence isn't worth a
+                    // transcode restart, and direct play still gets mpv's own
+                    // no-audio step from `cycle audio`.
+                    audioIdx = (audioIdx + 1) % audioStreams.length
+                    selectedAudioId = String(audioStreams[audioIdx].id || "")
+                } else {
+                    subtitleIdx++
+                    if (subtitleIdx >= subtitleStreams.length) subtitleIdx = -1
+                    selectedSubtitleId = subtitleIdx >= 0 ? subtitleStreams[subtitleIdx].id : ""
+                }
                 // Keep the autoplay carry-over hints in step with the new choice so
                 // the next episode inherits it.
                 captureCarryLanguages()

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -35,6 +35,13 @@ local A_TRANS  = "&HFF&"
 local A_DIM    = "&H99&"  -- 40% opacity for unfocused seek fill
 
 local function get_audio_str()
+    -- Transcoded stream: read track info passed explicitly from QML
+    local transcode_audio = mp.get_opt("transcode-audio")
+    if transcode_audio and transcode_audio ~= "" then
+        if transcode_audio == "Off" then return "(NONE)" end
+        return (transcode_audio:gsub("_", " ")):upper()
+    end
+
     local id = mp.get_property_number("current-tracks/audio/id", 0)
     if id == 0 then return "(NONE)" end
     local title    = (mp.get_property("current-tracks/audio/title", "") or ""):upper()
@@ -81,10 +88,18 @@ end
 -- Set by the app when the subtitle is burned into the stream and only the module
 -- can change it (Jellyfin transcode): mpv has no sub track to cycle, so the
 -- SUBTITLE button asks the module to re-request the stream instead.
-local sub_cycle = mp.get_opt("sub-cycle") == "1"
+-- Set by the app during transcoding when audio track changes require re-requesting the stream
+local sub_cycle   = mp.get_opt("sub-cycle") == "1"
+local audio_cycle = mp.get_opt("audio-cycle") == "1"
 
 local btn_actions = {
-    function() mp.command("no-osd cycle audio") end,
+    function()
+        if audio_cycle then
+            mp.commandv("script-message", "cycle-audio")
+        else
+            mp.command("no-osd cycle audio")
+        end
+    end,
     function()
         if sub_cycle then
             mp.commandv("script-message", "cycle-sub")

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -88,8 +88,9 @@ end
 -- Set by the app when the subtitle is burned into the stream and only the module
 -- can change it (Jellyfin transcode): mpv has no sub track to cycle, so the
 -- SUBTITLE button asks the module to re-request the stream instead.
--- Set by the app during transcoding when audio track changes require re-requesting the stream
 local sub_cycle   = mp.get_opt("sub-cycle") == "1"
+-- Same for audio when the track is baked into the stream (Jellyfin transcode):
+-- the AUDIO button asks the module to re-request rather than cycling locally.
 local audio_cycle = mp.get_opt("audio-cycle") == "1"
 
 local btn_actions = {

--- a/src/player/MpvController.cpp
+++ b/src/player/MpvController.cpp
@@ -518,6 +518,8 @@ void MpvController::onIpcReadyRead() {
                         emit skipRequested();
                     else if (msg == "cycle-sub")
                         emit subtitleCycleRequested();
+                    else if (msg == "cycle-audio")
+                        emit audioCycleRequested();
                 }
             }
             continue;

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -86,6 +86,7 @@ signals:
     // has nothing to cycle (see `sub-cycle` in scripts/mpv-osc.lua). The module
     // owns the change — typically stop, re-request the stream, relaunch.
     void subtitleCycleRequested();
+    void audioCycleRequested();
 
 private slots:
     void onProcessFinished();

--- a/src/player/MpvController.h
+++ b/src/player/MpvController.h
@@ -86,6 +86,9 @@ signals:
     // has nothing to cycle (see `sub-cycle` in scripts/mpv-osc.lua). The module
     // owns the change — typically stop, re-request the stream, relaunch.
     void subtitleCycleRequested();
+    // The OSC's AUDIO button when the track is baked into the stream and mpv has
+    // nothing to cycle (see `audio-cycle` in scripts/mpv-osc.lua). As above, the
+    // module owns the change.
     void audioCycleRequested();
 
 private slots:


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Allows the user to change the audio track while transcoding in the Jellyfin module. Uses a very similar implementation as my earlier PR for subtitle switching. 
## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Used to check my work
## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->

Tested on MacOS with my Jellyfin server

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
