### PR TITLE
fix(plex,jellyfin,emby): browse-by-letter jumps using sort title 

### DIFF
--- a/modules/emby/views/Items.qml
+++ b/modules/emby/views/Items.qml
@@ -27,16 +27,31 @@ FocusScope {
     property bool letterNavActive: false
     property var letterIndex: []
 
-    // Sort key for a title: strip a leading article, take the first A–Z char,
-    // else group under "#".
-    function sortKey(title) {
-        var t = (title || "").toLowerCase()
-        var articles = ["the ", "a ", "an "]
-        for (var i = 0; i < articles.length; i++) {
-            if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
+    // Sort key for an item: take the first A–Z char of the server's sort name
+    // (which the browse queries also sort by, and which already has articles
+    // stripped per the server's config), else group under "#". Falls back to
+    // stripping a leading article from the display title when no sort name came
+    // back — otherwise the letters would disagree with the list order.
+    function sortKey(item) {
+        var sortTitle = (item && item.titleSort) || ""
+        var t = (sortTitle || (item && item.title) || "").toLowerCase()
+        if (!sortTitle) {
+            var articles = ["the ", "a ", "an "]
+            for (var i = 0; i < articles.length; i++) {
+                if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
+            }
         }
         var ch = t.charAt(0).toUpperCase()
         return (ch >= 'A' && ch <= 'Z') ? ch : '#'
+    }
+
+    // Highlights the letter matching the currently selected item.
+    function syncLetterToItem() {
+        var curLetter = sortKey(items[itemList.currentIndex])
+        for (var i = 0; i < letterIndex.length; i++) {
+            if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+        }
+        letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
     }
 
     // Build [{letter, firstIndex}] over the (already alpha-sorted) item list.
@@ -44,7 +59,7 @@ FocusScope {
         var seen = {}
         var result = []
         for (var i = 0; i < itemArr.length; i++) {
-            var letter = sortKey(itemArr[i].title || "")
+            var letter = sortKey(itemArr[i])
             if (!seen[letter]) {
                 seen[letter] = true
                 result.push({ letter: letter, firstIndex: i })
@@ -231,11 +246,7 @@ FocusScope {
             if (count === 0) return
             if (currentIndex > 0) {
                 currentIndex--
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
-                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+                itemListRoot.syncLetterToItem()
             }
             else {
                 currentIndex = count - 1
@@ -248,11 +259,7 @@ FocusScope {
             if (count === 0) return
             if (currentIndex < count - 1) {
                 currentIndex++
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
-                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+                itemListRoot.syncLetterToItem()
             }
             else {
                 currentIndex = 0
@@ -265,10 +272,7 @@ FocusScope {
         Keys.onPressed: function(event) {
             // Right hands focus to the letter panel, synced to the current letter.
             if (event.key === Qt.Key_Right && showLetterNav && letterIndex.length > 0) {
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
+                itemListRoot.syncLetterToItem()
                 letterNavActive = true
                 letterList.forceActiveFocus()
                 event.accepted = true

--- a/modules/jellyfin/views/Items.qml
+++ b/modules/jellyfin/views/Items.qml
@@ -27,16 +27,31 @@ FocusScope {
     property bool letterNavActive: false
     property var letterIndex: []
 
-    // Sort key for a title: strip a leading article, take the first A–Z char,
-    // else group under "#".
-    function sortKey(title) {
-        var t = (title || "").toLowerCase()
-        var articles = ["the ", "a ", "an "]
-        for (var i = 0; i < articles.length; i++) {
-            if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
+    // Sort key for an item: take the first A–Z char of the server's sort name
+    // (which the browse queries also sort by, and which already has articles
+    // stripped per the server's config), else group under "#". Falls back to
+    // stripping a leading article from the display title when no sort name came
+    // back — otherwise the letters would disagree with the list order.
+    function sortKey(item) {
+        var sortTitle = (item && item.titleSort) || ""
+        var t = (sortTitle || (item && item.title) || "").toLowerCase()
+        if (!sortTitle) {
+            var articles = ["the ", "a ", "an "]
+            for (var i = 0; i < articles.length; i++) {
+                if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
+            }
         }
         var ch = t.charAt(0).toUpperCase()
         return (ch >= 'A' && ch <= 'Z') ? ch : '#'
+    }
+
+    // Highlights the letter matching the currently selected item.
+    function syncLetterToItem() {
+        var curLetter = sortKey(items[itemList.currentIndex])
+        for (var i = 0; i < letterIndex.length; i++) {
+            if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+        }
+        letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
     }
 
     // Build [{letter, firstIndex}] over the (already alpha-sorted) item list.
@@ -44,7 +59,7 @@ FocusScope {
         var seen = {}
         var result = []
         for (var i = 0; i < itemArr.length; i++) {
-            var letter = sortKey(itemArr[i].title || "")
+            var letter = sortKey(itemArr[i])
             if (!seen[letter]) {
                 seen[letter] = true
                 result.push({ letter: letter, firstIndex: i })
@@ -231,12 +246,8 @@ FocusScope {
         Keys.onUpPressed: {
             if (count === 0) return
             if (currentIndex > 0) {
-                currentIndex-- 
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
-                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+                currentIndex--
+                itemListRoot.syncLetterToItem()
             }
             else {
                 currentIndex = count-1
@@ -249,11 +260,7 @@ FocusScope {
             if (count === 0) return
             if (currentIndex < count - 1) {
                 currentIndex++
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
-                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+                itemListRoot.syncLetterToItem()
             }
             else {
                 currentIndex = 0
@@ -266,10 +273,7 @@ FocusScope {
         Keys.onPressed: function(event) {
             // Right hands focus to the letter panel, synced to the current letter.
             if (event.key === Qt.Key_Right && showLetterNav && letterIndex.length > 0) {
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
+                itemListRoot.syncLetterToItem()
                 letterNavActive = true
                 letterList.forceActiveFocus()
                 event.accepted = true

--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -27,21 +27,36 @@ FocusScope {
     property bool letterNavActive: false
     property var letterIndex: []
 
-    function sortKey(title) {
-        var t = (title || "").toLowerCase()
-        var articles = ["the ", "a ", "an "]
-        for (var i = 0; i < articles.length; i++) {
-            if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
+    // Buckets by the server's sort title when one is set (Plex sorts the list by
+    // titleSort), otherwise falls back to article-stripping the display title —
+    // which is what Plex itself does for items without a custom sort title.
+    function sortKey(item) {
+        var sortTitle = (item && item.titleSort) || ""
+        var t = (sortTitle || (item && item.title) || "").toLowerCase()
+        if (!sortTitle) {
+            var articles = ["the ", "a ", "an "]
+            for (var i = 0; i < articles.length; i++) {
+                if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
+            }
         }
         var ch = t.charAt(0).toUpperCase()
         return (ch >= 'A' && ch <= 'Z') ? ch : '#'
+    }
+
+    // Highlights the letter matching the currently selected item.
+    function syncLetterToItem() {
+        var curLetter = sortKey(items[itemList.currentIndex])
+        for (var i = 0; i < letterIndex.length; i++) {
+            if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
+        }
+        letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
     }
 
     function buildLetterIndex(itemArr) {
         var seen = {}
         var result = []
         for (var i = 0; i < itemArr.length; i++) {
-            var letter = sortKey(itemArr[i].title || "")
+            var letter = sortKey(itemArr[i])
             if (!seen[letter]) {
                 seen[letter] = true
                 result.push({ letter: letter, firstIndex: i })
@@ -333,11 +348,7 @@ FocusScope {
             if (count === 0) return
             if (currentIndex > 0) {
                 currentIndex--
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
-                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+                itemListRoot.syncLetterToItem()
             }
             else {
                 currentIndex = count - 1
@@ -350,11 +361,7 @@ FocusScope {
             if (count === 0) return
             if (currentIndex < count - 1) {
                 currentIndex++
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
-                letterList.positionViewAtIndex(letterList.currentIndex, ListView.Contain)
+                itemListRoot.syncLetterToItem()
             }
             else {
                 currentIndex = 0
@@ -369,10 +376,7 @@ FocusScope {
                 itemListRoot.goBack()
                 event.accepted = true
             } else if (event.key === Qt.Key_Right && showLetterNav && letterIndex.length > 0) {
-                var curLetter = sortKey((items[itemList.currentIndex] && items[itemList.currentIndex].title) || "")
-                for (var i = 0; i < letterIndex.length; i++) {
-                    if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
-                }
+                itemListRoot.syncLetterToItem()
                 letterNavActive = true
                 letterList.forceActiveFocus()
                 event.accepted = true

--- a/src/modules/emby/EmbyBackend.cpp
+++ b/src/modules/emby/EmbyBackend.cpp
@@ -691,6 +691,10 @@ QVariantMap EmbyBackend::formatItem(const QJsonObject &item) const {
     map["itemId"]          = item["Id"].toString();
     map["seriesId"]        = item["SeriesId"].toString();
     map["title"]           = item["Name"].toString();
+    // Server-side sort key (only present when the caller asked for the SortName
+    // field). The letter-nav panel buckets on this so its letters agree with the
+    // sortBy=SortName ordering the browse queries use.
+    map["titleSort"]       = item["SortName"].toString().toUpper();
     map["type"]            = item["Type"].toString().toLower();
     map["overview"]        = item["Overview"].toString();
     QString releaseDate = item["ReleaseDate"].toString();
@@ -811,7 +815,7 @@ void EmbyBackend::load_items(const QString &parentId, const QString &includeType
     // Browse rows only need title/year/overview/played state. Skip the heavy
     // per-item MediaSources/MediaStreams here (now that the list is unbounded) —
     // Item.qml re-fetches full detail via load_item_detail when an item is opened.
-    q.addQueryItem("fields", "Overview,Genres,UserData");
+    q.addQueryItem("fields", "Overview,Genres,UserData,SortName");
     if (!includeTypes.isEmpty())
         q.addQueryItem("includeItemTypes", includeTypes);
     if (!sortBy.isEmpty()) {
@@ -947,7 +951,7 @@ void EmbyBackend::load_folder_children(const QString &parentId) {
     QUrlQuery q;
     q.addQueryItem("parentId", parentId);
     q.addQueryItem("recursive", "false");
-    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount");
+    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount,SortName");
     q.addQueryItem("sortBy", "SortName");
     q.addQueryItem("sortOrder", "Ascending");
     url.setQuery(q);

--- a/src/modules/jellyfin/JellyfinBackend.cpp
+++ b/src/modules/jellyfin/JellyfinBackend.cpp
@@ -551,6 +551,10 @@ QVariantMap JellyfinBackend::formatItem(const QJsonObject &item) const {
     map["itemId"]          = item["Id"].toString();
     map["seriesId"]        = item["SeriesId"].toString();
     map["title"]           = item["Name"].toString();
+    // Server-side sort key (only present when the caller asked for the SortName
+    // field). The letter-nav panel buckets on this so its letters agree with the
+    // sortBy=SortName ordering the browse queries use.
+    map["titleSort"]       = item["SortName"].toString().toUpper();
     map["type"]            = item["Type"].toString().toLower();
     map["overview"]        = item["Overview"].toString();
     QString releaseDate = item["ReleaseDate"].toString();
@@ -659,7 +663,7 @@ void JellyfinBackend::load_items(const QString &parentId, const QString &include
     // Browse rows only need title/year/overview/played state. Skip the heavy
     // per-item MediaSources/MediaStreams here (now that the list is unbounded) —
     // Item.qml re-fetches full detail via load_item_detail when an item is opened.
-    q.addQueryItem("fields", "Overview,Genres,UserData");
+    q.addQueryItem("fields", "Overview,Genres,UserData,SortName");
     if (!includeTypes.isEmpty())
         q.addQueryItem("includeItemTypes", includeTypes);
     if (!sortBy.isEmpty()) {
@@ -760,7 +764,7 @@ void JellyfinBackend::load_boxset_children(const QString &parentId) {
     QUrlQuery q;
     q.addQueryItem("parentId", parentId);
     q.addQueryItem("recursive", "false");
-    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount,ReleaseDate,PremiereDate");
+    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount,ReleaseDate,PremiereDate,SortName");
     q.addQueryItem("sortBy", "SortName");
     q.addQueryItem("sortOrder", "Ascending");
     url.setQuery(q);
@@ -795,7 +799,7 @@ void JellyfinBackend::load_folder_children(const QString &parentId) {
     QUrlQuery q;
     q.addQueryItem("parentId", parentId);
     q.addQueryItem("recursive", "false");
-    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount");
+    q.addQueryItem("fields", "Overview,Genres,UserData,ChildCount,SortName");
     q.addQueryItem("sortBy", "SortName");
     q.addQueryItem("sortOrder", "Ascending");
     url.setQuery(q);

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -626,6 +626,7 @@ QVariantMap PlexBackend::formatItem(const QJsonObject &m) const {
     return QVariantMap{
         {"ratingKey",              m["ratingKey"].toString()},
         {"title",                  m["title"].toString().toUpper()},
+        {"titleSort",              m["titleSort"].toString().toUpper()},
         {"editionTitle",           m["editionTitle"].toString()},
         {"year",                   m["year"].toVariant()},
         {"duration",               m["duration"].toInt()},


### PR DESCRIPTION
## Summary

Closes https://github.com/anthonycaccese/240-MP/issues/219

## AI involvement

used to help structure an approach to work across plex,jellyfin and emby

## Testing

Tested on MacOS against real libraries for Plex, Emby and Jellyfin.  Tried changing sort name values to check with leading and without leading articles and confirmed the browse and list sorting stays in sync

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
