### PR TITLE
feat(mpv): Allow holding key to skip repeatedly

### DIFF
--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -379,9 +379,8 @@ local function toggle_menu()
 
         mp.add_forced_key_binding("UP",    "menu-up",    function() update_nav("up")    end)
         mp.add_forced_key_binding("DOWN",  "menu-down",  function() update_nav("down")  end)
-        mp.add_forced_key_binding("LEFT",  "menu-left",  function() update_nav("left")  end)
-        mp.add_forced_key_binding("RIGHT", "menu-right", function() update_nav("right") end)
-        mp.add_forced_key_binding("ENTER", "menu-enter", function() update_nav("enter") end)
+        mp.add_forced_key_binding("LEFT",  "menu-left",  function() update_nav("left")  end, {repeatable = true})
+        mp.add_forced_key_binding("RIGHT", "menu-right", function() update_nav("right") end, {repeatable = true})
         mp.add_forced_key_binding("ESC",   "menu-esc",   toggle_menu)
         mp.add_forced_key_binding("BS",    "menu-bs",    toggle_menu)
     end

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -377,7 +377,7 @@ local function toggle_menu()
         update_timer = mp.add_periodic_timer(0.5, draw_menu)
         reset_idle_timer()
 
-        p.add_forced_key_binding("UP",    "menu-up",    function() update_nav("up")    end)
+        mp.add_forced_key_binding("UP",    "menu-up",    function() update_nav("up")    end)
         mp.add_forced_key_binding("DOWN",  "menu-down",  function() update_nav("down")  end)
         mp.add_forced_key_binding("LEFT",  "menu-left",  function() update_nav("left")  end, {repeatable = true})
         mp.add_forced_key_binding("RIGHT", "menu-right", function() update_nav("right") end, {repeatable = true})

--- a/scripts/mpv-osc.lua
+++ b/scripts/mpv-osc.lua
@@ -377,10 +377,11 @@ local function toggle_menu()
         update_timer = mp.add_periodic_timer(0.5, draw_menu)
         reset_idle_timer()
 
-        mp.add_forced_key_binding("UP",    "menu-up",    function() update_nav("up")    end)
+        p.add_forced_key_binding("UP",    "menu-up",    function() update_nav("up")    end)
         mp.add_forced_key_binding("DOWN",  "menu-down",  function() update_nav("down")  end)
         mp.add_forced_key_binding("LEFT",  "menu-left",  function() update_nav("left")  end, {repeatable = true})
         mp.add_forced_key_binding("RIGHT", "menu-right", function() update_nav("right") end, {repeatable = true})
+        mp.add_forced_key_binding("ENTER", "menu-enter", function() update_nav("enter") end)
         mp.add_forced_key_binding("ESC",   "menu-esc",   toggle_menu)
         mp.add_forced_key_binding("BS",    "menu-bs",    toggle_menu)
     end


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issue, e.g. "Closes #12". -->
Can now hold left or right while on the playback bar on the osc to repeatedly skip. 
## AI involvement

<!--
Required. Per CONTRIBUTING.md, please describe the scope of any AI use: which parts (if
any) were AI-generated, and what human review/testing you did before submitting.
Please write "No AI used" if that's the case. PRs that omit this may be closed without review.
-->
Not used
## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->
Tested on MacOS

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
