### PR TITLE
Support IR receivers that present as a single keyboard (Flirc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 # 240-MP #
 ######################
 /build
+/build-*
 /.cache
 # AppImage build outputs (scripts/build-appimage.sh, scripts/build-mpv.sh)
 /AppDir

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -381,6 +381,12 @@ void InputManager::loadKeyRemap() {
         { "select", Action::Select },
         { "back",   Action::Back },
     };
+#ifdef Q_OS_LINUX
+    // A remote's OK button sends KEY_SELECT, not KEY_ENTER. Seeded before the
+    // stored bindings so a viewer's own choice still wins.
+    m_keyRemap[kEvdevKeyBase + KEY_SELECT] = Action::Select;
+#endif
+
     for (const auto &entry : kRemapActions) {
         bool ok = false;
         const int qtKey = m_appCore->get_setting(QString(), QStringLiteral("remote_keymap.") + entry.name).toInt(&ok);
@@ -414,26 +420,100 @@ void InputManager::setRemapCapture(bool active) {
 // Scanned once at startup, no hotplug, this is a fixed USB dongle here, not
 // something swapped mid-session. Harmless no-op on a machine with no such
 // device (nothing matches the name, nothing is opened).
+// The codes a remote sends that Qt's keyboard path cannot hand on. A standard
+// keyboard layout has no keysym for them, so eglfs delivers a QKeyEvent whose
+// key() is 0 -- which is also what this app stores to mean "no binding", so
+// such a button cannot even be bound from the Controls screen. Reading them
+// from the device is the only way they can act or be remapped.
+//
+// Deliberately short. Every code here is taken off a device that is ALSO the
+// plain keyboard, so anything Qt can deliver must not be listed or it would
+// arrive twice and fire its action twice.
+static bool advertisesKey(int fd, int linuxCode) {
+    unsigned long bits[(KEY_MAX / (8 * sizeof(unsigned long))) + 1] = {0};
+    if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(bits)), bits) < 0)
+        return false;
+    const size_t wordBits = 8 * sizeof(unsigned long);
+    return (bits[linuxCode / wordBits] >> (linuxCode % wordBits)) & 1UL;
+}
+
+// A standard keyboard layout has no keysym for these, so EGLFS delivers a
+// QKeyEvent whose key() is 0 — which is also what this app stores to mean "no
+// binding", so the Controls screen cannot capture one either. Reading them off
+// the device is the only way they can act or be remapped.
+//
+// Keep this list to codes Qt genuinely cannot deliver: they are taken from a
+// device that is also the plain keyboard, so anything Qt does deliver would
+// arrive twice and fire its action twice.
+bool InputManager::isUnmappableRemoteCode(int linuxCode) {
+    switch (linuxCode) {
+    case KEY_CHANNELUP:
+    case KEY_CHANNELDOWN:
+    case KEY_SELECT:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void InputManager::openConsumerControlDevice() {
     QDir dir(QStringLiteral("/dev/input"));
     const QStringList entries = dir.entryList(QStringList() << QStringLiteral("event*"), QDir::System);
+
+    int sharedFd = -1;
+    QString sharedName, sharedPath;
+
     for (const QString &entry : entries) {
         const QString path = dir.filePath(entry);
         const int fd = ::open(path.toUtf8().constData(), O_RDONLY | O_NONBLOCK);
         if (fd < 0)
             continue;
         char name[256] = {0};
-        const bool isConsumerControl = ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0
-            && QString::fromUtf8(name).contains(QStringLiteral("Consumer Control"), Qt::CaseInsensitive);
-        if (isConsumerControl) {
+        if (ioctl(fd, EVIOCGNAME(sizeof(name)), name) < 0) {
+            ::close(fd);
+            continue;
+        }
+        const QString devName = QString::fromUtf8(name);
+
+        // A dedicated interface sends nothing else, so all of it is ours.
+        if (devName.contains(QStringLiteral("Consumer Control"), Qt::CaseInsensitive)) {
+            if (sharedFd >= 0)
+                ::close(sharedFd);
             m_consumerFd = fd;
+            m_consumerIsSharedKeyboard = false;
             m_consumerNotifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
             connect(m_consumerNotifier, &QSocketNotifier::activated, this, &InputManager::onConsumerControlReadable);
             qInfo("[input] Consumer Control device found: %s (%s)", name, qPrintable(path));
             return;
         }
+
+        // A receiver that presents as one keyboard — a Flirc, most IR
+        // receivers — puts these codes there instead, where the name above
+        // never finds them. Held as a fallback so a dedicated interface later
+        // in the scan still wins. Pads are SDL's, never read here.
+        const bool couldBeRemote = !advertisesKey(fd, BTN_GAMEPAD)
+                                   && (advertisesKey(fd, KEY_CHANNELUP)
+                                       || advertisesKey(fd, KEY_CHANNELDOWN)
+                                       || advertisesKey(fd, KEY_SELECT));
+        if (sharedFd < 0 && couldBeRemote) {
+            sharedFd = fd;
+            sharedName = devName;
+            sharedPath = path;
+            continue;
+        }
         ::close(fd);
     }
+
+    if (sharedFd >= 0) {
+        m_consumerFd = sharedFd;
+        m_consumerIsSharedKeyboard = true;
+        m_consumerNotifier = new QSocketNotifier(sharedFd, QSocketNotifier::Read, this);
+        connect(m_consumerNotifier, &QSocketNotifier::activated, this, &InputManager::onConsumerControlReadable);
+        qInfo("[input] remote keys read from %s (%s) — its channel/select codes are ones Qt cannot deliver",
+              qPrintable(sharedName), qPrintable(sharedPath));
+        return;
+    }
+
     qInfo("[input] no Consumer Control device found, remote's extra buttons (if any) won't be remappable");
 }
 
@@ -453,12 +533,17 @@ void InputManager::onConsumerControlReadable() {
             m_consumerNotifier->setEnabled(false);
             m_consumerNotifier->deleteLater();
             m_consumerNotifier = nullptr;
+            m_consumerIsSharedKeyboard = false;
             ::close(m_consumerFd);
             m_consumerFd = -1;
             return;
         }
         if (ev.type != EV_KEY || ev.value == 2)   // ignore autorepeat and non-key events
             continue;
+        // The rest of this device's keys are already arriving as QKeyEvents.
+        if (m_consumerIsSharedKeyboard && !isUnmappableRemoteCode(ev.code))
+            continue;
+
         const int extendedId = kEvdevKeyBase + ev.code;
 
         if (m_remapCapture) {

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -100,6 +100,9 @@ private:
     void loadKeyRemap();
 #ifdef Q_OS_LINUX
     void openConsumerControlDevice();
+    // True for the codes Qt's keyboard path cannot represent, which is why
+    // they have to be read from the device directly. See the definition.
+    static bool isUnmappableRemoteCode(int linuxCode);
 #endif
     static QString evdevKeyName(int linuxCode);
     static QString mouseButtonName(int qtButton);
@@ -160,6 +163,11 @@ private:
 #ifdef Q_OS_LINUX
     int m_consumerFd = -1;
     QSocketNotifier *m_consumerNotifier = nullptr;
+    // Set when the device was chosen for the codes it advertises rather than
+    // for being a dedicated Consumer Control interface. Such a device is also
+    // the plain keyboard, and Qt is already delivering its ordinary keys, so
+    // only the codes Qt drops may be taken from it.
+    bool m_consumerIsSharedKeyboard = false;
 #endif
 
     QString m_lastInputDevice = "keyboard";

--- a/views/RemapControls.qml
+++ b/views/RemapControls.qml
@@ -29,6 +29,8 @@ FocusScope {
     property var rows: []
     property bool capturing: false
     property int captureIndex: -1
+    // Shown in the capture overlay when a button cannot be bound.
+    property string captureError: ""
 
     // While capturing, InputManager suspends remap delivery and reports every
     // real input (keyboard key, Consumer Control button, mouse button) through
@@ -61,10 +63,20 @@ FocusScope {
 
     function startCapture(idx) {
         captureIndex = idx
+        captureError = ""
         capturing = true
     }
 
     function finishCapture(qtKey) {
+        // Qt reports 0 for a button no keyboard layout has a keysym for, and
+        // 0 is what this screen stores to mean "not bound" -- saving it would
+        // look exactly like never having pressed anything.
+        if (!qtKey) {
+            captureError = "THAT BUTTON CANNOT BE REMAPPED.\n"
+                           + "IT REACHES THE APP WITHOUT A NAME TO SAVE."
+            return
+        }
+        captureError = ""
         if (captureIndex >= 0 && captureIndex < actions.length) {
             // One physical button, one action: InputManager's remap table is
             // keyed by the button, so a key left bound to two actions would
@@ -86,6 +98,7 @@ FocusScope {
     function cancelCapture() {
         capturing = false
         captureIndex = -1
+        captureError = ""
         rowList.forceActiveFocus()
     }
 
@@ -270,6 +283,15 @@ FocusScope {
                 color: root.accentColor
                 font.family: root.globalFont
                 font.pixelSize: root.sh * 0.05 //24
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Text {
+                text: remapRoot.captureError
+                visible: remapRoot.captureError !== ""
+                color: root.accentColor
+                font.family: root.globalFont
+                font.pixelSize: root.sh * 0.0291667 //14
+                horizontalAlignment: Text.AlignHCenter
                 anchors.horizontalCenter: parent.horizontalCenter
             }
             Text {


### PR DESCRIPTION
This allows Flirc to work on 240mp, hopefully alongside the recommended type of controller. I have not tested it, as I do not have one, so if someone else could I would appreciate it. With this I was able to get 240mp working with my universal remote (a sofabaton x2) so it's seamless with the rest of my entertainment system. The rest of this PR was written by Claude, and reviewed by me. 

## Summary

An IR receiver that presents as one USB keyboard — a Flirc, and most receivers
like it — sends `KEY_SELECT` for OK and `KEY_CHANNELUP` / `KEY_CHANNELDOWN` for
channel up and down. No keyboard layout has a keysym for those, so EGLFS
delivers a `QKeyEvent` whose `key()` is `0` and the buttons do nothing.

They could not be bound out of it either: the Controls screen captures whatever
it is handed, `0` included, and `0` is what the app stores to mean "not bound" —
so the row went back to reading "default" and the press looked unrecognised. The
recovery path needed the one thing that was broken.

`InputManager` already reads these codes off the device, but only opened a device
whose *name* contains "Consumer Control", which is how a multi-interface remote
exposes them. A single-interface receiver puts them on the keyboard, where that
test never looks. It now falls back to the first device that *advertises* the
codes, whatever it is called.

That device is also the plain keyboard, so only the codes Qt cannot deliver are
taken from it — anything Qt does deliver would arrive twice and fire its action
twice. Gamepads are excluded; they belong to SDL. A dedicated Consumer Control
interface still wins the scan and is still read in full, so existing remotes are
unaffected.

Also: `KEY_SELECT` gets `Action::Select` by default, and a capture the app cannot
store is now refused on screen instead of silently saved as `0`.

Channel up/down are read and become bindable here. They act once the actions they
map to exist, which is a separate change.

## AI involvement

Written with Claude Code (Opus). The diagnosis came from captured `evdev` events
off the receiver, which is what identified `KEY_SELECT` rather than `KEY_ENTER`
and the `key() == 0` path; the implementation is AI-authored. I reviewed the
change and tested it on hardware with the actual remote before submitting —
see Testing below for what was exercised directly and what was simulated.

## Testing

- Platform(s) tested: Raspberry Pi 4 Model B, Raspberry Pi OS Trixie (Debian 13),
  Qt 6.8.2, EGLFS. Not tested on macOS — the changed path is `Q_OS_LINUX` only.
- Display / output tested: HDMI

With a Flirc and its remote:
- Select, Channel Up and Channel Down now work; before the change all three did nothing.
- Arrows and other ordinary keys still fire once per press (the double-handling risk).

Original multi-interface remote path, simulated with a `uinput` device named
"… Consumer Control" alongside the Flirc:
- The dedicated interface is still chosen even though the Flirc is scanned first
  and matches the new fallback, and the original log line is what appears.
- Removing that device mid-run tears down cleanly (existing disconnect path).

Not exercised on device: the new "cannot be remapped" message in the Controls
screen — the guard is straightforward but I have not seen it on the TV.

## Checklist

- [x] Changes work with remote-only navigation (up/down/left/right, enter, esc/backspace)
- [x] Handled sizing and positioning using the `root.sh` & `root.sw` properties (did not hardcode pixels) and kept CRT overscan in mind
- [x] Did not add tracking or analytics; only wrote settings to the local data directory if the change required storage
- [x] Follows the patterns in [ARCHITECTURE.md](https://github.com/anthonycaccese/240-MP/blob/main/ARCHITECTURE.md) and the principles in [CONTRIBUTING.md](https://github.com/anthonycaccese/240-MP/blob/main/CONTRIBUTING.md)