### PR TITLE
fix(rpi): remove boot splash from install script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -171,7 +171,7 @@ However, if you already have Raspberry Pi OS set up and working on your TV then 
 
 3) Place the SD card in your Raspberry Pi and let it run through its first boot sequence
 
-    - Raspberry Pi OS Lite does **not** boot to a desktop. On first boot you may see boot log text, a text login console, or sometimes just a blinking cursor for a bit while it finishes booting. (If you later choose the optional boot splash in step 5, a 240-MP logo replaces all of that from then on.)
+    - Raspberry Pi OS Lite does **not** boot to a desktop. On first boot you may see boot log text, a text login console, or sometimes just a blinking cursor for a bit while it finishes booting.
 
 4) Once complete, SSH in and run `sudo raspi-config`
 
@@ -195,10 +195,6 @@ However, if you already have Raspberry Pi OS set up and working on your TV then 
     - If you type `Y` and press enter it will set up 240-MP to autostart when your Raspberry Pi boots which creates a nice appliance experience (bascially a dedicated 240-MP device).
     - If you choose that option please make sure to enter your primary user for the pi at the next prompt.  If you don't provide one it will set it up for the `Pi` user.
     - If you ever need to inspect the autostart logs later, use `sudo journalctl -u 240mp -f`
-    - Choosing autostart also gets you a third prompt: `Install boot splash screen? [y/N]`
-        - Answering `Y` replaces the kernel logo, boot log text and blinking cursor with a 240-MP logo that stays on screen until the app appears, so the Pi boots like an appliance rather than a computer
-        - It uses the official `rpi-splash-screen-support` package (Raspberry Pi OS Trixie or newer) and takes effect from the **next reboot**
-        - It relies on `auto_initramfs=1` being in your `config.txt`.  For new installs that's included in the above configs but if you are on a previous set up then you will need to add that to your config.txt file in order for it to work (the installer will warn you if it's missing so you'll know then and there)
 
 At this point you can type `240mp` at any time to start up the app.  And if you installed the autostart service then the next time you boot your Pi it will boot directly into 240-MP.
 
@@ -260,7 +256,6 @@ The Local Files module will be enabled by default and you can open settings to e
     - If you already have autostart set up please answer `Y` (that's needed to keep the app files owned by the service user, which in-app updates rely on)
     - If you don't have autostart installed and want to keep it that way just answer `N`
     - And if you want to turn on autostart please answer `Y`
-    - If you answered `Y` you'll also be asked about the boot splash. If you've done that in the past then answering `Y` a second time is harmless (it just rewrites the same settings).  If you've not installed the boot splash before then answering `Y` will set it up at this step.
 4) Once that completes just run `sudo reboot` and when your pi restarts you'll be on the latest version
 
 ### Uninstall
