### PR TITLE
fix(plex): recover from PMS 401 by refreshing server tokens

### DIFF
--- a/modules/plex/views/Libraries.qml
+++ b/modules/plex/views/Libraries.qml
@@ -18,11 +18,13 @@ FocusScope {
     // means the quick-switch action (◄/►) is offered.
     property var switchableServers: []
     property bool canSwitchServer: switchableServers.length > 1
+    property string errorMsg: ""
 
     Connections {
         target: plexBackend
 
         function onLibrariesLoaded(items) {
+            browseRoot.errorMsg = ""
             browseRoot.libraries = items
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
@@ -33,6 +35,7 @@ FocusScope {
 
         function onErrorOccurred(msg) {
             console.log("[Library] Error: " + msg)
+            browseRoot.errorMsg = msg
         }
     }
 
@@ -69,12 +72,26 @@ FocusScope {
 
     // Loading Indicator
     Text {
-        visible: libraries.length === 0
+        visible: libraries.length === 0 && browseRoot.errorMsg === ""
         text: "LOADING..."
         color: root.tertiaryColor
         font.family: root.globalFont
         anchors.centerIn: parent
         font.pixelSize: root.sh * 0.05 //24
+    }
+
+    // Error message
+    Text {
+        visible: browseRoot.errorMsg !== ""
+        text: browseRoot.errorMsg
+        color: root.secondaryColor
+        font.family: root.globalFont
+        font.capitalization: Font.AllUppercase
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+        width: root.sw * 0.6 //384
+        anchors.centerIn: parent
+        font.pixelSize: root.sh * 0.0375 //18
     }
 
     // Body

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -1192,15 +1192,40 @@ void PlexBackend::load_libraries_impl() {
                     handle498([this]{ load_libraries_impl(); });
                 } else if (secStatus == 401) {
                     // 401 from PMS means this server rejected our token — the plex.tv account
-                    // auth is NOT invalidated. Do not delete plex_auth.json. The server may be
-                    // running an older version that doesn't accept JWTs yet; the user should
-                    // try selecting a different server or update their Plex Media Server.
-                    emit errorOccurred("SERVER AUTHENTICATION FAILED. TRY SELECTING A DIFFERENT SERVER OR UPDATE YOUR PLEX MEDIA SERVER.");
+                    // auth is NOT invalidated. Do not delete plex_auth.json.
+                    //
+                    // The usual cause is a stale per-server token: the map is first written at
+                    // link time straight from /api/v2/resources, where servers the user owns
+                    // come back with a plex.tv JWT that PMS does not accept. activateUser swaps
+                    // those for a PMS-usable token during user selection, but that swap is
+                    // skipped silently if either of its two requests fails (a brief network
+                    // blip during first-run setup is enough), leaving the JWT in place forever.
+                    //
+                    // So before surfacing an error, re-run activateUser for the active user to
+                    // refetch and rewrite the token map, then retry once. m_serverAuthRetried
+                    // keeps that to a single attempt.
+                    // activateUser emits its own "USER NOT FOUND" if the id isn't in the
+                    // cached users array, which would be a confusing thing to show here —
+                    // so only take the retry path when we know it will resolve.
+                    QJsonObject a = loadAuth();
+                    QString uid = a["active_user_id"].toString();
+                    bool known = false;
+                    for (const auto &v : a["users"].toArray())
+                        if (v.toObject()["id"].toString() == uid) { known = true; break; }
+                    if (!m_serverAuthRetried && !uid.isEmpty() && known) {
+                        m_serverAuthRetried = true;
+                        qWarning("[PlexBackend] PMS rejected our token — refreshing server tokens and retrying");
+                        activateUser(uid, [this](const QVariantList &) { load_libraries_impl(); });
+                    } else {
+                        m_serverAuthRetried = false;
+                        emit errorOccurred("SERVER REJECTED THIS DEVICE. PLEASE TRY AGAIN.");
+                    }
                 } else {
                     emit errorOccurred("LOAD LIBRARIES FAILED: " + secReply->errorString());
                 }
                 return;
             }
+            m_serverAuthRetried = false; // this server accepted our token; re-arm the retry
             QJsonArray sections = QJsonDocument::fromJson(secReply->readAll())
                                   .object()["MediaContainer"].toObject()["Directory"].toArray();
 

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -213,6 +213,7 @@ private:
     QString m_clientId;          // cached after first load
     bool    m_refreshInFlight  = false;
     bool    m_deviceVerified   = false; // set after first successful plex.tv check per session
+    bool    m_serverAuthRetried = false; // guards the one-shot token re-fetch on a PMS 401
 
     // Live TV session state. m_liveDvrId is cached from the last load_live_channels.
     // The rest are set by tune_channel and drive the timeline keep-alive that stops


### PR DESCRIPTION
## Summary

Found in trying to replicate https://github.com/anthonycaccese/240-MP/issues/240 that a brief network failure during user selection could leave the link-time plex.tv JWT in user_server_tokens, which the current version of PMS rejects, permanently breaking the module with no in-app recovery. 

So on a 401 the app now re-runs activateUser to rewrite the token map and retries once before erroring. 

This also corrects the misleading "update your Plex Media Server" text and surfaces the error on the libraries screen instead of hanging on "LOADING..." if this occurs.  

Existing users with working library loads shouldn't see any change after this is merged (because they are already able to view their servers so they didn't hit this error before). I only found it by blocking network access during the auth flow so its a low risk change that legit fixed a hidden till now bug =)

Note: its not clear yet that this will fix the bug called out in #240 but there is a chance it will (need a few answers to the questions i asked first to verify)

That said this was a legit bug either way so it was good to find it and fix it.

## AI involvement

Used to work through the order of operations that could trigger this bug and implement a remedy.  I verified on MacOS and RPi with an existing working plex_auth and a new auth where I blocked network access at a specific time to cause the bug to manifest.   Recovery worked well and existing working auth had no differences in experience.

## Testing

I verified on MacOS and RPi with an existing working plex_auth and a new auth where I blocked network access at a specific time to cause the bug to manifest.   Recovery worked well and existing working auth had no differences in experience.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
