### PR TITLE
fix(settings): scroll module settings list to follow selection

### DIFF
--- a/views/ModuleSettings.qml
+++ b/views/ModuleSettings.qml
@@ -195,16 +195,16 @@ FocusScope {
         focus: true
 
         Keys.onUpPressed: {
-            if (currentIndex > 0) currentIndex-- 
+            if (currentIndex > 0) currentIndex--
             else {
                 currentIndex = schemaItems.length-1
             }
-            schemaItems.positionViewAtIndex(currentIndex, ListView.Contain)
+            settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
         }
         Keys.onDownPressed: {
             if (currentIndex < count - 1) currentIndex++
             else currentIndex = 0
-            schemaItems.positionViewAtIndex(currentIndex, ListView.Contain)
+            settingsList.positionViewAtIndex(currentIndex, ListView.Contain)
         }
 
         Keys.onLeftPressed: {


### PR DESCRIPTION
## Summary

Found this while working through another update

Keys.onUpPressed/onDownPressed called positionViewAtIndex on schemaItems, the model array, instead of the settingsList ListView — a TypeError at runtime, so the viewport never followed currentIndex and wraparound left the selection off-screen in modules with more settings than fit.

## AI involvement

None

## Testing

Verified on Plex module by adding an additional setting to check that scrolling correctly worked after.