@@ -280,16 +275,6 @@ The Local Files module will be enabled by default and you can open settings to e
     sudo rm -f /etc/systemd/system/240mp.service /etc/systemd/system/240mp-terminal.service /usr/local/bin/240mp-stop
     sudo systemctl daemon-reload
     ```
-
-3) If you installed the boot splash and want to go back to a normal text boot then please run the following:
-
-    ```bash
-    sudo mv /boot/firmware/cmdline.txt.bak /boot/firmware/cmdline.txt
-    sudo rm -f /lib/firmware/logo.tga /etc/initramfs-tools/hooks/splash-screen-hook.sh
-    sudo update-initramfs -k all -u
-    ```
-
-    Note: `cmdline.txt.bak` is the backup that `configure-splash` made before its edit to add boot splash support.  If that backup file isn't there then just remove the `fullscreen_logo=1`, `fullscreen_logo_name=logo.tga` and `vt.global_cursor_default=0` options from `/boot/firmware/cmdline.txt` by hand and add `console=tty1` back.)
 
 ## On macOS (ARM)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,13 +64,9 @@ sudo udevadm trigger /dev/tty0
 echo ""
 read -r -p "Install systemd autostart service? [y/N] " AUTOSTART_REPLY
 SERVICE_USER=""
-SPLASH_REPLY=""
 if [[ "${AUTOSTART_REPLY}" =~ ^[Yy]$ ]]; then
     read -r -p "Run service as user [default: pi]: " SERVICE_USER
     SERVICE_USER="${SERVICE_USER:-pi}"
-    # Only offered alongside autostart — a boot splash makes sense for the
-    # appliance experience, not for a manually launched desktop install.
-    read -r -p "Install boot splash screen? [y/N] " SPLASH_REPLY
 fi
 OWNER_USER="${SERVICE_USER:-$USER}"
 
@@ -268,51 +264,6 @@ TERMINAL_UNIT
     sudo systemctl enable 240mp.service
     echo "Service installed and enabled."
     echo "Start now with: sudo systemctl start 240mp"
-fi
-
-# ── Optional: boot splash ─────────────────────────────────────────────────────
-# Uses the Raspberry Pi kernel's fullscreen_logo support: configure-splash copies
-# the TGA to /lib/firmware, installs an initramfs hook, and adds
-# "fullscreen_logo=1 fullscreen_logo_name=... vt.global_cursor_default=0" to
-# cmdline.txt while dropping "console=tty1". The image replaces the Tux logo at
-# fbcon init and — with getty@tty1 masked by the autostart block above — stays on
-# screen right through to 240-MP's first frame. Never fatal: a failure here still
-# leaves a working install, so each step is guarded against `set -e`.
-if [[ "${SPLASH_REPLY}" =~ ^[Yy]$ ]]; then
-    echo ""
-    echo "Configuring boot splash..."
-    # boot-splash.tga is a 1920x1080 uncompressed 24-bit TGA (the format the
-    # kernel logo loader needs) with the logo centered small enough to survive
-    # being centred/clipped on a 720x480 composite framebuffer. Regenerate with:
-    #   magick -background none assets/images/logo.svg -resize 440x240 \
-    #     -background black -alpha remove -alpha off -threshold 50% \
-    #     -colorspace sRGB -type TrueColor -gravity center -extent 1920x1080 \
-    #     -compress none assets/images/boot-splash.tga
-    SPLASH_IMAGE="${INSTALL_DIR}/share/240mp/assets/images/boot-splash.tga"
-    if [ ! -f "${SPLASH_IMAGE}" ]; then
-        echo "Warning: ${SPLASH_IMAGE} not found — boot splash not configured."
-    elif ! sudo apt-get install -y rpi-splash-screen-support; then
-        echo "Warning: could not install rpi-splash-screen-support (needs Raspberry Pi OS"
-        echo "         Trixie or newer) — boot splash not configured."
-    elif ! sudo configure-splash "${SPLASH_IMAGE}"; then
-        echo "Warning: configure-splash failed — boot splash not configured."
-    else
-        # fullscreen_logo reads the image out of the initramfs, so the firmware
-        # has to be loading one. Stock Raspberry Pi OS sets auto_initramfs=1, but
-        # a hand-written config.txt often drops it and the splash then silently
-        # does nothing.
-        CONFIG_TXT="/boot/firmware/config.txt"
-        [ -f "${CONFIG_TXT}" ] || CONFIG_TXT="/boot/config.txt"
-        if [ -f "${CONFIG_TXT}" ] \
-           && ! grep -Eq '^[[:space:]]*(auto_initramfs=1|initramfs[[:space:]=])' "${CONFIG_TXT}"; then
-            echo ""
-            echo "Warning: no initramfs is configured in ${CONFIG_TXT}, so the splash will not"
-            echo "         appear. Add this line to that file and reboot:"
-            echo ""
-            echo "             auto_initramfs=1"
-        fi
-        echo "Boot splash installed — it appears from the next reboot."
-    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

details on why: https://github.com/anthonycaccese/240-MP/discussions/210#discussioncomment-17883175

I'll instead add details to the wiki for anyone that would want to explore adding a boot splash to their set up (after working through it I feel this is an OS configuration that is a bit outside of the scope for what I want to focus on for 240-MP)

## AI involvement

None

## Testing

tested an alpha build on a fresh SD card using `bash <(curl -fsSL https://github.com/anthonycaccese/240-MP/releases/download/vXXXX.XX.XX-alpha/install.sh) vXXXX.XX.XX-alpha` to install the specific version and test its specific install script.  Worked as expected, autostart works, no boot splash option.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
