### PR TITLE
feat(plex): add shuffle and play all options to playlists and collections

### DIFF
--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -34,39 +34,34 @@ FocusScope {
     // go through actionRows.length. `rows` is what the ListView actually shows.
     // ----------------------------------------------------------------
     property bool canQueue: listType === "playlist_items" || listType === "collection_items"
-    // Only leaf playables can be queued. flattenSeasons has already expanded any
-    // seasons, but a collection of shows still yields `show` rows, which have no
-    // media of their own — such a collection simply gets no queue rows.
+    // Passed to the backend as-is: seasons were flattened when the list loaded,
+    // so a row is either a leaf or a show, and expand_queue fans the shows out
+    // into their episodes. The ordering (and any shuffle) happens after that
+    // expansion, in QueuePlay.qml — shuffling here would randomize shows, not
+    // episodes.
     property var queueItems: canQueue
-        ? items.filter(function(i) { return i && i.type !== "show" })
+        ? items.filter(function(i) { return i && i.ratingKey })
         : []
-    property var actionRows: queueItems.length > 1
-        ? [{ __action: "play_all", title: "PLAY ALL" },
-           { __action: "shuffle",  title: "SHUFFLE"  }]
-        : []
+    property var actionRows: queueRowsWarranted(queueItems) ? [
+            { __action: "play_all", title: "» PLAY ALL" },
+            { __action: "shuffle",  title: "~ SHUFFLE"  }
+        ] : []
     property var rows: actionRows.concat(items)
+
+    // One show is already a queue — all of its episodes — so it earns the rows on
+    // its own, where a lone movie does not.
+    function queueRowsWarranted(candidates) {
+        if (candidates.length > 1) return true
+        return candidates.length === 1 && candidates[0].type === "show"
+    }
 
     // Number of leading action rows for a given backend result. Used by the
     // restore clamps, which run while `items` is mid-assignment and so cannot
     // read the actionRows binding.
     function actionRowCountFor(loadedItems) {
         if (!canQueue) return 0
-        var playable = 0
-        for (var i = 0; i < loadedItems.length; i++) {
-            if (loadedItems[i] && loadedItems[i].type !== "show") playable++
-        }
-        return playable > 1 ? 2 : 0
-    }
-
-    function buildQueue(shuffle) {
-        var keys = queueItems.map(function(i) { return i.ratingKey })
-        if (shuffle) {
-            for (var i = keys.length - 1; i > 0; i--) {
-                var j = Math.floor(Math.random() * (i + 1))
-                var tmp = keys[i]; keys[i] = keys[j]; keys[j] = tmp
-            }
-        }
-        return keys
+        var candidates = loadedItems.filter(function(i) { return i && i.ratingKey })
+        return queueRowsWarranted(candidates) ? 2 : 0
     }
 
     // Buckets by the server's sort title when one is set (Plex sorts the list by
@@ -222,7 +217,8 @@ FocusScope {
         // Virtual queue rows — play the whole set instead of drilling into one item.
         if (item.__action) {
             itemListRoot.navigateTo("QueuePlay.qml", {
-                queue: buildQueue(item.__action === "shuffle"),
+                queueItems: queueItems,
+                shuffle: item.__action === "shuffle",
                 title: listTitle,
                 libraryName: libraryName
             }, { currentIndex: itemList.currentIndex })

--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -27,6 +27,48 @@ FocusScope {
     property bool letterNavActive: false
     property var letterIndex: []
 
+    // ----------------------------------------------------------------
+    // PLAY ALL / SHUFFLE rows — curated sets can be played as a queue.
+    // They are prepended as virtual rows rather than mixed into `items`, so
+    // `items` stays exactly what the backend sent and every index into it has to
+    // go through actionRows.length. `rows` is what the ListView actually shows.
+    // ----------------------------------------------------------------
+    property bool canQueue: listType === "playlist_items" || listType === "collection_items"
+    // Only leaf playables can be queued. flattenSeasons has already expanded any
+    // seasons, but a collection of shows still yields `show` rows, which have no
+    // media of their own — such a collection simply gets no queue rows.
+    property var queueItems: canQueue
+        ? items.filter(function(i) { return i && i.type !== "show" })
+        : []
+    property var actionRows: queueItems.length > 1
+        ? [{ __action: "play_all", title: "PLAY ALL" },
+           { __action: "shuffle",  title: "SHUFFLE"  }]
+        : []
+    property var rows: actionRows.concat(items)
+
+    // Number of leading action rows for a given backend result. Used by the
+    // restore clamps, which run while `items` is mid-assignment and so cannot
+    // read the actionRows binding.
+    function actionRowCountFor(loadedItems) {
+        if (!canQueue) return 0
+        var playable = 0
+        for (var i = 0; i < loadedItems.length; i++) {
+            if (loadedItems[i] && loadedItems[i].type !== "show") playable++
+        }
+        return playable > 1 ? 2 : 0
+    }
+
+    function buildQueue(shuffle) {
+        var keys = queueItems.map(function(i) { return i.ratingKey })
+        if (shuffle) {
+            for (var i = keys.length - 1; i > 0; i--) {
+                var j = Math.floor(Math.random() * (i + 1))
+                var tmp = keys[i]; keys[i] = keys[j]; keys[j] = tmp
+            }
+        }
+        return keys
+    }
+
     // Buckets by the server's sort title when one is set (Plex sorts the list by
     // titleSort), otherwise falls back to article-stripping the display title —
     // which is what Plex itself does for items without a custom sort title.
@@ -45,7 +87,7 @@ FocusScope {
 
     // Highlights the letter matching the currently selected item.
     function syncLetterToItem() {
-        var curLetter = sortKey(items[itemList.currentIndex])
+        var curLetter = sortKey(items[itemList.currentIndex - actionRows.length])
         for (var i = 0; i < letterIndex.length; i++) {
             if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
         }
@@ -86,8 +128,11 @@ FocusScope {
                 if (itemListRoot.showLetterNav)
                     itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
                 if (loadedItems.length > 0) {
+                    // The saved index is a *row* index, so the clamp has to account
+                    // for the PLAY ALL / SHUFFLE rows this list may have prepended.
+                    var rowCount = loadedItems.length + itemListRoot.actionRowCountFor(loadedItems)
                     var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
-                    itemList.currentIndex = Math.min(restore, loadedItems.length - 1)
+                    itemList.currentIndex = Math.min(restore, rowCount - 1)
                     itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
                 }
             }
@@ -171,8 +216,18 @@ FocusScope {
     // ----------------------------------------------------------------
 
     function selectItem() {
-        var item = items[itemList.currentIndex]
+        var item = rows[itemList.currentIndex]
         if (!item) return
+
+        // Virtual queue rows — play the whole set instead of drilling into one item.
+        if (item.__action) {
+            itemListRoot.navigateTo("QueuePlay.qml", {
+                queue: buildQueue(item.__action === "shuffle"),
+                title: listTitle,
+                libraryName: libraryName
+            }, { currentIndex: itemList.currentIndex })
+            return
+        }
 
         // Intermediate lists that navigate deeper
         if (listType === "hubs") {
@@ -333,7 +388,7 @@ FocusScope {
     // Body
     ListView {
         id: itemList
-        model: items
+        model: rows
         opacity: letterNavActive ? 0.3 : 1
         anchors.top: parent.top
         anchors.left: parent.left

--- a/modules/plex/views/Player.qml
+++ b/modules/plex/views/Player.qml
@@ -41,6 +41,13 @@ FocusScope {
     // Show/season ratingKey a shuffle card draws its episodes from; empty for
     // every other kind of playback, which advances sequentially.
     property string shuffleScope:       navParams.shuffleScope || ""
+    // PLAY ALL / SHUFFLE over a playlist or collection: the ordered ratingKeys of
+    // everything still to play, and where in them the current item sits. Empty for
+    // every other kind of playback. A queue advances unconditionally — the user
+    // asked for the whole set — so it is checked ahead of autoplayNext, and
+    // QueuePlay.qml passes allowAutoplay: false to keep the two from racing.
+    property var    queue:              navParams.queue || []
+    property int    queueIndex:         navParams.queueIndex || 0
 
     property bool stoppedReported:    false
     property bool playbackStarted:    false
@@ -267,12 +274,26 @@ FocusScope {
             // Empty detail → no next episode in the season (or a lookup failure).
             // Fall back to the standard behavior: return to the detail view.
             if (!detail || !detail.ratingKey) {
+                // Inside a queue an unplayable entry is skipped instead: one bad
+                // item must not end a playlist the user asked to play in full.
+                if (playerRoot.requestNextQueueItem()) return
                 pendingNextEpisode = false
                 goBack()
                 return
             }
             playerRoot.advanceToEpisode(detail)
         }
+    }
+
+    // Ask the backend for the next item of the queue, if there is one. Reports
+    // through nextEpisodeReady, so the advance is the same code path as autoplay.
+    // Returns false when there is no queue or it is exhausted.
+    function requestNextQueueItem() {
+        if (queue.length === 0 || queueIndex + 1 >= queue.length) return false
+        queueIndex++
+        pendingNextEpisode = true
+        plexBackend.load_queue_item(queue[queueIndex])
+        return true
     }
 
     // Swap the player's context to the next episode in place (no navigation) and
@@ -305,7 +326,9 @@ FocusScope {
         // Repoint the BACK target so exiting returns to THIS episode's detail
         // screen, not the one we auto-advanced from. Item.qml reloads from
         // item.ratingKey, so a minimal item carrying the new keys suffices.
-        updateBackItem({
+        // A queue was launched with replaceWith, so the stack top is the list the
+        // queue came from — leave it pointing at the list.
+        if (queue.length === 0) updateBackItem({
             ratingKey: detail.ratingKey,
             type: detail.type || "episode",
             title: detail.title || "",
@@ -382,6 +405,13 @@ FocusScope {
             // onNextEpisodeReady falls back to goBack(). Everything else returns to
             // the detail view here.
             reportStopped(finalPositionMs, finalDurationMs)
+            if (reason === "eof" && queue.length > 0) {
+                // A queue advances regardless of the autoplay setting: playing the
+                // whole set is what the user selected. Exhausted → back to the list.
+                if (requestNextQueueItem()) return
+                goBack()
+                return
+            }
             if (reason === "eof" && autoplayNext) {
                 pendingNextEpisode = true
                 // Same advance machinery either way — only the source of the next

--- a/modules/plex/views/QueuePlay.qml
+++ b/modules/plex/views/QueuePlay.qml
@@ -16,10 +16,14 @@ FocusScope {
     signal replaceWith(string path, var params)
     signal goBack()
 
-    // Ordered ratingKeys — already shuffled by the caller for SHUFFLE.
-    property var    queue:     navParams.queue || []
-    property string queueTitle: navParams.title || ""
+    // The rows the user queued, straight from the list view: leaves and shows.
+    property var    queueItems: navParams.queueItems || []
+    property bool   shuffle:    navParams.shuffle    || false
+    property string queueTitle: navParams.title      || ""
 
+    // The ratingKeys that actually play, once the shows have been expanded into
+    // their episodes and the order has been settled.
+    property var    queue:        []
     property int    queueIndex:   0
     property string errorMessage: ""
     property string sessionId:    ""
@@ -44,11 +48,27 @@ FocusScope {
 
     function start() {
         errorMessage = ""
-        if (queue.length === 0) { fail("NOTHING TO PLAY"); return }
-        // A retry after "nothing resolved" starts the queue over from the top.
-        if (queueIndex >= queue.length) queueIndex = 0
+        if (queueItems.length === 0) { fail("NOTHING TO PLAY"); return }
         launching = true
-        plexBackend.load_queue_item(queue[queueIndex])
+        // Answers immediately when there is nothing to expand; a set containing
+        // shows costs one request per show plus one per season first, which is
+        // what the loading screen is covering.
+        plexBackend.expand_queue(queueItems)
+    }
+
+    // Play the expanded queue from its first entry, in order or shuffled. The
+    // shuffle happens here, after expansion, so it interleaves episodes across
+    // shows rather than merely reordering the shows themselves.
+    function startQueue(keys) {
+        if (shuffle) {
+            for (var i = keys.length - 1; i > 0; i--) {
+                var j = Math.floor(Math.random() * (i + 1))
+                var tmp = keys[i]; keys[i] = keys[j]; keys[j] = tmp
+            }
+        }
+        queue = keys
+        queueIndex = 0
+        plexBackend.load_queue_item(queue[0])
     }
 
     Keys.onPressed: function(event) {
@@ -64,6 +84,12 @@ FocusScope {
 
     Connections {
         target: plexBackend
+
+        function onQueueReady(ratingKeys) {
+            if (!queueRoot.launching) return
+            if (ratingKeys.length === 0) { queueRoot.fail("NOTHING TO PLAY"); return }
+            queueRoot.startQueue(ratingKeys)
+        }
 
         function onNextEpisodeReady(detail) {
             if (!queueRoot.launching) return

--- a/modules/plex/views/QueuePlay.qml
+++ b/modules/plex/views/QueuePlay.qml
@@ -1,0 +1,186 @@
+import QtQuick
+
+// PLAY ALL / SHUFFLE launcher for a playlist or collection. Resolves the first
+// playable item of the queue, builds its stream, then replaces itself with
+// Player.qml — which carries the rest of the queue and advances through it.
+//
+// replaceWith (not navigateTo) leaves no entry on the nav stack, so backing out
+// of the player returns straight to the list the queue was started from, with
+// its selected row restored. This mirrors CardPlay.qml, the other launcher that
+// plays something without going through a detail screen.
+FocusScope {
+    id: queueRoot
+
+    property var navParams: ({})
+
+    signal replaceWith(string path, var params)
+    signal goBack()
+
+    // Ordered ratingKeys — already shuffled by the caller for SHUFFLE.
+    property var    queue:     navParams.queue || []
+    property string queueTitle: navParams.title || ""
+
+    property int    queueIndex:   0
+    property string errorMessage: ""
+    property string sessionId:    ""
+    // Guards against a stray nextEpisodeReady / streamUrlReady from an earlier
+    // view reaching us.
+    property bool   launching:    false
+    property var    pendingDetail: null
+
+    focus: true
+
+    function newSessionId() {
+        var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var id = ""
+        for (var i = 0; i < 12; i++) id += chars[Math.floor(Math.random() * chars.length)]
+        return id
+    }
+
+    function fail(msg) {
+        launching = false
+        errorMessage = msg
+    }
+
+    function start() {
+        errorMessage = ""
+        if (queue.length === 0) { fail("NOTHING TO PLAY"); return }
+        // A retry after "nothing resolved" starts the queue over from the top.
+        if (queueIndex >= queue.length) queueIndex = 0
+        launching = true
+        plexBackend.load_queue_item(queue[queueIndex])
+    }
+
+    Keys.onPressed: function(event) {
+        if (errorMessage === "") return
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Backspace || event.key === Qt.Key_Back) {
+            goBack()
+            event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            start()
+            event.accepted = true
+        }
+    }
+
+    Connections {
+        target: plexBackend
+
+        function onNextEpisodeReady(detail) {
+            if (!queueRoot.launching) return
+            // An unplayable entry must not sink the whole queue — skip to the next
+            // one, and only give up once nothing in the queue resolves.
+            if (!detail || !detail.ratingKey) {
+                queueRoot.queueIndex++
+                if (queueRoot.queueIndex >= queueRoot.queue.length) {
+                    queueRoot.fail("COULD NOT LOAD THIS ITEM")
+                    return
+                }
+                plexBackend.load_queue_item(queueRoot.queue[queueRoot.queueIndex])
+                return
+            }
+            queueRoot.pendingDetail = detail
+            queueRoot.sessionId = queueRoot.newSessionId()
+            // Like CardPlay.qml, no set_audio_stream / set_subtitle_stream call:
+            // the first item plays the server's stored defaults, and Player.qml
+            // carries that selection forward by language from there.
+            if (detail.forceTranscode) {
+                // Always from 0 — a queue launch starts the item at its beginning.
+                plexBackend.request_transcode(detail.ratingKey, detail.partKey, queueRoot.sessionId,
+                                              detail.selectedAudioId || "",
+                                              detail.selectedSubtitleId || "0", 0)
+            } else {
+                plexBackend.build_stream_url(detail.ratingKey, detail.partKey, queueRoot.sessionId)
+            }
+        }
+
+        function onStreamUrlReady(url, plexToken) {
+            if (!queueRoot.launching || !queueRoot.pendingDetail) return
+            var d = queueRoot.pendingDetail
+            queueRoot.launching = false
+            queueRoot.replaceWith("Player.qml", {
+                streamUrl:          url,
+                plexToken:          plexToken,
+                ratingKey:          d.ratingKey,
+                partKey:            d.partKey,
+                partId:             d.partId,
+                sessionId:          queueRoot.sessionId,
+                // A queue always starts its items from the beginning, so no resume
+                // prompt on the first one either — every later item starts at 0 too.
+                viewOffset:         0,
+                title:              d.title,
+                audioStreams:       d.audioStreams,
+                subtitleStreams:    d.subtitleStreams,
+                isTranscoding:      d.forceTranscode || false,
+                selectedAudioId:    d.selectedAudioId,
+                selectedSubtitleId: d.selectedSubtitleId,
+                // The queue owns advancing: the season-based autoplay chain must
+                // not also fire at the end of an episode inside a playlist.
+                allowAutoplay:      false,
+                queue:              queueRoot.queue,
+                queueIndex:         queueRoot.queueIndex
+            })
+        }
+
+        function onErrorOccurred(message) {
+            if (!queueRoot.launching) return
+            queueRoot.fail(message)
+        }
+    }
+
+    Component.onCompleted: start()
+
+    Rectangle {
+        anchors.fill: parent
+        color: "black"
+
+        Column {
+            anchors.centerIn: parent
+            spacing: root.sh * 0.05
+            visible: errorMessage === ""
+
+            Text {
+                text: "LOADING..."
+                color: "white"
+                font.family: root.globalFont
+                anchors.horizontalCenter: parent.horizontalCenter
+                font.pixelSize: root.sh * 0.05
+            }
+            Text {
+                visible: queueTitle !== ""
+                text: queueTitle
+                color: "#919191"
+                font.family: root.globalFont
+                font.capitalization: Font.AllUppercase
+                width: root.sw * 0.76875
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                font.pixelSize: root.sh * 0.0333333
+            }
+        }
+
+        Column {
+            anchors.centerIn: parent
+            spacing: root.sh * 0.05
+            visible: errorMessage !== ""
+
+            Text {
+                text: errorMessage
+                color: "white"
+                font.family: root.globalFont
+                width: root.sw * 0.5625
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                font.pixelSize: root.sh * 0.0375
+            }
+            Text {
+                text: root.hints.back + ":BACK " + root.hints.select + ":RETRY"
+                color: "#919191"
+                font.family: root.globalFont
+                anchors.horizontalCenter: parent.horizontalCenter
+                font.pixelSize: root.sh * 0.0333333
+            }
+        }
+    }
+}

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -2264,6 +2264,73 @@ void PlexBackend::load_random_episode(const QString &scopeRatingKey) {
     });
 }
 
+// A guard, not a policy: a queue is just a list of ratingKeys, but a very large
+// collection of shows would otherwise fan out into thousands of entries — and
+// every one of them was a request. Nothing real comes close.
+static constexpr int kMaxQueueItems = 2000;
+
+// Expands a PLAY ALL / SHUFFLE selection into what actually plays.
+//
+// Shows are the only rows that need expanding: seasons were already flattened
+// when the list was loaded, so everything else is a leaf. flattenSeasons itself
+// can't do this job — it builds the *displayed* list, and expanding shows there
+// would make a collection of shows browse as a wall of episodes.
+//
+// The shows fan out in parallel into ordered slots, so a collection's episodes
+// stay grouped by show, in season/episode order, however the replies land. A
+// show whose fetch fails contributes nothing and never stalls the queue:
+// fetchChildren reports an empty list on error rather than not reporting.
+void PlexBackend::expand_queue(const QVariantList &items) {
+    int showCount = 0;
+    for (const auto &v : items) {
+        if (v.toMap()["type"].toString() == QLatin1String("show")) showCount++;
+    }
+
+    // No shows: the selection is already the queue, so answer without a round trip.
+    if (showCount == 0) {
+        QStringList keys;
+        for (const auto &v : items) {
+            const QString key = v.toMap()["ratingKey"].toString();
+            if (!key.isEmpty()) keys.append(key);
+        }
+        emit queueReady(keys);
+        return;
+    }
+
+    auto *keySlots =  new QList<QStringList>(items.size());
+    auto *pending = new int(showCount);
+
+    for (int i = 0; i < items.size(); i++) {
+        const QVariantMap item = items[i].toMap();
+        const QString key = item["ratingKey"].toString();
+        if (item["type"].toString() != QLatin1String("show")) {
+            if (!key.isEmpty()) (*keySlots)[i] = QStringList{key};
+            continue;
+        }
+        const int idx = i;
+        fetchEpisodePool(key, [this, keySlots, pending, idx](const QVariantList &pool) {
+            QStringList episodes;
+            for (const auto &v : pool) {
+                const QString epKey = v.toMap()["ratingKey"].toString();
+                if (!epKey.isEmpty()) episodes.append(epKey);
+            }
+            (*keySlots)[idx] = episodes;
+            if (--(*pending) == 0) {
+                QStringList result;
+                for (const auto &bucket : *keySlots) result.append(bucket);
+                if (result.size() > kMaxQueueItems) {
+                    qWarning("[Plex] queue truncated from %lld to %d items",
+                             qlonglong(result.size()), kMaxQueueItems);
+                    result = result.mid(0, kMaxQueueItems);
+                }
+                emit queueReady(result);
+                delete keySlots;
+                delete pending;
+            }
+        });
+    }
+}
+
 // A queue's order is decided in QML from rows that are already loaded, so this
 // only has to resolve one ratingKey — which emitNextEpisode already does, through
 // the signal the Player's advance path consumes. An empty key (queue exhausted)

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -2264,6 +2264,14 @@ void PlexBackend::load_random_episode(const QString &scopeRatingKey) {
     });
 }
 
+// A queue's order is decided in QML from rows that are already loaded, so this
+// only has to resolve one ratingKey — which emitNextEpisode already does, through
+// the signal the Player's advance path consumes. An empty key (queue exhausted)
+// reports an empty map, which the Player treats as the end.
+void PlexBackend::load_queue_item(const QString &ratingKey) {
+    emitNextEpisode(ratingKey);
+}
+
 void PlexBackend::resolve_card(const QString &guid, const QString &mode) {
     if (guid.isEmpty()) { emit cardError(QStringLiteral("THIS CARD HAS NO PLEX ITEM")); return; }
     const QString uri = serverUrl(), token = serverToken();

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -82,6 +82,10 @@ public:
     // show/season. Emits nextEpisodeReady (the same signal autoplay already
     // consumes) or an empty map, so the Player advances identically either way.
     Q_INVOKABLE void load_random_episode(const QString &scopeRatingKey);
+    // Next item of a PLAY ALL / SHUFFLE queue over a playlist or collection.
+    // Emits nextEpisodeReady (the same signal autoplay and shuffle cards use), so
+    // the Player advances a queue with the machinery it already has.
+    Q_INVOKABLE void load_queue_item(const QString &ratingKey);
     Q_INVOKABLE void request_transcode(const QString &ratingKey, const QString &partKey,
                                        const QString &sessionId,
                                        const QString &audioId, const QString &subtitleId,

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -82,6 +82,11 @@ public:
     // show/season. Emits nextEpisodeReady (the same signal autoplay already
     // consumes) or an empty map, so the Player advances identically either way.
     Q_INVOKABLE void load_random_episode(const QString &scopeRatingKey);
+    // Expands a PLAY ALL / SHUFFLE selection into the ratingKeys it actually
+    // plays: leaf items pass straight through, and every show fans out into all
+    // of its episodes in season/episode order. Takes the row maps the list view
+    // already holds (ratingKey + type) and emits queueReady with the flat list.
+    Q_INVOKABLE void expand_queue(const QVariantList &items);
     // Next item of a PLAY ALL / SHUFFLE queue over a playlist or collection.
     // Emits nextEpisodeReady (the same signal autoplay and shuffle cards use), so
     // the Player advances a queue with the machinery it already has.
@@ -145,6 +150,7 @@ signals:
     void extrasLoaded(const QVariant &items);
     void inProgressEpisodeLoaded(const QVariant &item);
     void nextEpisodeReady(const QVariant &detail);
+    void queueReady(const QStringList &ratingKeys);
     void cardItemReady(const QVariant &detail);
     void cardError(const QString &message);
 


### PR DESCRIPTION
## Summary

Closes https://github.com/anthonycaccese/240-MP/issues/272

Adds `Play All` and `Shuffle` options to the top of any playlist or collection across your Plex libraries.  Shuffle will randomize the playback of all items in a given playlist and Play All will start from the first item and play through all until complete (or until stopped).  

## AI involvement

Used to plan the approach for appending virtual Play/Shuffle rows to collections and playlists as well as working through the queue logic

## Testing

Verified on MacOS, RPi through multiple collections and playlists on my TV and Movie libraries.  Confirmed working for mixed playlists, collections of shows movies, etc...

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
