### PR TITLE
feat(plex): support PIN-protected plex home profiles on user switch

### DIFF
--- a/modules/plex/views/Libraries.qml
+++ b/modules/plex/views/Libraries.qml
@@ -9,6 +9,9 @@ FocusScope {
     property var navListState: navParams.navListState || ({})
 
     signal navigateTo(string path, var params, var listState)
+    // Used for the PIN handoff below: replacing rather than pushing keeps this
+    // view from ending up on the stack twice when ProfilePin returns here.
+    signal replaceWith(string path, var params)
     signal goBack()
 
     property var libraries: []
@@ -36,6 +39,17 @@ FocusScope {
         function onErrorOccurred(msg) {
             console.log("[Library] Error: " + msg)
             browseRoot.errorMsg = msg
+        }
+
+        // The 401-recovery retry re-runs the user switch, which can turn out to
+        // need the profile's PIN.
+        function onUserPinRequired(userId, wrongPin) {
+            browseRoot.replaceWith("ProfilePin.qml", {
+                userId: userId,
+                title: browseRoot.userName,
+                reauth: true,
+                wrongPin: wrongPin
+            })
         }
     }
 

--- a/modules/plex/views/PinAuth.qml
+++ b/modules/plex/views/PinAuth.qml
@@ -13,6 +13,8 @@ FocusScope {
     property string pinCode: ""
     property bool waiting: false
     property string errorMsg: ""
+    // Remembered only so a PIN prompt can name the profile it is asking about.
+    property var autoUser: null
 
     Connections {
         target: plexBackend
@@ -30,10 +32,23 @@ FocusScope {
         function onUsersLoaded(users) {
             if (users.length === 1) {
                 // Only one user — auto-select and go straight to server select
+                pinAuthRoot.autoUser = users[0]
                 plexBackend.select_user(users[0].id)
             } else {
                 pinAuthRoot.replaceWith("UserSelect.qml", { users: users })
             }
+        }
+
+        // The auto-selected profile is PIN-protected. Hand off rather than sitting
+        // on "Waiting..." forever.
+        function onUserPinRequired(userId, wrongPin) {
+            pinAuthRoot.waiting = false
+            pinAuthRoot.replaceWith("ProfilePin.qml", {
+                userId: userId,
+                title: pinAuthRoot.autoUser ? pinAuthRoot.autoUser.title : "",
+                reauth: false,
+                wrongPin: wrongPin
+            })
         }
 
         function onServersLoaded(servers) {

--- a/modules/plex/views/ProfilePin.qml
+++ b/modules/plex/views/ProfilePin.qml
@@ -1,0 +1,213 @@
+import QtQuick
+import Components
+
+// Entry for a Plex Home profile's 4-digit PIN.
+//
+// Reached only when plex.tv refuses the user switch and asks for one — the
+// profile's "protected" flag is not a reliable predictor, so this view is never
+// shown speculatively. Note the name: "PinAuth" is the plex.tv/link code, this is
+// the profile PIN, and they are unrelated.
+//
+// Built as a spinner rather than a text field because the app is driven by a
+// remote and a gamepad, which have no digit keys. Digit keys still work when a
+// keyboard is attached.
+FocusScope {
+    id: profilePinRoot
+
+    property var navParams: ({})
+
+    signal navigateTo(string path, var params)
+    // Success leaves via replaceWith, not navigateTo, so this view drops off the
+    // nav stack once the PIN is accepted — backing out of the library should
+    // return to whatever came before the prompt, never re-ask for the PIN.
+    signal replaceWith(string path, var params)
+    signal goBack()
+
+    property string userId: navParams.userId || ""
+    property string userTitle: navParams.title || ""
+    property bool   reauth: navParams.reauth === true
+
+    readonly property int slotCount: 4
+    property var digits: [0, 0, 0, 0]
+    property int cursor: 0
+
+    property bool submitting: false
+    property string errorMsg: navParams.wrongPin === true ? "INCORRECT PIN" : ""
+
+    function setDigit(value) {
+        var d = digits.slice()
+        d[cursor] = (value + 10) % 10
+        digits = d
+    }
+
+    function submit() {
+        if (userId === "") return
+        profilePinRoot.submitting = true
+        profilePinRoot.errorMsg = ""
+        var pin = digits.join("")
+        if (reauth) plexBackend.reauth_select_user(userId, pin)
+        else        plexBackend.select_user(userId, pin)
+    }
+
+    function cancel() {
+        plexBackend.cancel_pending_pin()
+        goBack()
+    }
+
+    Connections {
+        target: plexBackend
+
+        // Routing continues from here, mirroring UserSelect.qml — this view is on
+        // screen when the retry lands, so it owns the handoff.
+        function onServersLoaded(servers) {
+            if (!profilePinRoot.reauth)
+                profilePinRoot.replaceWith("ServerSelect.qml", { servers: servers })
+        }
+
+        function onAuthSuccess() {
+            if (profilePinRoot.reauth)
+                profilePinRoot.replaceWith("Libraries.qml", {})
+        }
+
+        // Rejected again — stay put and let them retry.
+        function onUserPinRequired(userId, wrongPin) {
+            profilePinRoot.submitting = false
+        }
+
+        function onErrorOccurred(msg) {
+            profilePinRoot.submitting = false
+            profilePinRoot.errorMsg = msg
+        }
+    }
+
+    focus: true
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace
+            || event.key === Qt.Key_Back) {
+            cancel()
+            event.accepted = true
+            return
+        }
+        if (submitting) { event.accepted = true; return }
+
+        if (event.key === Qt.Key_Up) {
+            setDigit(digits[cursor] + 1)
+        } else if (event.key === Qt.Key_Down) {
+            setDigit(digits[cursor] - 1)
+        } else if (event.key === Qt.Key_Left) {
+            // Wraps, per the app-wide list convention. BACKSPACE is reserved for
+            // leaving the view, so LEFT is how you go back to correct a digit.
+            cursor = cursor > 0 ? cursor - 1 : slotCount - 1
+        } else if (event.key === Qt.Key_Right) {
+            cursor = cursor < slotCount - 1 ? cursor + 1 : 0
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            submit()
+        } else if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
+            setDigit(event.key - Qt.Key_0)
+            if (cursor < slotCount - 1) cursor++
+        } else {
+            return
+        }
+        event.accepted = true
+    }
+
+    // ---
+    // UI
+    // ---
+
+    // Header
+    AppBar {
+        iconSource: moduleRoot.moduleIcon
+        title: moduleRoot.moduleName
+        subtitle: "Enter PIN"
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: root.sh * 0.125 //60
+        anchors.leftMargin: root.sw * 0.125 //80
+    }
+
+    // Body
+    Column {
+        anchors.centerIn: parent
+        spacing: root.sh * 0.05 //24
+
+        Text {
+            text: profilePinRoot.userTitle !== ""
+                  ? "Enter the PIN for " + profilePinRoot.userTitle
+                  : "Enter your profile PIN"
+            color: root.secondaryColor
+            font.family: root.globalFont
+            font.capitalization: Font.AllUppercase
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            font.pixelSize: root.sh * 0.0333333 //16
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: root.sw * 0.025 //16
+
+            Repeater {
+                model: profilePinRoot.slotCount
+
+                Rectangle {
+                    width: root.sw * 0.0625 //40
+                    height: root.sh * 0.125 //60
+                    color: "transparent"
+                    border.width: root.sh * 0.0041667 //2
+                    border.color: profilePinRoot.cursor === index
+                                  ? root.accentColor : root.tertiaryColor
+
+                    Text {
+                        // The slot under the cursor shows its digit so the spinner
+                        // is usable; the rest are masked.
+                        text: profilePinRoot.cursor === index
+                              ? profilePinRoot.digits[index] : "*"
+                        color: profilePinRoot.cursor === index
+                               ? root.accentColor : root.primaryColor
+                        font.family: root.globalFont
+                        anchors.centerIn: parent
+                        font.pixelSize: root.sh * 0.0666667 //32
+                    }
+                }
+            }
+        }
+
+        Text {
+            visible: profilePinRoot.submitting
+            text: "Checking..."
+            color: root.tertiaryColor
+            font.family: root.globalFont
+            font.capitalization: Font.AllUppercase
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            font.pixelSize: root.sh * 0.0333333 //16
+        }
+
+        Text {
+            visible: profilePinRoot.errorMsg !== "" && !profilePinRoot.submitting
+            text: profilePinRoot.errorMsg
+            color: root.accentColor
+            font.family: root.globalFont
+            font.capitalization: Font.AllUppercase
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            width: root.sw * 0.6
+            anchors.horizontalCenter: parent.horizontalCenter
+            font.pixelSize: root.sh * 0.0375 //18
+        }
+    }
+
+    // Footer
+    Text {
+        id: footer
+        text: root.hints.back + ":BACK " + root.hints.navigate + ":DIGIT " + root.hints.change + ":CHANGE " + root.hints.select + ":SUBMIT"
+        color: root.tertiaryColor
+        font.family: root.globalFont
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: root.sh * 0.1041667 //50
+        anchors.leftMargin: root.sw * 0.125 //80
+        font.pixelSize: root.sh * 0.0333333 //16
+    }
+}

--- a/modules/plex/views/Root.qml
+++ b/modules/plex/views/Root.qml
@@ -89,7 +89,14 @@ FocusScope {
     Component.onCompleted: {
         plexBackend.reset_device_check()
         var state = plexBackend.get_auth_state()
-        if (state === "authed") {
+        // A user picked in the app Settings screen whose switch was refused for
+        // want of a PIN. Settings has no Plex view to prompt from, so the prompt
+        // is deferred to here — ahead of auto_sign_in, which would otherwise walk
+        // straight past it into Libraries with the previous user still active.
+        var pendingPin = plexBackend.pending_pin_user()
+        if (state === "authed" && pendingPin !== "") {
+            navigateTo("ProfilePin.qml", { userId: pendingPin, reauth: true })
+        } else if (state === "authed") {
             var autoSignIn = appCore.get_setting(moduleId, "auto_sign_in")
             if (autoSignIn !== true && autoSignIn !== "ON") {
                 plexBackend.load_users_from_cache()

--- a/modules/plex/views/UserSelect.qml
+++ b/modules/plex/views/UserSelect.qml
@@ -10,12 +10,29 @@ FocusScope {
     signal goBack()
 
     property var users: navParams.users || []
+    property string errorMsg: ""
+
+    function titleFor(userId) {
+        for (var i = 0; i < users.length; i++)
+            if (users[i].id === userId) return users[i].title || ""
+        return ""
+    }
 
     Connections {
         target: plexBackend
 
         function onUsersLoaded(loadedUsers) {
             userSelectRoot.users = loadedUsers
+        }
+
+        // plex.tv wants the profile's PIN before it will switch.
+        function onUserPinRequired(userId, wrongPin) {
+            userSelectRoot.navigateTo("ProfilePin.qml", {
+                userId: userId,
+                title: userSelectRoot.titleFor(userId),
+                reauth: userSelectRoot.navParams.reauth === true,
+                wrongPin: wrongPin
+            })
         }
 
         function onServersLoaded(servers) {
@@ -32,6 +49,7 @@ FocusScope {
 
         function onErrorOccurred(msg) {
             console.log("[UserSelect] Error: " + msg)
+            userSelectRoot.errorMsg = msg
         }
     }
 
@@ -142,6 +160,23 @@ FocusScope {
                 }
             }
         }
+    }
+
+    // Error message — without this a failed switch is invisible in the very view
+    // the selection was made from.
+    Text {
+        visible: userSelectRoot.errorMsg !== ""
+        text: userSelectRoot.errorMsg
+        color: root.secondaryColor
+        font.family: root.globalFont
+        font.capitalization: Font.AllUppercase
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+        width: root.sw * 0.6
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: footer.top
+        anchors.bottomMargin: root.sh * 0.05
+        font.pixelSize: root.sh * 0.0333333 //16
     }
 
     // Footer

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -21,6 +21,25 @@
 
 static const QString PLEX_TV = QStringLiteral("https://plex.tv");
 
+// Auth logging helpers.  plex.tv issues JWTs while PMS only accepts opaque
+// per-server tokens, so "which kind of token did we end up with" is the single
+// most useful thing to see in a bug report — and it can be logged safely.
+// tokenShape reports the kind and length only, midTail reduces a machine ID to
+// its last four characters, which is enough to correlate lines.  Neither ever
+// emits credential material; keep it that way if you add call sites.
+static QString tokenShape(const QString &t) {
+    if (t.isEmpty()) return QStringLiteral("<empty>");
+    return QStringLiteral("%1 len=%2")
+        .arg(t.startsWith(QLatin1String("eyJ")) ? QStringLiteral("JWT")
+                                                : QStringLiteral("opaque"),
+             QString::number(t.size()));
+}
+
+static QString midTail(const QString &mid) {
+    if (mid.isEmpty()) return QStringLiteral("<empty>");
+    return QStringLiteral("…") + mid.right(4);
+}
+
 static const QSet<QString> kSupportedLibraryTypes = {"movie", "show", "clip"};
 
 #ifdef Q_OS_MAC
@@ -496,21 +515,122 @@ QString PlexBackend::serverToken() const {
     return accountToken();
 }
 
+// The subset of a plex.tv Home user we persist and hand to QML. Single definition
+// so the link-time fetch and the live PIN-flag check cannot drift apart.
+QJsonObject PlexBackend::homeUserEntry(const QJsonObject &u) {
+    QJsonObject entry;
+    entry["id"]      = QString::number(u["id"].toInt());
+    entry["uuid"]    = u["uuid"].toString();
+    entry["title"]   = u["title"].toString(u["username"].toString()).toUpper();
+    entry["managed"] = u["managed"].toBool();
+    // "protected" means the profile has a PIN. Authoritative for prompting;
+    // see activateUser for why it is re-read live rather than trusted from cache.
+    entry["protected"] = u["protected"].toBool();
+    entry["admin"]     = u["admin"].toBool();
+    return entry;
+}
+
+QJsonObject PlexBackend::cachedUser(const QString &userId) const {
+    for (const auto &v : loadAuth()["users"].toArray()) {
+        if (v.toObject()["id"].toString() == userId) return v.toObject();
+    }
+    return {};
+}
+
 bool PlexBackend::isAccountOwner(const QString &userId) const {
     QString aid = loadAuth()["account_user_id"].toString();
     return !aid.isEmpty() && aid == userId;
 }
 
+// Reports whether a switch response is plex.tv refusing the switch for want of a
+// PIN.  Error code 1041 ("A valid PIN is required to perform this action") covers
+// both "the profile is PIN-protected and you sent none" and "that PIN was wrong".
+//
+// A 403 with no code we recognise is treated as a PIN refusal too, since that is
+// what a forbidden switch has meant in every report so far — but a bare 401 is
+// not: that is an invalid account token, and prompting for a PIN would send the
+// user down the wrong path entirely.
+static bool switchNeedsPin(int status, const QByteArray &body) {
+    if (status != 401 && status != 403) return false;
+
+    QJsonArray errors = QJsonDocument::fromJson(body).object()["errors"].toArray();
+    for (const auto &ev : errors)
+        if (ev.toObject()["code"].toInt() == 1041) return true;
+
+    return status == 403 && errors.isEmpty();
+}
+
 // Single consolidated user-switch path.  All three public callers (select_user,
 // reauth_select_user, applyCurrentUserSetting) delegate here and supply a callback
 // that handles the caller-specific signal and any post-switch state writes.
-void PlexBackend::activateUser(const QString &userId,
+//
+// pin is empty on the first attempt and only set when the caller is retrying after
+// userPinRequired.  It goes on the wire and is never written to disk.
+void PlexBackend::activateUser(const QString &userId, const QString &pin,
                                 std::function<void(const QVariantList &)> callback) {
-    QJsonObject auth = loadAuth();
-    QJsonObject user;
-    for (const auto &v : auth["users"].toArray()) {
-        if (v.toObject()["id"].toString() == userId) { user = v.toObject(); break; }
-    }
+    QJsonObject user = cachedUser(userId);
+    if (user.isEmpty()) { emit errorOccurred("USER NOT FOUND"); return; }
+
+    m_pendingPinUserId.clear();   // re-armed below if this attempt is refused
+
+    // Retrying with a PIN in hand: the gate has already been answered.
+    if (!pin.isEmpty()) { performUserSwitch(userId, pin, callback); return; }
+
+    // Honour the profile's own PIN gate before asking plex.tv to switch. plex.tv
+    // only *validates* a PIN when one is supplied — on many accounts it will
+    // happily switch into a "PIN Required" profile when none is sent — so this
+    // flag is what makes the parental control mean anything, and it is what every
+    // other Plex client prompts on. A supplied PIN is still checked server-side,
+    // so this is a gate, not a pretence.
+    //
+    // Read it live rather than from plex_auth.json: the cached copy is written at
+    // link time, so a PIN added in Plex afterwards would be silently ignored (and
+    // a PIN removed would prompt forever). A switch is an explicit, infrequent
+    // action that already costs two round trips, so one more is worth not having
+    // a security gate depend on stale state. If the request fails we fall back to
+    // the cached flag, and the 1041 refusal path still backstops us either way.
+    auto *usersReply = plexGet(QUrl(PLEX_TV + "/api/v2/home/users"), accountToken());
+    connect(usersReply, &QNetworkReply::finished, this,
+            [this, usersReply, userId, user, callback]() {
+        usersReply->deleteLater();
+
+        bool isProtected = user["protected"].toBool();
+        if (usersReply->error() == QNetworkReply::NoError) {
+            QJsonArray fresh;
+            for (const auto &v : QJsonDocument::fromJson(usersReply->readAll())
+                                     .object()["users"].toArray()) {
+                QJsonObject entry = homeUserEntry(v.toObject());
+                if (entry["id"].toString() == userId)
+                    isProtected = entry["protected"].toBool();
+                fresh.append(entry);
+            }
+            // Keep the cache honest while we have the answer — this is also how
+            // renamed, added and removed profiles get picked up.
+            if (!fresh.isEmpty()) {
+                QJsonObject a = loadAuth();
+                a["users"] = fresh;
+                saveAuth(a);
+            }
+        } else {
+            qWarning().noquote() << "[PlexAuth] live PIN-flag check failed ("
+                                 << usersReply->errorString()
+                                 << ") — falling back to cached flag";
+        }
+
+        if (isProtected) {
+            qWarning().noquote() << "[PlexAuth] profile is PIN-protected — prompting";
+            m_pendingPinUserId = userId;
+            emit userPinRequired(userId, false);
+            return;
+        }
+        performUserSwitch(userId, QString(), callback);
+    });
+}
+
+// The switch itself, split out so activateUser can gate on the PIN flag first.
+void PlexBackend::performUserSwitch(const QString &userId, const QString &pin,
+                                     std::function<void(const QVariantList &)> callback) {
+    QJsonObject user = cachedUser(userId);
     if (user.isEmpty()) { emit errorOccurred("USER NOT FOUND"); return; }
 
     QString switchKey = user["uuid"].toString();
@@ -518,16 +638,46 @@ void PlexBackend::activateUser(const QString &userId,
     QString masterToken = accountToken();
     bool owner = isAccountOwner(userId);
 
-    auto *switchReply = plexPost(
-        QUrl(PLEX_TV + "/api/v2/home/users/" + switchKey + "/switch"), masterToken);
+    QUrl switchUrl(PLEX_TV + "/api/v2/home/users/" + switchKey + "/switch");
+    if (!pin.isEmpty()) {
+        QUrlQuery pq;
+        pq.addQueryItem("pin", pin);
+        switchUrl.setQuery(pq);
+    }
+    bool hadPin = !pin.isEmpty();
+
+    auto *switchReply = plexPost(switchUrl, masterToken);
     connect(switchReply, &QNetworkReply::finished, this,
-            [this, switchReply, userId, masterToken, owner, callback]() mutable {
+            [this, switchReply, userId, masterToken, owner, hadPin, callback]() mutable {
         switchReply->deleteLater();
+        int switchStatus = switchReply->attribute(
+            QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        QByteArray switchBody = switchReply->readAll();
+
+        // A PIN-protected profile refuses the switch outright.  Stop here rather
+        // than falling through to the resource fetch: without a switch token the
+        // owner's per-server tokens stay JWTs, PMS rejects every one of them, and
+        // the failure only surfaces much later as an unexplained 401.
+        if (switchNeedsPin(switchStatus, switchBody)) {
+            qWarning().noquote() << "[PlexAuth] switch needs PIN — status=" << switchStatus
+                                 << "retry=" << hadPin;
+            // Park the user so a caller with no UI to prompt from (the
+            // current_user_id setting) can hand off to Root.qml on module entry.
+            // In-module callers prompt immediately and clear this on the retry.
+            m_pendingPinUserId = userId;
+            if (hadPin) emit errorOccurred("INCORRECT PIN");
+            emit userPinRequired(userId, hadPin);
+            return;
+        }
+
         QString switchToken = masterToken;
         if (switchReply->error() == QNetworkReply::NoError) {
-            QString t = QJsonDocument::fromJson(switchReply->readAll()).object()["authToken"].toString();
+            QString t = QJsonDocument::fromJson(switchBody).object()["authToken"].toString();
             if (!t.isEmpty()) switchToken = t;
         }
+        qWarning().noquote() << "[PlexAuth] switch status=" << switchStatus
+                             << "token=" << tokenShape(switchToken)
+                             << "differsFromMaster=" << (switchToken != masterToken);
 
         QUrl resUrl(PLEX_TV + "/api/v2/resources");
         QUrlQuery q;
@@ -563,6 +713,33 @@ void PlexBackend::activateUser(const QString &userId,
                             tokenMap[it.key()] = switchToken;
                     }
                 }
+            }
+
+            // Never persist a JWT as a server token.  plex.tv hands back the account
+            // JWT as the accessToken for owned servers, and PMS rejects those, so a
+            // JWT that survived the swap above is not a credential — storing it only
+            // buys an unexplained 401 later.  Shared servers (owned=false) come with
+            // real opaque tokens straight from /api/v2/resources and are unaffected.
+            int dropped = 0;
+            for (const QString &mid : tokenMap.keys()) {
+                if (tokenMap[mid].toString().startsWith(QLatin1String("eyJ"))) {
+                    tokenMap.remove(mid);
+                    dropped++;
+                }
+            }
+            qWarning().noquote() << "[PlexAuth] server tokens usable=" << tokenMap.size()
+                                 << "dropped(JWT)=" << dropped;
+
+            // Every token we were given is unusable — activating would leave the
+            // module authenticated but unable to reach any server.  Say so now.
+            // (An empty map with nothing dropped just means the resource fetch
+            // failed; that path still falls through and keeps the previous tokens.)
+            if (tokenMap.isEmpty() && dropped > 0) {
+                emit errorOccurred("PLEX DID NOT ISSUE A SERVER TOKEN FOR THIS DEVICE");
+                return;
+            }
+
+            if (owner) {
                 if (!tokenMap.isEmpty())
                     a["user_server_tokens"] = tokenMap;
                 a["managed_user_tokens"] = QJsonObject{}; // cleared on owner switch
@@ -847,15 +1024,8 @@ void PlexBackend::fetchUsersAndServers(const QString &token) {
         QJsonObject usersData = QJsonDocument::fromJson(usersReply->readAll()).object();
         QJsonArray rawUsers = usersData["users"].toArray();
         QJsonArray users;
-        for (const auto &v : rawUsers) {
-            QJsonObject u = v.toObject();
-            QJsonObject entry;
-            entry["id"]      = QString::number(u["id"].toInt());
-            entry["uuid"]    = u["uuid"].toString();
-            entry["title"]   = u["title"].toString(u["username"].toString()).toUpper();
-            entry["managed"] = u["managed"].toBool();
-            users.append(entry);
-        }
+        for (const auto &v : rawUsers)
+            users.append(homeUserEntry(v.toObject()));
 
         // Step 2: fetch resources (servers)
         QUrl resUrl(PLEX_TV + "/api/v2/resources");
@@ -1059,8 +1229,8 @@ void PlexBackend::load_users_from_cache() {
 // select_user
 // ---------------------------------------------------------------------------
 
-void PlexBackend::select_user(const QString &userId) {
-    activateUser(userId, [this, userId](const QVariantList &accessibleServers) {
+void PlexBackend::select_user(const QString &userId, const QString &pin) {
+    activateUser(userId, pin, [this, userId](const QVariantList &accessibleServers) {
         QJsonObject cfg = loadConfig();
         QJsonObject mods = cfg["modules"].toObject();
         QJsonObject plexCfg = mods["com.240mp.plex"].toObject();
@@ -1169,6 +1339,12 @@ void PlexBackend::load_libraries_impl() {
     QString token = serverToken();
     if (uri.isEmpty()) { emit errorOccurred("NO SERVER CONFIGURED"); return; }
 
+    // The one line that says whether we are about to hand PMS something it can
+    // use.  "JWT" here means a 401 is coming; see tokenShape.
+    qWarning().noquote() << "[PlexAuth] load_libraries mid="
+                         << midTail(loadAuth()["active_server_machine_id"].toString())
+                         << "token=" << tokenShape(token);
+
     // Check continue watching
     QUrl cwUrl(uri + "/hubs/continueWatching");
     QUrlQuery cwq; cwq.addQueryItem("limit","1");
@@ -1215,10 +1391,19 @@ void PlexBackend::load_libraries_impl() {
                     if (!m_serverAuthRetried && !uid.isEmpty() && known) {
                         m_serverAuthRetried = true;
                         qWarning("[PlexBackend] PMS rejected our token — refreshing server tokens and retrying");
-                        activateUser(uid, [this](const QVariantList &) { load_libraries_impl(); });
+                        // No PIN here: if the profile needs one, activateUser emits
+                        // userPinRequired and the view prompts.
+                        activateUser(uid, QString(),
+                                     [this](const QVariantList &) { load_libraries_impl(); });
                     } else {
                         m_serverAuthRetried = false;
-                        emit errorOccurred("SERVER REJECTED THIS DEVICE. PLEASE TRY AGAIN.");
+                        // A JWT-shaped token means plex.tv never issued a server
+                        // credential for us — naming that is more use than "try again".
+                        emit errorOccurred(
+                            serverToken().startsWith(QLatin1String("eyJ"))
+                                ? "PLEX DID NOT ISSUE A SERVER TOKEN FOR THIS DEVICE. "
+                                  "SIGN OUT AND SIGN IN AGAIN."
+                                : "SERVER REJECTED THIS DEVICE. PLEASE TRY AGAIN.");
                     }
                 } else {
                     emit errorOccurred("LOAD LIBRARIES FAILED: " + secReply->errorString());
@@ -2309,7 +2494,10 @@ void PlexBackend::applyCurrentUserSetting() {
                      ["com.240mp.plex"].toObject()["current_user_id"].toString();
     if (userId.isEmpty()) return;
 
-    activateUser(userId, [this](const QVariantList &accessibleServers) {
+    // This runs from the app Settings screen, where the Plex views are not loaded
+    // and so cannot prompt.  activateUser parks the user in m_pendingPinUserId and
+    // Root.qml drains it on the next module entry, ahead of the auto_sign_in branch.
+    activateUser(userId, QString(), [this](const QVariantList &accessibleServers) {
         QJsonObject a = loadAuth();
         QString curMid = a["active_server_machine_id"].toString();
         bool curAccessible = false;
@@ -2359,8 +2547,26 @@ void PlexBackend::applyCurrentServerSetting() {
 // reauth_select_user
 // ---------------------------------------------------------------------------
 
-void PlexBackend::reauth_select_user(const QString &userId) {
-    activateUser(userId, [this, userId](const QVariantList &accessibleServers) {
+// Backing out of a PIN prompt.  The current_user_id setting may already name the
+// user we failed to switch to, so put it back to whoever is actually active —
+// otherwise config claims a user the app never activated.
+void PlexBackend::cancel_pending_pin() {
+    m_pendingPinUserId.clear();
+
+    QString activeId = loadAuth()["active_user_id"].toString();
+    QJsonObject cfg = loadConfig();
+    QJsonObject mods = cfg["modules"].toObject();
+    QJsonObject plexCfg = mods["com.240mp.plex"].toObject();
+    if (plexCfg["current_user_id"].toString() == activeId) return;
+
+    plexCfg["current_user_id"] = activeId;
+    mods["com.240mp.plex"] = plexCfg;
+    cfg["modules"] = mods;
+    saveConfig(cfg);
+}
+
+void PlexBackend::reauth_select_user(const QString &userId, const QString &pin) {
+    activateUser(userId, pin, [this, userId](const QVariantList &accessibleServers) {
         QJsonObject a = loadAuth();
         QJsonObject cfg = loadConfig();
         QJsonObject mods = cfg["modules"].toObject();

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -26,8 +26,14 @@ public:
     // Auth flow
     Q_INVOKABLE void start_pin_auth();
     Q_INVOKABLE void load_users_from_cache();
-    Q_INVOKABLE void select_user(const QString &userId);
-    Q_INVOKABLE void reauth_select_user(const QString &userId);
+    // pin is only supplied on a retry, after plex.tv has told us the profile
+    // needs one (see userPinRequired). It is never stored.
+    Q_INVOKABLE void select_user(const QString &userId, const QString &pin = QString());
+    Q_INVOKABLE void reauth_select_user(const QString &userId, const QString &pin = QString());
+    // Set when a switch was refused for want of a PIN on a path that has no UI to
+    // prompt from (the current_user_id setting); Root.qml drains it on module entry.
+    Q_INVOKABLE QString pending_pin_user() const { return m_pendingPinUserId; }
+    Q_INVOKABLE void    cancel_pending_pin();
     Q_INVOKABLE void select_server(const QString &machineId);
     Q_INVOKABLE void logout();
 
@@ -97,6 +103,9 @@ signals:
     void logoutComplete();
     void authStateChanged();
     void authRevoked();
+    // plex.tv refused the user switch until we supply the profile's PIN.
+    // wrongPin distinguishes "we haven't asked yet" from "that PIN was wrong".
+    void userPinRequired(const QString &userId, bool wrongPin);
 
     void librariesLoaded(const QVariant &libraries);
     void continueWatchingLoaded(const QVariant &items);
@@ -174,8 +183,16 @@ private:
 
     // User activation — single path for all three switch callers
     bool isAccountOwner(const QString &userId) const;
-    void activateUser(const QString &userId,
+    static QJsonObject homeUserEntry(const QJsonObject &rawUser);
+    QJsonObject cachedUser(const QString &userId) const;
+    // Checks the profile's PIN gate (live, not cached) and then switches.
+    void activateUser(const QString &userId, const QString &pin,
                       std::function<void(const QVariantList &accessibleServers)> callback);
+    void performUserSwitch(const QString &userId, const QString &pin,
+                           std::function<void(const QVariantList &accessibleServers)> callback);
+
+    // User the current_user_id setting selected but whose switch needs a PIN.
+    QString m_pendingPinUserId;
 
     // PIN auth
     void pollPinTick();


### PR DESCRIPTION
## Summary

Work related to https://github.com/anthonycaccese/240-MP/issues/240

A PIN-protected Plex Home profile makes POST /api/v2/home/users/{uuid}/switch return 403 (error 1041), so no opaque server token is ever minted. activateUser silently fell back to the account JWT, PMS rejects JWTs, and every library load 401d with no way to recover so the module was broken for anyone whose account enforces the profile PIN.

plex.tv's enforcement oddly looks to vary by account: it always validates a PIN when one is supplied, but only demands one on some accounts (for some reason on my account it doesn't demand one when I have one set and its not clear why). So because of that the prompt fires on two independent triggers... the profile's PIN flag, and a 1041 refusal (neither alone is sufficient from testing). Without the flag, 240-MP walks straight into a profile marked "PIN Required", which is the parental control quietly not working; without the refusal, accounts that enforce server-side can't access their libraries.

So this commit does the following:
- thread an optional PIN through select_user / reauth_select_user / activateUser; send it as ?pin= on the switch. It is never stored
- on a refusal, stop and ask rather than storing a token PMS cannot use
- read the PIN flag live per switch. Refreshes the cached user list as a side effect; falls back to the cached flag if the request fails, with the 1041 refusal still behind it
- ProfilePin.qml: 4-slot digit spinner. Up/Down sets the digit, Left/Right moves between slots, digit keys work when a keyboard is present
- handled in UserSelect, PinAuth (which auto-selects when there is exactly one Home user), and Libraries (the 401-recovery retry). The current_user_id setting has no view to prompt from, so it parks the user and Root.qml drains it ahead of the auto_sign_in branch, which would otherwise walk past it into Libraries with the previous user still active
- ProfilePin leaves via replaceWith, so backing out of the library steps over the PIN prompt correctly; same for the Libraries handoff, which would otherwise push a duplicate Libraries entry
- never persist a JWT as a server token, and abort with a clear message if that leaves none (previously this state was invisible until a later 401)
- UserSelect now shows errors at all; it only console.logged them before
- keep three credential-free token-shape log lines (kind + length, machine IDs truncated) so the next report is diagnosable without a debug build

## AI involvement

Used Claude Opus to trace the 2 paths and implement the overall check architecture.  I verified the flow and implementation as well as build the QML UI for pin entry.

## Testing

Verified on macOS and on a Raspberry Pi 4: prompt on the flag and on a refusal, wrong PIN, correct PIN, cancel, back-out, PIN removed in Plex honored without re-auth, PIN-free profiles unaffected, and the spinner driven by a remote and gamepad d-pad.  I also turned on and off pin for my primary user during testing to verify that the check works in real time.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)