### PR TITLE
feat(plex): add browse by folder to the library menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Watch on YouTube: https://youtu.be/r-gylGDoELY
 - Autoplay next episode in a season (optional, off by default)
 - Write an NFC card for any movie, episode, season or show from its detail screen to use with the NFC Reader module
 - Hub, Playlist, Collection and Category support
+- Folder browsing — walk a library by its on-disk folder structure
 - Movie editions
 - Select preferred audio/subtitle track before playback and switch tracks during playback
 - Full library browsing by letter

--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -18,12 +18,17 @@ FocusScope {
     property string ratingKey: navParams.ratingKey || ""
     property string categoryKey: navParams.categoryKey || ""
     property string libraryName: navParams.libraryName || ""
+    // Folder browsing: the key of the folder being listed (empty at a section's
+    // top level) and its name, which stands in for the library name in the header
+    // so a deep folder still says where it is.
+    property string folderKey: navParams.folderKey || ""
+    property string folderName: navParams.folderName || ""
 
     property var items: []
     property bool isLoading: false
     property string errorMessage: ""
 
-    property bool showLetterNav: listType === "library_all"
+    property bool showLetterNav: listType === "library_all" || listType === "folders"
     property bool letterNavActive: false
     property var letterIndex: []
 
@@ -185,6 +190,20 @@ FocusScope {
             }
         }
 
