### PR TITLE
feat(settings): add ip address display

### DIFF
--- a/src/AppCore.cpp
+++ b/src/AppCore.cpp
@@ -7,6 +7,7 @@
 #include <QVariantMap>
 #include <QDebug>
 #include <QRegularExpression>
+#include <QNetworkInterface>
 #include <QQmlContext>
 
 AppCore::AppCore(const QString &appRoot, const QString &dataRoot, QObject *parent)
@@ -388,6 +389,47 @@ QString AppCore::parentDirectory(const QString &path) {
 
 QString AppCore::homePath() {
     return QDir::homePath();
+}
+
+// A device typically has several addresses (RPi: eth0 + wlan0; SteamOS: wlan0 plus
+// Docker/Flatpak bridges; macOS: en0 plus awdl/bridge/utun VPN interfaces), so pick
+// rather than take the first: skip loopback, virtual/tunnel and down interfaces, keep
+// only routable IPv4, and prefer wired over wireless over anything else.
+QString AppCore::localIpAddress() const {
+    // Interface names that are virtual/tunnel/link-local by convention on the three
+    // targets. Qt's type() misses some of these (Docker bridges report as Ethernet).
+    static const QRegularExpression kVirtualIface(
+        "^(docker|br-|bridge|veth|virbr|vmnet|vboxnet|utun|tun|tap|ipsec|zt|awdl|llw|anpi|ap\\d)",
+        QRegularExpression::CaseInsensitiveOption);
+
+    QString best;
+    int bestScore = -1;
+
+    const QList<QNetworkInterface> interfaces = QNetworkInterface::allInterfaces();
+    for (const QNetworkInterface &iface : interfaces) {
+        const QNetworkInterface::InterfaceFlags flags = iface.flags();
+        if (!flags.testFlag(QNetworkInterface::IsUp)) continue;
+        if (!flags.testFlag(QNetworkInterface::IsRunning)) continue;
+        if (flags.testFlag(QNetworkInterface::IsLoopBack)) continue;
+        if (iface.type() == QNetworkInterface::Virtual) continue;
+        if (kVirtualIface.match(iface.name()).hasMatch()) continue;
+
+        int score = 0;
+        if (iface.type() == QNetworkInterface::Ethernet) score = 2;
+        else if (iface.type() == QNetworkInterface::Wifi) score = 1;
+        if (score <= bestScore) continue;
+
+        const QList<QNetworkAddressEntry> entries = iface.addressEntries();
+        for (const QNetworkAddressEntry &entry : entries) {
+            const QHostAddress addr = entry.ip();
+            if (addr.protocol() != QAbstractSocket::IPv4Protocol) continue;
+            if (addr.isLoopback() || addr.isLinkLocal()) continue;
+            best = addr.toString();
+            bestScore = score;
+            break;
+        }
+    }
+    return best;
 }
 
 QString AppCore::startupModuleEntryPoint() const {

--- a/src/AppCore.h
+++ b/src/AppCore.h
@@ -45,6 +45,7 @@ public:
     Q_INVOKABLE QVariantList listDirectories(const QString &path);
     Q_INVOKABLE QString parentDirectory(const QString &path);
     Q_INVOKABLE QString homePath();
+    Q_INVOKABLE QString localIpAddress() const;
     Q_INVOKABLE QString startupModuleEntryPoint() const;
     Q_INVOKABLE QString get_module_auth_state(const QString &moduleId);
 

--- a/views/Settings.qml
+++ b/views/Settings.qml
@@ -216,6 +216,30 @@ FocusScope {
         anchors.leftMargin: root.sw * 0.125 //80
     }
 
+    // IP address
+    property string ipAddress: ""
+    Timer {
+        interval: 5000
+        running: true
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: settingsRoot.ipAddress = appCore.localIpAddress()
+    }
+    Text {
+        text: settingsRoot.ipAddress
+        visible: settingsRoot.ipAddress !== ""
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: root.sh * 0.125 //60
+        anchors.rightMargin: root.sw * 0.125 //80
+        font.pixelSize: root.sh * 0.0291667 //14
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        font.capitalization: Font.AllUppercase
+        topPadding: root.sh * 0.0125 //6
+        rightPadding: root.sw * 0.00625 //4
+    }
+
     ListView {
         id: settingsList
         model: settingsItems


### PR DESCRIPTION
## Summary

Idea from: https://github.com/anthonycaccese/240-MP/discussions/228

Idea for this is to provide a quick way to display the device's IP address so its easier to see what address to use when needing to ssh in or ftp data.

Add AppCore::localIpAddress(), selecting the best routable IPv4 across interfaces (skips loopback/virtual/tunnel, prefers wired over wireless), and bind the Settings header display it

## AI involvement

Used to work through the lookup logic so that its works well for each device target

## Testing

Tested on Raspberry Pi with wifi and wired connection, on MacOS switching between wifi and hotspot.  Address correctly updated in all tests.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)