### PR TITLE
fix(appimage): drop QtQuick.Controls import and pin Qt style vars

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Window
 
 Window {

--- a/packaging/linux/AppRun
+++ b/packaging/linux/AppRun
@@ -84,4 +84,41 @@ if [ -n "${DISPLAY:-}" ]; then
     export QT_QPA_PLATFORM
 fi
 
+# Qt settings that belong to us, not to the session we happen to start in.
+#
+# A Linux session exports Qt variables to every Qt program under it, knowing
+# nothing about any of them. KDE-derived setups point QT_QUICK_CONTROLS_STYLE at
+# org.kde.desktop, whose QML plugin links against the HOST's Qt — pulled into our
+# bundled Qt that is two Qt copies in one process, and the app dies before the
+# first frame (issue #258, CachyOS under Steam Big Picture).
+#
+# Which systems export it is a per-distro packaging choice, not a property of KDE:
+# SteamOS desktop mode is also Plasma and does NOT trigger this, and #258 fired
+# under Big Picture with no Plasma session running at all — so CachyOS is setting
+# it more globally than a session script would. Don't reason from "is it KDE?";
+# assume any host may hand us any of these, and pin regardless.
+#
+# So these are pinned unconditionally rather than deferred to with ${VAR:-...}
+# like QT_QPA_PLATFORM above, and the difference is who the value is about.
+# X11-vs-Wayland is a property of the user's machine: the session knows it better
+# than we do, and yielding is right. A widget style is a property of OUR design —
+# a fixed look, with nothing here to theme — so a value arriving in it is not a
+# choice made for 240-MP, it is ambient session state. ${VAR:-...} cannot tell
+# the two apart, because both reach us under the same name.
+#
+# Pin by name, never by namespace: QT_LOGGING_RULES / QSG_* are how we ask a user
+# to debug a black screen, and swallowing their launch option would make that
+# miserable. QT_QPA_PLATFORM and scale-factor variables stay theirs too.
+#
+# If an override is ever genuinely needed — 240-MP starts using real Qt Quick
+# Controls types, or someone hits a case where a pin here is wrong for their
+# hardware — add an MP240_-prefixed variable to read instead. Nothing else on any
+# system sets that prefix, so a value found in one is deliberate by construction,
+# while the session's broadcast stays locked out. Do not reopen these names.
+QT_QUICK_CONTROLS_STYLE=Basic
+QT_QUICK_CONTROLS_FALLBACK_STYLE=Basic
+export QT_QUICK_CONTROLS_STYLE QT_QUICK_CONTROLS_FALLBACK_STYLE
+unset QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE
+unset QT_PLUGIN_PATH QML2_IMPORT_PATH QML_IMPORT_PATH
+
 exec "$HERE/usr/bin/240mp" "$@"


### PR DESCRIPTION
## Summary

Closes #258 

Importing the module forces Qt to resolve a Controls style at load time, which a host-set QT_QUICK_CONTROLS_STYLE=org.kde.desktop hijacks. That style's plugin links against the host's Qt, so the AppImage's bundled Qt loads a second Qt copy and dies before the first frame (#258, CachyOS under Steam Big Picture).

Which hosts export that var is a per-distro packaging choice, not a KDE property (SteamOS desktop mode is also Plasma and doesn't trigger it, and #258 fired with no Plasma session running). Since the blast radius isn't enumerable, remove the question rather than predict who asks it: nothing in the app instantiates a Controls type, so the import was dead. Also drops an undeclared runtime dependency on qtquickcontrols2 for native installs and stops linuxdeploy bundling the module.

Insurance for the day a Controls type comes back: pin the style to Basic and unset the vars that tell our bundled Qt to load parts from the host's toolbox (platformtheme, style override, plugin/QML import paths).

Pinned unconditionally rather than deferred to with ${VAR:-...} like QT_QPA_PLATFORM -- the platform is a property of the user's machine, a widget style is a property of our design, and ${VAR:-...} cannot tell a deliberate launch option from a desktop's room-wide broadcast. Scrubbed by name, never by namespace, so QT_LOGGING_RULES/QSG_* still work for remote debugging.

## AI involvement

Used to help debug the QT_QUICK_CONTROLS_STYLE import, I reasoned through the approach, reviewed the change and tested the app bundle changes through from there.

## Testing

Tested along side the reporter in #258 on both Steam OS and CatchyOS using both the existing .appimage and the new bundle created from this PR.  

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
