### PR TITLE
docs: document YouTube JavaScript runtime setup

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,13 +25,15 @@ brew install mpv
 
 Note: 240-MP uses mpv as an external subprocess for video playback. It does not link against libmpv at build time, so mpv only needs to be on your `PATH` when running the app.
 
-**Install yt-dlp (optional, required only for the YouTube module):**
+**Install yt-dlp and Deno (optional, required only for the YouTube module):**
 
 ```bash
-brew install yt-dlp
+brew install yt-dlp deno
 ```
 
 mpv's ytdl hook uses `yt-dlp` to resolve YouTube URLs at playback time. The YouTube module also expects at least one of two files in the data directory (`#` comments allowed in both; each file only gates its own menu entries): `youtube_subscriptions.txt` (one channel ID per line — enables Subscriptions/Channels; see [INSTALL.md](INSTALL.md)) and/or `youtube_playlists.txt` (one playlist URL or ID per line, optional `My Name | <url>` display-name prefix — enables Playlists; contents are fetched by running `yt-dlp` directly).
+
+For full YouTube support, current yt-dlp versions also use an external JavaScript runtime. Deno is the recommended runtime. See yt-dlp's [EJS setup guide](https://github.com/yt-dlp/yt-dlp/wiki/EJS) for the currently supported runtimes and versions.
 
 **Install SDL2 (required, gamepad input):**
 
@@ -120,11 +122,24 @@ Either way, run the reader setup script once to grant device access (it installs
 bash scripts/setup-nfc-reader.sh
 ```
 
-For the YouTube module, additionally install `yt-dlp` — mpv's ytdl hook uses it to resolve YouTube URLs at playback time and it needs to be up to date.  The version bundled with mpv by default on the Raspberry Pi is out of date so you'll need to use wget to get the latest directly from yt-dlp's github.
+For the YouTube module, additionally install `yt-dlp` — mpv's ytdl hook uses it to resolve YouTube URLs at playback time and it needs to be kept up to date. The version bundled with mpv on Raspberry Pi OS may be out of date, so install the latest executable directly from yt-dlp's GitHub releases.
 
 ```bash
 sudo wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp && sudo chmod a+rx /usr/local/bin/yt-dlp
 ```
+
+For full YouTube support, yt-dlp also uses an external JavaScript runtime. Deno is the recommended runtime; follow yt-dlp's [EJS setup guide](https://github.com/yt-dlp/yt-dlp/wiki/EJS) for installation and current version requirements. Make sure `deno` is on the `PATH` of the user or systemd service that runs 240-MP.
+
+You can verify the setup with:
+
+```bash
+yt-dlp --version
+deno --version
+yt-dlp --verbose --simulate \
+  'https://www.youtube.com/watch?v=VIDEO_ID'
+```
+
+The verbose output should list Deno under `JS runtimes`. If extraction still fails, use the extractor error in this output for diagnosis; not every pre-playback failure means that yt-dlp is missing or outdated.
 
 ### Get the source
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -139,6 +139,8 @@ yt-dlp --verbose --simulate --force-ipv6 \
   'https://www.youtube.com/watch?v=VIDEO_ID'
 ```
 
+If IPv4 returns the bot-check error while IPv6 succeeds, the failure is tied to the IPv4 route rather than the yt-dlp installation. A working IPv6 route may allow playback to proceed, but enabling it is a device and network configuration choice outside 240-MP.
+
 IPv6 is not a 240-MP requirement, and 240-MP should not enable or force it automatically; these commands are only a diagnostic.
 
 ### Get the source

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -122,24 +122,24 @@ Either way, run the reader setup script once to grant device access (it installs
 bash scripts/setup-nfc-reader.sh
 ```
 
-For the YouTube module, additionally install `yt-dlp` — mpv's ytdl hook uses it to resolve YouTube URLs at playback time and it needs to be kept up to date. The version bundled with mpv on Raspberry Pi OS may be out of date, so install the latest executable directly from yt-dlp's GitHub releases.
+For the YouTube module, additionally install `yt-dlp` — mpv's ytdl hook uses it to resolve YouTube URLs at playback time and it needs to be up to date.  The version bundled with mpv by default on the Raspberry Pi is out of date so you'll need to use wget to get the latest directly from yt-dlp's github.
 
 ```bash
 sudo wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp && sudo chmod a+rx /usr/local/bin/yt-dlp
 ```
 
-For full YouTube support, yt-dlp also uses an external JavaScript runtime. Deno is the recommended runtime; follow yt-dlp's [EJS setup guide](https://github.com/yt-dlp/yt-dlp/wiki/EJS) for installation and current version requirements. Make sure `deno` is on the `PATH` of the user or systemd service that runs 240-MP.
+For full YouTube support, yt-dlp also uses an external JavaScript runtime; install the recommended Deno runtime by following yt-dlp's [EJS setup guide](https://github.com/yt-dlp/yt-dlp/wiki/EJS), and make sure `deno` is on the `PATH` of the user or systemd service that runs 240-MP.
 
-You can verify the setup with:
+If yt-dlp is current and Deno is detected but YouTube still returns `Sign in to confirm you're not a bot`, the response can be route-specific. On a system that already has working IPv6, compare:
 
 ```bash
-yt-dlp --version
-deno --version
-yt-dlp --verbose --simulate \
+yt-dlp --verbose --simulate --force-ipv4 \
+  'https://www.youtube.com/watch?v=VIDEO_ID'
+yt-dlp --verbose --simulate --force-ipv6 \
   'https://www.youtube.com/watch?v=VIDEO_ID'
 ```
 
-The verbose output should list Deno under `JS runtimes`. If extraction still fails, use the extractor error in this output for diagnosis; not every pre-playback failure means that yt-dlp is missing or outdated.
+IPv6 is not a 240-MP requirement, and 240-MP should not enable or force it automatically; these commands are only a diagnostic.
 
 ### Get the source
 


### PR DESCRIPTION
## Summary

- document Deno alongside yt-dlp for macOS and Raspberry Pi YouTube setup
- link yt-dlp's official EJS setup guide
- add route-comparison diagnostics for the observed YouTube bot-check response
- clarify that IPv6 is diagnostic and not a 240-MP requirement

This is a documentation-only change. It does not alter 240-MP's playback, error-message, or network behavior.

## Why

A Raspberry Pi showed 240-MP's generic yt-dlp playback error even though yt-dlp was current. The investigation found that yt-dlp initially reported no available JavaScript runtime. Installing Deno satisfied yt-dlp's current runtime guidance, while the remaining playback failure was ultimately traced to a route-specific YouTube network challenge: IPv4 failed and IPv6 succeeded for the same video.

The documentation should therefore include the JavaScript runtime prerequisite and the bounded route diagnostic without having 240-MP enable or force IPv6.

Related: #203

## Validation

- `git diff --check origin/main...HEAD`
- confirmed the official yt-dlp EJS guide returns HTTP 200
- verified yt-dlp `2026.07.04` detects Deno `2.9.5` on Raspberry Pi OS arm64
- confirmed successful YouTube extraction and 240-MP playback on the Raspberry Pi after the separate network-route issue was resolved

SteamOS instructions were intentionally left unchanged because Deno installation and persistence were not validated there.

## AI use

Codex was used to help investigate the Raspberry Pi logs, cross-reference yt-dlp's documentation, and prepare the initial documentation change and PR description. I reviewed and revised the documentation and PR communication on my fork before this upstream submission.