+        function onFolderLoaded(loadedItems) {
+            if (itemListRoot.listType === "folders") {
+                itemListRoot.isLoading = false
+                itemListRoot.items = loadedItems
+                if (itemListRoot.showLetterNav)
+                    itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
+                if (loadedItems.length > 0) {
+                    var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
+                    itemList.currentIndex = Math.min(restore, loadedItems.length - 1)
+                    itemList.positionViewAtIndex(itemList.currentIndex, ListView.Contain)
+                }
+            }
+        }
+
         function onCategoriesLoaded(loadedItems) {
             if (itemListRoot.listType === "categories") {
                 itemListRoot.isLoading = false
@@ -220,6 +239,20 @@ FocusScope {
                 queueItems: queueItems,
                 shuffle: item.__action === "shuffle",
                 title: listTitle,
+                libraryName: libraryName
+            }, { currentIndex: itemList.currentIndex })
+            return
+        }
+
+        // A folder row opens the next level down. The server's own key is passed
+        // back untouched, so the section id only matters at the top level.
+        if (item.type === "folder") {
+            itemListRoot.navigateTo("Items.qml", {
+                listType: "folders",
+                title: item.title,
+                sectionId: sectionId,
+                folderKey: item.folderKey,
+                folderName: item.title,
                 libraryName: libraryName
             }, { currentIndex: itemList.currentIndex })
             return
@@ -326,6 +359,8 @@ FocusScope {
             plexBackend.load_categories(sectionId)
         else if (listType === "category_items")
             plexBackend.load_category_items(sectionId, categoryKey)
+        else if (listType === "folders")
+            plexBackend.load_folder(sectionId, folderKey)
         else if (listType === "continue_watching")
             plexBackend.load_continue_watching()
     }
@@ -346,7 +381,7 @@ FocusScope {
     AppBar {
         iconSource: moduleRoot.moduleIcon
         title: moduleRoot.moduleName
-        subtitle: libraryName
+        subtitle: folderName !== "" ? folderName : libraryName
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: root.sh * 0.125 //60
@@ -453,6 +488,7 @@ FocusScope {
                 Text {
                     id: rowText
                     text: {
+                        if (modelData.type === "folder") return (modelData.title || "") + "/"
                         if (modelData.type === "episode" && modelData.grandparentTitle) {
                             var sNum = (modelData.parentIndex != null) ? modelData.parentIndex : "?"
                             var eNum = (modelData.index != null) ? modelData.index : "?"

--- a/modules/plex/views/Items.qml
+++ b/modules/plex/views/Items.qml
@@ -19,16 +19,23 @@ FocusScope {
     property string categoryKey: navParams.categoryKey || ""
     property string libraryName: navParams.libraryName || ""
     // Folder browsing: the key of the folder being listed (empty at a section's
-    // top level) and its name, which stands in for the library name in the header
-    // so a deep folder still says where it is.
+    // top level) and the trail of folder names walked to reach it. The trail is
+    // appended to the library name in the header, so a deep folder says where it
+    // is — the leaf on its own is ambiguous, since the "Season 1" folders of two
+    // different shows would give identical headers.
     property string folderKey: navParams.folderKey || ""
-    property string folderName: navParams.folderName || ""
+    property string folderTrail: navParams.folderTrail || ""
 
     property var items: []
     property bool isLoading: false
     property string errorMessage: ""
 
-    property bool showLetterNav: listType === "library_all" || listType === "folders"
+    // A folder listing only earns the panel when it agrees with the rows it
+    // points into — see letterNavUsable, which sets this as the listing loads.
+    // library_all is always server-sorted, so it needs no such test.
+    property bool folderLetterNav: false
+    property bool showLetterNav: listType === "library_all"
+                                 || (listType === "folders" && folderLetterNav)
     property bool letterNavActive: false
     property var letterIndex: []
 
@@ -69,10 +76,28 @@ FocusScope {
         return queueRowsWarranted(candidates) ? 2 : 0
     }
 
+    // First character as a bucket label; everything non-alphabetic shares '#'.
+    function bucket(text) {
+        var ch = text.charAt(0).toUpperCase()
+        return (ch >= 'A' && ch <= 'Z') ? ch : '#'
+    }
+
+    // '#' sorts ahead of the letters, matching the panel's own ordering.
+    function bucketRank(key) {
+        return key === '#' ? 0 : key.charCodeAt(0)
+    }
+
     // Buckets by the server's sort title when one is set (Plex sorts the list by
     // titleSort), otherwise falls back to article-stripping the display title —
     // which is what Plex itself does for items without a custom sort title.
+    //
+    // Folder listings are the exception: there a row *is* the name on disk, so it
+    // buckets on the literal first character. Article-stripping is metadata logic,
+    // and it makes the panel disagree with what is on screen — a library filed
+    // into letter folders keeps "An Inconvenient Truth" in A/ on disk, but
+    // stripping the article would bucket it under I.
     function sortKey(item) {
+        if (listType === "folders") return bucket((item && item.title) || "")
         var sortTitle = (item && item.titleSort) || ""
         var t = (sortTitle || (item && item.title) || "").toLowerCase()
         if (!sortTitle) {
@@ -81,12 +106,33 @@ FocusScope {
                 if (t.indexOf(articles[i]) === 0) { t = t.substring(articles[i].length); break }
             }
         }
-        var ch = t.charAt(0).toUpperCase()
-        return (ch >= 'A' && ch <= 'Z') ? ch : '#'
+        return bucket(t)
+    }
+
+    // The panel is only useful when it agrees with the list it jumps into: the
+    // rows have to already be in bucket order, and there has to be more than one
+    // bucket to jump between. Plex returns a folder's subfolders ahead of its
+    // loose files, each group sorted on its own, so a folder holding both
+    // restarts the alphabet — A B C A B C — and a letter present in both groups
+    // could only ever reach the folder. Testing the whole listing catches that
+    // along with any other ordering surprise, and it also drops the panel for a
+    // single-bucket folder, where every row shares one letter anyway.
+    function letterNavUsable(itemArr) {
+        if (itemArr.length === 0) return false
+        var distinct = 1
+        var prev = sortKey(itemArr[0])
+        for (var i = 1; i < itemArr.length; i++) {
+            var key = sortKey(itemArr[i])
+            if (bucketRank(key) < bucketRank(prev)) return false
+            if (key !== prev) distinct++
+            prev = key
+        }
+        return distinct > 1
     }
 
     // Highlights the letter matching the currently selected item.
     function syncLetterToItem() {
+        if (letterIndex.length === 0) return
         var curLetter = sortKey(items[itemList.currentIndex - actionRows.length])
         for (var i = 0; i < letterIndex.length; i++) {
             if (letterIndex[i].letter === curLetter) { letterList.currentIndex = i; break }
@@ -194,8 +240,9 @@ FocusScope {
             if (itemListRoot.listType === "folders") {
                 itemListRoot.isLoading = false
                 itemListRoot.items = loadedItems
-                if (itemListRoot.showLetterNav)
-                    itemListRoot.letterIndex = itemListRoot.buildLetterIndex(loadedItems)
+                itemListRoot.folderLetterNav = itemListRoot.letterNavUsable(loadedItems)
+                itemListRoot.letterIndex = itemListRoot.folderLetterNav
+                    ? itemListRoot.buildLetterIndex(loadedItems) : []
                 if (loadedItems.length > 0) {
                     var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0
                     itemList.currentIndex = Math.min(restore, loadedItems.length - 1)
@@ -252,7 +299,7 @@ FocusScope {
                 title: item.title,
                 sectionId: sectionId,
                 folderKey: item.folderKey,
-                folderName: item.title,
+                folderTrail: (folderTrail !== "" ? folderTrail + " / " : "") + item.title,
                 libraryName: libraryName
             }, { currentIndex: itemList.currentIndex })
             return
@@ -381,7 +428,7 @@ FocusScope {
     AppBar {
         iconSource: moduleRoot.moduleIcon
         title: moduleRoot.moduleName
-        subtitle: folderName !== "" ? folderName : libraryName
+        subtitle: folderTrail !== "" ? libraryName + " / " + folderTrail : libraryName
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: root.sh * 0.125 //60

--- a/modules/plex/views/Library.qml
+++ b/modules/plex/views/Library.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import Components
 
-// Sub-menu for a single library: Recommended, Library, Collections, Playlists, Categories
+// Sub-menu for a single library: Recommended, Library, Collections, Playlists, Categories, Folders
 FocusScope {
     id: subMenuRoot
 
@@ -27,6 +27,7 @@ FocusScope {
             items.push({ label: "COLLECTIONS", action: "collections" })
             items.push({ label: "PLAYLISTS", action: "playlists" })
             items.push({ label: "CATEGORIES", action: "categories" })
+            items.push({ label: "FOLDERS", action: "folders" })
             subMenuRoot.menuItems = items
             if (items.length > 0) {
                 var restore = (navListState.currentIndex !== undefined) ? navListState.currentIndex : 0

--- a/src/modules/plex/PlexBackend.cpp
+++ b/src/modules/plex/PlexBackend.cpp
@@ -1736,6 +1736,56 @@ void PlexBackend::load_category_items(const QString &sectionId, const QString &f
     }
 }
 
+// Folder browsing — Plex's "by folder" library view, which walks the library's
+// on-disk directory tree instead of its metadata. A section's top level is
+// /library/sections/{id}/folder; every level below it is reached by following the
+// key the server put on the folder row (…/folder?parent=<n>), passed back here
+// verbatim rather than rebuilt, so the parent ids stay the server's business.
+//
+// The response mixes two shapes: folder rows arrive under Directory on some PMS
+// versions and under Metadata (type "folder") on others, while leaf media always
+// arrives under Metadata. Both arrays are read, and a Metadata entry only counts
+// as media when it carries a ratingKey.
+void PlexBackend::load_folder(const QString &sectionId, const QString &folderKey) {
+    QString uri = serverUrl(), token = serverToken();
+    QUrl url(uri + (folderKey.isEmpty() ? "/library/sections/" + sectionId + "/folder"
+                                        : folderKey));
+    auto *reply = plexGet(url, token);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, sectionId, folderKey]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 498) {
+                handle498([this, sectionId, folderKey]{ load_folder(sectionId, folderKey); }); return;
+            }
+            emit errorOccurred("LOAD FOLDERS FAILED: " + reply->errorString()); return;
+        }
+        QJsonObject mc = QJsonDocument::fromJson(reply->readAll())
+                         .object()["MediaContainer"].toObject();
+        QVariantList items;
+        // A folder row with no key is not openable, so it is dropped rather than
+        // listed as a dead end.
+        auto appendFolder = [&items, &sectionId](const QJsonObject &d) {
+            QString key = d["key"].toString();
+            if (key.isEmpty()) return;
+            items.append(QVariantMap{
+                {"title",     d["title"].toString().toUpper()},
+                {"type",      "folder"},
+                {"folderKey", key},
+                {"sectionId", sectionId},
+            });
+        };
+        for (const auto &dv : mc["Directory"].toArray()) appendFolder(dv.toObject());
+        for (const auto &mv : mc["Metadata"].toArray()) {
+            QJsonObject m = mv.toObject();
+            if (m["ratingKey"].toString().isEmpty() || m["type"].toString() == "folder")
+                appendFolder(m);
+            else
+                items.append(formatItem(m));
+        }
+        emit folderLoaded(items);
+    });
+}
+
 void PlexBackend::check_section_capabilities(const QString &sectionId) {
     QString uri = serverUrl(), token = serverToken();
 

--- a/src/modules/plex/PlexBackend.h
+++ b/src/modules/plex/PlexBackend.h
@@ -50,6 +50,11 @@ public:
     Q_INVOKABLE void load_playlist_items(const QString &ratingKey);
     Q_INVOKABLE void load_categories(const QString &sectionId);
     Q_INVOKABLE void load_category_items(const QString &sectionId, const QString &filterKey);
+    // Folder browsing (Plex's "by folder" library view). folderKey is empty for a
+    // section's top level and otherwise the key the server put on the folder row
+    // being opened. Emits folderLoaded with a mix of folder rows (type "folder",
+    // carrying folderKey) and ordinary media items.
+    Q_INVOKABLE void load_folder(const QString &sectionId, const QString &folderKey);
     Q_INVOKABLE void check_section_capabilities(const QString &sectionId);
     Q_INVOKABLE void load_children(const QString &ratingKey);
     // Loads the extras (trailers, deleted scenes, …) attached to an item and
@@ -141,6 +146,7 @@ signals:
     void collectionsLoaded(const QVariant &collections);
     void playlistsLoaded(const QVariant &playlists);
     void categoriesLoaded(const QVariant &categories);
+    void folderLoaded(const QVariant &items);
     void capabilitiesLoaded(const QVariant &capabilities);
 
     void itemLoaded(const QVariant &detail);


### PR DESCRIPTION
## Summary

Adds a `FOLDERS` entry to the per-library menu, mirroring browse-by-folder in the Plex web client. It lists the library's on-disk directory tree. Folders drill down, files open the normal detail screen. Useful for content without metadata (such as WOC recordings).

Backed by a new `load_folder` / `folderLoaded` pair on `PlexBackend` hitting `/library/sections/{id}/folder`, following the same shape as the other browse calls. `Items.qml` handles the new `folders` listType.

A couple notes:

- The `FOLDERS` row is unconditional, like `COLLECTIONS` and `PLAYLISTS`
- The A–Z panel assumes an alphabetical listing, so in a folder mixing subfolders with loose files it can jump backwards (Plex returns folders first, then files, each sorted separately)


<img width="1920" height="1200" alt="pi" src="https://github.com/user-attachments/assets/16d568d9-ba91-4bdc-9887-393132f4697a" />
<img width="1920" height="1200" alt="pi2" src="https://github.com/user-attachments/assets/789e2fce-71d7-4792-ad51-060a956a56e5" />


## AI involvement

The implementation was AI-generated using Claude Code. I reviewed the diff, built from source on a Pi 3, and and verified the behaviour by hand by browsing folder listings in my own library against a live PMS.

## Testing

<!-- How did you verify this? Single-platform testing is fine — just say which. -->

Built from source and run on the Pi against a live Plex Media Server. Navigated into a library, opened `FOLDERS`, drilled through directory levels, walked back out with esc, and used the A–Z panel. Played content from top-level and nested directories.
- Platform(s) tested: Raspberry Pi 3B, built with `cmake --build build`
- Display / output tested: HDMI and composite

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)
